### PR TITLE
Antiaffinity fix for sidekick

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
@@ -73,4 +73,7 @@ public abstract class DeploymentUnitInstance {
     }
 
     public abstract void waitForNotTransitioning();
+
+    public abstract void waitForAllocate();
+
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DefaultDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DefaultDeploymentUnitInstance.java
@@ -3,7 +3,9 @@ package io.cattle.platform.servicediscovery.deployment.impl;
 import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.constants.HealthcheckConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
+import io.cattle.platform.core.model.Host;
 import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.InstanceHostMap;
 import io.cattle.platform.core.model.Service;
 import io.cattle.platform.core.model.ServiceExposeMap;
 import io.cattle.platform.engine.process.impl.ProcessCancelException;
@@ -14,6 +16,8 @@ import io.cattle.platform.servicediscovery.api.util.ServiceDiscoveryUtil;
 import io.cattle.platform.servicediscovery.deployment.DeploymentUnitInstance;
 import io.cattle.platform.servicediscovery.deployment.InstanceUnit;
 import io.cattle.platform.servicediscovery.deployment.impl.DeploymentManagerImpl.DeploymentServiceContext;
+import static io.cattle.platform.core.model.tables.InstanceHostMapTable.INSTANCE_HOST_MAP;
+
 
 import java.util.HashMap;
 import java.util.Map;
@@ -137,6 +141,19 @@ public class DefaultDeploymentUnitInstance extends DeploymentUnitInstance implem
     public void waitForNotTransitioning() {
         if (this.instance != null) {
             this.instance = context.resourceMonitor.waitForNotTransitioning(this.instance);
+        }
+    }
+
+    @Override
+    public void waitForAllocate() {
+        if (this.instance != null) {
+            instance = context.resourceMonitor.waitFor(instance, new ResourcePredicate<Instance>() {
+                @Override
+                public boolean evaluate(Instance obj) {
+                    return context.objectManager.find(InstanceHostMap.class, INSTANCE_HOST_MAP.INSTANCE_ID,
+                            instance.getId()).size() > 0;
+                }
+            });
         }
     }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnit.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnit.java
@@ -162,8 +162,16 @@ public class DeploymentUnit {
                 createInstance(launchConfigName, duService.getService());
             }
         }
+
+        this.waitForAllocate();
     }
     
+    protected void waitForAllocate() {
+        for (DeploymentUnitInstance instance : getDeploymentUnitInstances()) {
+            instance.waitForAllocate();
+        }
+    }
+
     public void waitForStart(){
         for (DeploymentUnitInstance instance : getDeploymentUnitInstances()) {
             instance.waitForStart();

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/ExternalDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/ExternalDeploymentUnitInstance.java
@@ -93,4 +93,8 @@ public class ExternalDeploymentUnitInstance extends DeploymentUnitInstance {
         }
     }
 
+    @Override
+    public void waitForAllocate() {
+        return;
+    }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/LoadBalancerDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/LoadBalancerDeploymentUnitInstance.java
@@ -1,11 +1,14 @@
 package io.cattle.platform.servicediscovery.deployment.impl;
 
+import static io.cattle.platform.core.model.tables.InstanceHostMapTable.INSTANCE_HOST_MAP;
 import static io.cattle.platform.core.model.tables.LoadBalancerTable.LOAD_BALANCER;
 import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.constants.HealthcheckConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
 import io.cattle.platform.core.constants.LoadBalancerConstants;
+import io.cattle.platform.core.model.Host;
 import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.InstanceHostMap;
 import io.cattle.platform.core.model.LoadBalancer;
 import io.cattle.platform.core.model.LoadBalancerHostMap;
 import io.cattle.platform.core.model.Service;
@@ -130,6 +133,19 @@ public class LoadBalancerDeploymentUnitInstance extends DeploymentUnitInstance i
     public void waitForNotTransitioning() {
         if (this.hostMap != null) {
             this.hostMap = context.resourceMonitor.waitForNotTransitioning(this.hostMap);
+        }
+    }
+
+    @Override
+    public void waitForAllocate() {
+        if (this.instance != null) {
+            instance = context.resourceMonitor.waitFor(instance, new ResourcePredicate<Instance>() {
+                @Override
+                public boolean evaluate(Instance obj) {
+                    return context.objectManager.find(InstanceHostMap.class, INSTANCE_HOST_MAP.INSTANCE_ID,
+                            instance.getId()).size() > 0;
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
Wait for unit to be allocated before starting a new unit. This fix is needed for the case when anti-affinity rule is defined on the service having sidekicks. If we continue deploying units in parallel, its possible for the deployment units to clash - when Primary instance of Unit1 lands on the same host with Secondary instance of unit2. In this case neither primary instance of Unit2, nor secondary instance of Unit1 going to deploy as they have 2 contradicting affinity rules now:

* deploy on the same host with other instance of the same deployment unit
* deploy on a diff host from other instances of the same launch config.

@sonchang is going to put a fix for service-anti-affinity-to-itself translation to include launch config name, so instances of the same deployment unit won't conflict with each other like they do today - as they share the same service name anti affinity rule. 