### PR TITLE
Upgrade docker-py and improve tests and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ resources/content/modules.properties
 resources/local
 runtime
 target
+venv
 
 *.egg-info
 *.launch

--- a/code/agent/src/agents/pyagent/README.md
+++ b/code/agent/src/agents/pyagent/README.md
@@ -1,0 +1,36 @@
+#pyagent
+This agent runs on compute nodes in a Rancher cluster. It receives events from the Rancher server, acts upon them, and returns response events.
+
+### Deployment notes
+This agent is typically deployed inside a container on Rancher compute nodes. See [the Rancher project](http://github.com/rancherio/rancher) for details.
+
+### Setup and Develiopment notes
+#### On Mac OS X
+Steps to get the tests running and passing:
+
+1. Have boot2docker up and running
+1. Install libvirt and pkg-config (they're needed to cleanly install requirements.txt)
+ 
+  ```
+  $ brew install libvirt
+  $ brew install pkg-config
+  ```
+1. Create virtual environment and install python dependencies:
+
+  ```
+  $ mkdir venv && virtualenv venv && . venv/bin/activate
+  $ pip install -r requirements.txt
+  $ pip install -r test-requirements.txt
+  ```
+1. Run the tests:
+
+  ```
+  mkdir $HOME/cattle-home
+  $ CATTLE_DOCKER_USE_BOOT2DOCKER=true DOCKER_TEST=true CATTLE_HOME=$HOME/cattle-home \
+  py.test tests
+  ```
+  Or you can do the equivalent in PyCharm. An explanation of those environment variables:
+  * ```CATTLE_DOCKER_USE_BOOT2DOCKER=true``` tells the docker client to use the connection settings derived from ```boot2docker shellinit```. You need this because boot2docker has TLS enabled by default.
+  * ```DOCKER_TEST=true``` tells the test framework to run the docker tests. They're disabled by default. We'll probably turn them on by default in the future.
+  * ```CATTLE_HOME``` is needed for some temporary files that are written (locks, specifically)
+

--- a/code/agent/src/agents/pyagent/cattle/plugins/docker/compute.py
+++ b/code/agent/src/agents/pyagent/cattle/plugins/docker/compute.py
@@ -9,7 +9,7 @@ from cattle.compute import BaseComputeDriver
 from cattle.agent.handler import KindBasedMixin
 from cattle.type_manager import get_type_list
 from cattle import utils
-from docker import APIError
+from docker.errors import APIError
 
 log = logging.getLogger('docker')
 

--- a/code/agent/src/agents/pyagent/cattle/plugins/docker/util.py
+++ b/code/agent/src/agents/pyagent/cattle/plugins/docker/util.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 
 from cattle.utils import get_command_output
 
@@ -17,6 +18,11 @@ def pipe_error(ctx, stderr, buffer):
 
 
 def net_util(pid, ip=None, mac=None, device=None):
+    if not sys.platform.startswith('linux'):
+        log.warn('Skipping net_util call because it is not supported on this '
+                 'platform.')
+        return
+
     args = [_NET_UTIL, '-p', str(pid)]
 
     if ip is not None:

--- a/code/agent/src/agents/pyagent/dist-requirements.txt
+++ b/code/agent/src/agents/pyagent/dist-requirements.txt
@@ -1,4 +1,4 @@
 mako
-docker-py==0.3.1
+docker-py==0.6
 portalocker
 # WebSockify is installed manually from package.sh

--- a/code/agent/src/agents/pyagent/requirements.txt
+++ b/code/agent/src/agents/pyagent/requirements.txt
@@ -1,7 +1,8 @@
 argparse
 mako
-docker-py==0.3.1
+docker-py==0.6
 portalocker
 libvirt-python
 websockify
 subprocess32
+psutil

--- a/code/agent/src/agents/pyagent/test-requirements.txt
+++ b/code/agent/src/agents/pyagent/test-requirements.txt
@@ -4,5 +4,5 @@ pytest
 datadiff==1.1.5
 
 mako
-docker-py==0.3.1
+docker-py==0.6
 portalocker


### PR DESCRIPTION
- Upgraded docker-py to 0.6
- Bumped docker api version to 1.15 and updated tests accordingly
- Made changes that will allow tests to run successfully on OS X
  - boot2docker configuration integration in docker_client function
  - skip platform dependent net-util script runs
- Added README.md documentation
- Added venv to .gitignore
