### PR TITLE
proxy: add a comment about specifying a protocol with generic proxy

### DIFF
--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/request/handler/GenericWhitelistedProxy.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/request/handler/GenericWhitelistedProxy.java
@@ -67,6 +67,12 @@ public class GenericWhitelistedProxy extends AbstractResponseGenerator {
             throw new ClientVisibleException(ResponseCodes.BAD_REQUEST, "InvalidRedirect", "The redirect is invalid", null);
         }
 
+        /* When no protocol is provided, use HTTPS by default. Please
+         * note that due to the following issue, it is in fact not
+         * possible to specify a protocol when cattle is running
+         * behind the websocket-proxy:
+         *   https://github.com/rancher/rancher/issues/1485
+         */
         if (!StringUtils.startsWith(redirect, "http")) {
             redirect = "https://" + redirect;
         }


### PR DESCRIPTION
Looking at the code, one may think that it's a sensible thing to do, but
it doesn't work because of rancher/rancher#1485. Add a comment with a
reference to the bug. See also rancher/cattle#658.