### PR TITLE
modify service name to include launchConfig as well

### DIFF
--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AllocatorServiceImpl.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AllocatorServiceImpl.java
@@ -8,10 +8,10 @@ import io.cattle.platform.allocator.constraint.ContainerLabelAffinityConstraint;
 import io.cattle.platform.allocator.constraint.HostAffinityConstraint;
 import io.cattle.platform.allocator.dao.AllocatorDao;
 import io.cattle.platform.core.dao.InstanceDao;
-import io.cattle.platform.core.model.Environment;
+import io.cattle.platform.core.dao.LabelsDao;
 import io.cattle.platform.core.model.Host;
 import io.cattle.platform.core.model.Instance;
-import io.cattle.platform.core.model.Service;
+import io.cattle.platform.core.model.Label;
 import io.cattle.platform.object.ObjectManager;
 
 import java.util.ArrayList;
@@ -32,6 +32,13 @@ public class AllocatorServiceImpl implements AllocatorService {
 
     // LEGACY: Temporarily support ${project_name} but this has become ${stack_name} now
     private static final String PROJECT_NAME_MACRO = "${project_name}";
+
+    // TODO: We should refactor since these are defined in ServiceDiscoveryConstants too
+    private static final String LABEL_STACK_NAME = "io.rancher.stack.name";
+    private static final String LABEL_STACK_SERVICE_NAME = "io.rancher.stack_service.name";
+
+    @Inject
+    LabelsDao labelsDao;
 
     @Inject
     AllocatorDao allocatorDao;
@@ -213,25 +220,31 @@ public class AllocatorServiceImpl implements AllocatorService {
         if (valueStr.indexOf(SERVICE_NAME_MACRO) != -1 ||
                 valueStr.indexOf(STACK_NAME_MACRO) != -1 ||
                 valueStr.indexOf(PROJECT_NAME_MACRO) != -1) {
-            Service service = null;
 
-            List<? extends Service> services = instanceDao.findServicesFor(instance);
-            if (services.size() > 0) {
-                service = services.get(0);
-            }
-
-            if (service != null) {
-                valueStr = valueStr.replace(SERVICE_NAME_MACRO, service.getName());
-            }
-
-            // LEGACY: ${project_name} rename ${stack_name}
-            if ((valueStr.indexOf(STACK_NAME_MACRO) != -1 || valueStr.indexOf(PROJECT_NAME_MACRO) != -1) && service != null) {
-                Environment stack = objectManager.loadResource(Environment.class, service.getEnvironmentId());
-                if (stack != null) {
-                    valueStr = valueStr.replace(STACK_NAME_MACRO, stack.getName());
-                    // LEGACY:
-                    valueStr = valueStr.replace(PROJECT_NAME_MACRO, stack.getName());
+            List<Label> labels = labelsDao.getLabelsForInstance(instance.getId());
+            String serviceLaunchConfigName = "";
+            String stackName = "";
+            for (Label label: labels) {
+                if (LABEL_STACK_NAME.equals(label.getKey())) {
+                    stackName = label.getValue();
+                } else if (LABEL_STACK_SERVICE_NAME.equals(label.getKey())) {
+                    if (label.getValue() != null) {
+                        int i = label.getValue().indexOf('/');
+                        if (i != -1) {
+                            serviceLaunchConfigName = label.getValue().substring(i + 1);
+                        }
+                    }
                 }
+            }
+            if (!StringUtils.isBlank(stackName)) {
+                valueStr = valueStr.replace(STACK_NAME_MACRO, stackName);
+
+                // LEGACY: ${project_name} rename ${stack_name}
+                valueStr = valueStr.replace(PROJECT_NAME_MACRO, stackName);
+            }
+
+            if (!StringUtils.isBlank(serviceLaunchConfigName)) {
+                valueStr = valueStr.replace(SERVICE_NAME_MACRO, serviceLaunchConfigName);
             }
         }
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnit.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnit.java
@@ -306,7 +306,7 @@ public class DeploymentUnit {
 
     protected Map<String, String> getLabels(DeploymentUnitInstance instance) {
         Map<String, String> labels = new HashMap<>();
-        String serviceName = instance.getService().getName();
+        String serviceName = instance.getService().getName() + '/' + instance.getLaunchConfigName();
         String envName = context.objectManager.loadResource(Environment.class, instance.getService().getEnvironmentId())
                 .getName();
         labels.put(ServiceDiscoveryConstants.LABEL_STACK_NAME, envName);

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -1098,14 +1098,16 @@ def test_validate_labels(client, context):
     result_labels_1 = {'affinity': 'container==B', '!affinity': "container==C",
                        'io.rancher.stack.name': env.name,
                        'io.rancher.stack_service.name':
-                           env.name + '/' + service_name1}
+                           env.name + '/' + service_name1 + '/' +
+                           "io.rancher.service.primary.launch.config"}
     instance1 = _validate_compose_instance_start(client, service1, env, "1")
     assert all(item in instance1.labels for item in result_labels_1) is True
 
     # check that only one internal label is set
     result_labels_2 = {'io.rancher.stack.name': env.name,
                        'io.rancher.stack_service.name':
-                           env.name + '/' + service_name2}
+                           env.name + '/' + service_name2 + '/' +
+                           "io.rancher.service.primary.launch.config"}
     instance2 = _validate_compose_instance_start(client, service2, env, "1")
     assert all(item in instance2.labels for item in result_labels_2) is True
 
@@ -1684,7 +1686,8 @@ def test_service_affinity_rules(super_client, new_context):
         "labels": {
             "io.rancher.scheduler.affinity:container_label_ne":
                 "io.rancher.stack_service.name=" +
-                env.name + '/' + service_name
+                env.name + '/' + service_name + '/' +
+                "io.rancher.service.primary.launch.config"
         }
     }
 

--- a/tests/integration/cattletest/core/test_svc_discovery_lb.py
+++ b/tests/integration/cattletest/core/test_svc_discovery_lb.py
@@ -436,7 +436,8 @@ def test_labels(super_client, client, context):
     lb_instance = _validate_lb_instance(host, lb, super_client, service)
     result_labels = {'affinity': "container==B", '!affinity': "container==C",
                      'io.rancher.stack_service.name':
-                         env.name + "/" + service_name}
+                         env.name + "/" + service_name + "/" +
+                         "io.rancher.service.primary.launch.config"}
 
     assert all(item in lb_instance.labels.items()
                for item in result_labels.items()) is True
@@ -458,7 +459,8 @@ def test_labels(super_client, client, context):
                                                 service, client,
                                                 ['8089:8089', '914:914'])
     lb_instance = _validate_lb_instance(host, lb, super_client, service)
-    name = env.name + '/' + service_name
+    name = env.name + '/' + service_name + '/' + \
+        "io.rancher.service.primary.launch.config"
     result_labels = {'io.rancher.stack_service.name': name}
     assert all(item in lb_instance.labels.items()
                for item in result_labels.items()) is True


### PR DESCRIPTION
@alena1108 @ibuildthecloud @cjellick 
The background to this change started from https://github.com/rancherio/rancher/issues/1419
Basically, @sangeethah spotted a bug where we weren't able to support even the basic case of a "spread" algorithm via the anti-affinity rule with a sidekick.  Since the anti-affinity rule label gets merged between the 2 launchConfigs and applied to the deployment of the primary and secondary instances, it automatically conflicted with trying to collocate them on the same host.
Adding the launchConfig value into the ${service_name} macro allows for a more granular anti-affinity rule.