### PR TITLE
proxy: use HTTPS by default when no protocol specified

### DIFF
--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/request/handler/GenericWhitelistedProxy.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/request/handler/GenericWhitelistedProxy.java
@@ -67,10 +67,8 @@ public class GenericWhitelistedProxy extends AbstractResponseGenerator {
             throw new ClientVisibleException(ResponseCodes.BAD_REQUEST, "InvalidRedirect", "The redirect is invalid", null);
         }
 
-        String protocol = servletRequest.getScheme();
-
         if (!StringUtils.startsWith(redirect, "http")) {
-            redirect = protocol + "://" + redirect;
+            redirect = "https://" + redirect;
         }
 
         URI url = URI.create(redirect);


### PR DESCRIPTION
When no protocol was specified, the protocol used for the incoming
request was used for the outgoing request. So, if a proxy request comes
over HTTP, the outgoing request is going over HTTP too. We use HTTPS by
default instead. Amazon EC2 endpoints are all HTTPS capable.

See #658.