### PR TITLE
API parity for following fields in container create: cap_add, cap_drop, dns, dns_search, domainname, memory, memory_swap, cpuset

### DIFF
--- a/resources/content/schema/admin/admin-auth.json
+++ b/resources/content/schema/admin/admin-auth.json
@@ -66,6 +66,7 @@
         "container.domainName" : "cr",
         "container.memorySwap" : "cr",
         "container.memory" : "cr",
+        "container.cpuSet" : "cr",
 
         "containerExec.attachStdin" : "cr",
         "containerExec.attachStdout" : "cr",

--- a/resources/content/schema/base/container.json
+++ b/resources/content/schema/base/container.json
@@ -144,10 +144,16 @@
             "nullable": true
         },
         "memorySwap": {
-        	"type": "int"
+        	"type": "int",
+        	"nullable": true
         },
         "memory": {
-            "type": "int"
+            "type": "int",
+            "nullable": true
+        },
+        "cpuSet": {
+            "type": "string",
+            "nullable": true
         }
     }
 }

--- a/tests/integration/cattletest/core/test_container.py
+++ b/tests/integration/cattletest/core/test_container.py
@@ -604,7 +604,8 @@ def test_container_auth(admin_client, client):
         'dnsSearch': 'cr',
         'domainName': 'cr',
         'memorySwap': 'cr',
-        'memory': 'cr'
+        'memory': 'cr',
+        'cpuSet': 'cr',
     })
 
     auth_check(client.schema, 'container', 'crud', {

--- a/tests/integration/cattletest/core/test_docker.py
+++ b/tests/integration/cattletest/core/test_docker.py
@@ -532,7 +532,8 @@ def test_container_fields(client, admin_client, docker_context):
                                       privileged=True,
                                       domainName="rancher.io",
                                       memory=8000000,
-                                      memorySwap=16000000)
+                                      memorySwap=16000000,
+                                      cpuSet="0,1")
     c = admin_client.wait_success(c)
 
     assert set(c.data['dockerInspect']['HostConfig']['CapAdd']) == set(caps)
@@ -545,6 +546,7 @@ def test_container_fields(client, admin_client, docker_context):
     assert c.data['dockerInspect']['Config']['Domainname'] == "rancher.io"
     assert c.data['dockerInspect']['Config']['Memory'] == 8000000
     assert c.data['dockerInspect']['Config']['MemorySwap'] == 16000000
+    assert c.data['dockerInspect']['Config']['Cpuset'] == "0,1"
 
 
 @if_docker


### PR DESCRIPTION
@cjellick @ibuildthecloud 
