### PR TITLE
Internal load balancer support

### DIFF
--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/lb/LoadBalancerListenerValidationFilter.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/lb/LoadBalancerListenerValidationFilter.java
@@ -5,6 +5,7 @@ import io.cattle.platform.core.model.LoadBalancerListener;
 import io.cattle.platform.iaas.api.filter.common.AbstractDefaultResourceManagerFilter;
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 import io.github.ibuildthecloud.gdapi.request.resource.ResourceManager;
+import io.github.ibuildthecloud.gdapi.validation.ValidationErrorCodes;
 
 public class LoadBalancerListenerValidationFilter extends AbstractDefaultResourceManagerFilter {
 
@@ -22,10 +23,25 @@ public class LoadBalancerListenerValidationFilter extends AbstractDefaultResourc
     public Object create(String type, ApiRequest request, ResourceManager next) {
         LoadBalancerListener listener = request.proxyRequestObject(LoadBalancerListener.class);
         Integer targetPort = listener.getTargetPort();
-        if (targetPort == null) {
-            int sourcePort = listener.getSourcePort();
-            listener.setTargetPort(sourcePort);
+        Integer privatePort = listener.getPrivatePort();
+        Integer sourcePort = listener.getSourcePort();
+        
+        if (privatePort == null && sourcePort == null) {
+            ValidationErrorCodes.throwValidationError(ValidationErrorCodes.MISSING_REQUIRED,
+                    LoadBalancerConstants.FIELD_LB_SOURCE_PORT);
         }
+
+        if (privatePort == null) {
+            privatePort = sourcePort;
+        }
+        
+        if (targetPort == null) {
+            targetPort = privatePort;
+        }
+
+        listener.setTargetPort(targetPort);
+        listener.setSourcePort(sourcePort);
+        listener.setPrivatePort(privatePort);
 
         String targetProtocol = listener.getTargetProtocol();
         if (targetProtocol == null) {

--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerUpdateConfig.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerUpdateConfig.java
@@ -208,7 +208,9 @@ public class LoadBalancerUpdateConfig extends AbstractObjectProcessLogic impleme
                     .getLoadBalancerConfigId());
             final Set<Integer> listenerPorts = new HashSet<>();
             for (LoadBalancerListener listener : listeners) {
-                listenerPorts.add(listener.getSourcePort());
+                if (listener.getSourcePort() != null) {
+                    listenerPorts.add(listener.getSourcePort());
+                }
             }
             List<? extends Instance> lbInstances = lbInstancesMap.get(lbId);
             // surround by lock

--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/service/impl/LoadBalancerInstanceManagerImpl.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/service/impl/LoadBalancerInstanceManagerImpl.java
@@ -249,8 +249,14 @@ public class LoadBalancerInstanceManagerImpl implements LoadBalancerInstanceMana
                 .getLoadBalancerConfigId());
         List<String> ports = new ArrayList<String>();
         for (LoadBalancerListener listener : listeners) {
-            String fullPort = listener.getSourcePort() + ":" + listener.getSourcePort();
-            ports.add(fullPort);
+            if (listener.getSourcePort() != null) {
+                // LEGACY: private port is read from source_port (if missing) to provide backwards compatibility
+                String fullPort = listener.getSourcePort().toString() + ":" + listener.getPrivatePort() != null ? listener
+                        .getPrivatePort().toString()
+                        : listener.getSourcePort().toString();
+                ports.add(fullPort);
+
+            }
         }
 
         return ports;

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
@@ -36,6 +36,7 @@ public class InstanceConstants {
     public static final String FIELD_COMPUTE_TRIES = "computeTries";
     public static final String FIELD_LABELS = "labels";
     public static final String FIELD_HEALTH_CHECK = "healthCheck";
+    public static final String FIELD_EXPOSE = "expose";
 
     public static final String PROCESS_DATA_NO_OP = "containerNoOpEvent";
 

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/LoadBalancerListener.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/LoadBalancerListener.java
@@ -190,6 +190,17 @@ public interface LoadBalancerListener extends java.io.Serializable {
 	@javax.persistence.Column(name = "service_id", precision = 19)
 	public java.lang.Long getServiceId();
 
+	/**
+	 * Setter for <code>cattle.load_balancer_listener.private_port</code>.
+	 */
+	public void setPrivatePort(java.lang.Integer value);
+
+	/**
+	 * Getter for <code>cattle.load_balancer_listener.private_port</code>.
+	 */
+	@javax.persistence.Column(name = "private_port", precision = 10)
+	public java.lang.Integer getPrivatePort();
+
 	// -------------------------------------------------------------------------
 	// FROM and INTO
 	// -------------------------------------------------------------------------

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/LoadBalancerListenerTable.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/LoadBalancerListenerTable.java
@@ -11,7 +11,7 @@ package io.cattle.platform.core.model.tables;
 @java.lang.SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class LoadBalancerListenerTable extends org.jooq.impl.TableImpl<io.cattle.platform.core.model.tables.records.LoadBalancerListenerRecord> {
 
-	private static final long serialVersionUID = -126849998;
+	private static final long serialVersionUID = -351965140;
 
 	/**
 	 * The singleton instance of <code>cattle.load_balancer_listener</code>
@@ -105,6 +105,11 @@ public class LoadBalancerListenerTable extends org.jooq.impl.TableImpl<io.cattle
 	 * The column <code>cattle.load_balancer_listener.service_id</code>.
 	 */
 	public final org.jooq.TableField<io.cattle.platform.core.model.tables.records.LoadBalancerListenerRecord, java.lang.Long> SERVICE_ID = createField("service_id", org.jooq.impl.SQLDataType.BIGINT, this, "");
+
+	/**
+	 * The column <code>cattle.load_balancer_listener.private_port</code>.
+	 */
+	public final org.jooq.TableField<io.cattle.platform.core.model.tables.records.LoadBalancerListenerRecord, java.lang.Integer> PRIVATE_PORT = createField("private_port", org.jooq.impl.SQLDataType.INTEGER, this, "");
 
 	/**
 	 * Create a <code>cattle.load_balancer_listener</code> table reference

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/records/LoadBalancerListenerRecord.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/records/LoadBalancerListenerRecord.java
@@ -11,9 +11,9 @@ package io.cattle.platform.core.model.tables.records;
 @java.lang.SuppressWarnings({ "all", "unchecked", "rawtypes" })
 @javax.persistence.Entity
 @javax.persistence.Table(name = "load_balancer_listener", schema = "cattle")
-public class LoadBalancerListenerRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.platform.core.model.tables.records.LoadBalancerListenerRecord> implements io.cattle.platform.db.jooq.utils.TableRecordJaxb, org.jooq.Record16<java.lang.Long, java.lang.String, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Integer, java.lang.String, java.lang.Integer, java.lang.String, java.lang.Long>, io.cattle.platform.core.model.LoadBalancerListener {
+public class LoadBalancerListenerRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.platform.core.model.tables.records.LoadBalancerListenerRecord> implements io.cattle.platform.db.jooq.utils.TableRecordJaxb, org.jooq.Record17<java.lang.Long, java.lang.String, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Integer, java.lang.String, java.lang.Integer, java.lang.String, java.lang.Long, java.lang.Integer>, io.cattle.platform.core.model.LoadBalancerListener {
 
-	private static final long serialVersionUID = 322104400;
+	private static final long serialVersionUID = -1638179654;
 
 	/**
 	 * Setter for <code>cattle.load_balancer_listener.id</code>.
@@ -288,6 +288,23 @@ public class LoadBalancerListenerRecord extends org.jooq.impl.UpdatableRecordImp
 		return (java.lang.Long) getValue(15);
 	}
 
+	/**
+	 * Setter for <code>cattle.load_balancer_listener.private_port</code>.
+	 */
+	@Override
+	public void setPrivatePort(java.lang.Integer value) {
+		setValue(16, value);
+	}
+
+	/**
+	 * Getter for <code>cattle.load_balancer_listener.private_port</code>.
+	 */
+	@javax.persistence.Column(name = "private_port", precision = 10)
+	@Override
+	public java.lang.Integer getPrivatePort() {
+		return (java.lang.Integer) getValue(16);
+	}
+
 	// -------------------------------------------------------------------------
 	// Primary key information
 	// -------------------------------------------------------------------------
@@ -301,23 +318,23 @@ public class LoadBalancerListenerRecord extends org.jooq.impl.UpdatableRecordImp
 	}
 
 	// -------------------------------------------------------------------------
-	// Record16 type implementation
+	// Record17 type implementation
 	// -------------------------------------------------------------------------
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-	public org.jooq.Row16<java.lang.Long, java.lang.String, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Integer, java.lang.String, java.lang.Integer, java.lang.String, java.lang.Long> fieldsRow() {
-		return (org.jooq.Row16) super.fieldsRow();
+	public org.jooq.Row17<java.lang.Long, java.lang.String, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Integer, java.lang.String, java.lang.Integer, java.lang.String, java.lang.Long, java.lang.Integer> fieldsRow() {
+		return (org.jooq.Row17) super.fieldsRow();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-	public org.jooq.Row16<java.lang.Long, java.lang.String, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Integer, java.lang.String, java.lang.Integer, java.lang.String, java.lang.Long> valuesRow() {
-		return (org.jooq.Row16) super.valuesRow();
+	public org.jooq.Row17<java.lang.Long, java.lang.String, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Integer, java.lang.String, java.lang.Integer, java.lang.String, java.lang.Long, java.lang.Integer> valuesRow() {
+		return (org.jooq.Row17) super.valuesRow();
 	}
 
 	/**
@@ -452,6 +469,14 @@ public class LoadBalancerListenerRecord extends org.jooq.impl.UpdatableRecordImp
 	 * {@inheritDoc}
 	 */
 	@Override
+	public org.jooq.Field<java.lang.Integer> field17() {
+		return io.cattle.platform.core.model.tables.LoadBalancerListenerTable.LOAD_BALANCER_LISTENER.PRIVATE_PORT;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	public java.lang.Long value1() {
 		return getId();
 	}
@@ -574,6 +599,14 @@ public class LoadBalancerListenerRecord extends org.jooq.impl.UpdatableRecordImp
 	@Override
 	public java.lang.Long value16() {
 		return getServiceId();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public java.lang.Integer value17() {
+		return getPrivatePort();
 	}
 
 	/**
@@ -724,7 +757,16 @@ public class LoadBalancerListenerRecord extends org.jooq.impl.UpdatableRecordImp
 	 * {@inheritDoc}
 	 */
 	@Override
-	public LoadBalancerListenerRecord values(java.lang.Long value1, java.lang.String value2, java.lang.Long value3, java.lang.String value4, java.lang.String value5, java.lang.String value6, java.lang.String value7, java.util.Date value8, java.util.Date value9, java.util.Date value10, java.util.Map<String,Object> value11, java.lang.Integer value12, java.lang.String value13, java.lang.Integer value14, java.lang.String value15, java.lang.Long value16) {
+	public LoadBalancerListenerRecord value17(java.lang.Integer value) {
+		setPrivatePort(value);
+		return this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public LoadBalancerListenerRecord values(java.lang.Long value1, java.lang.String value2, java.lang.Long value3, java.lang.String value4, java.lang.String value5, java.lang.String value6, java.lang.String value7, java.util.Date value8, java.util.Date value9, java.util.Date value10, java.util.Map<String,Object> value11, java.lang.Integer value12, java.lang.String value13, java.lang.Integer value14, java.lang.String value15, java.lang.Long value16, java.lang.Integer value17) {
 		return this;
 	}
 
@@ -753,6 +795,7 @@ public class LoadBalancerListenerRecord extends org.jooq.impl.UpdatableRecordImp
 		setTargetPort(from.getTargetPort());
 		setTargetProtocol(from.getTargetProtocol());
 		setServiceId(from.getServiceId());
+		setPrivatePort(from.getPrivatePort());
 	}
 
 	/**
@@ -778,7 +821,7 @@ public class LoadBalancerListenerRecord extends org.jooq.impl.UpdatableRecordImp
 	/**
 	 * Create a detached, initialised LoadBalancerListenerRecord
 	 */
-	public LoadBalancerListenerRecord(java.lang.Long id, java.lang.String name, java.lang.Long accountId, java.lang.String kind, java.lang.String uuid, java.lang.String description, java.lang.String state, java.util.Date created, java.util.Date removed, java.util.Date removeTime, java.util.Map<String,Object> data, java.lang.Integer sourcePort, java.lang.String sourceProtocol, java.lang.Integer targetPort, java.lang.String targetProtocol, java.lang.Long serviceId) {
+	public LoadBalancerListenerRecord(java.lang.Long id, java.lang.String name, java.lang.Long accountId, java.lang.String kind, java.lang.String uuid, java.lang.String description, java.lang.String state, java.util.Date created, java.util.Date removed, java.util.Date removeTime, java.util.Map<String,Object> data, java.lang.Integer sourcePort, java.lang.String sourceProtocol, java.lang.Integer targetPort, java.lang.String targetProtocol, java.lang.Long serviceId, java.lang.Integer privatePort) {
 		super(io.cattle.platform.core.model.tables.LoadBalancerListenerTable.LOAD_BALANCER_LISTENER);
 
 		setValue(0, id);
@@ -797,5 +840,6 @@ public class LoadBalancerListenerRecord extends org.jooq.impl.UpdatableRecordImp
 		setValue(13, targetPort);
 		setValue(14, targetProtocol);
 		setValue(15, serviceId);
+		setValue(16, privatePort);
 	}
 }

--- a/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
+++ b/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
@@ -31,7 +31,7 @@ defaults
 <#if listeners?has_content && backends?has_content>
 <#list listeners as listener >
 frontend ${listener.uuid}_frontend
-        bind ${publicIp}:${listener.sourcePort}
+        bind ${publicIp}:<#if listener.privatePort??>${listener.privatePort}<#else>${listener.sourcePort}</#if>
         mode ${listener.sourceProtocol}
         <#list backends as backend >
         <#if (listener.sourceProtocol == "http" || listener.sourceProtocol == "https") && (backend.portSpec.domain != "default" || backend.portSpec.path != "default")>

--- a/resources/content/db/changelog.xml
+++ b/resources/content/db/changelog.xml
@@ -58,4 +58,5 @@
     <include file="db/core-051.xml"/>
     <include file="db/core-052.xml"/>
     <include file="db/core-053.xml"/>
+    <include file="db/lbport.xml"/>
 </databaseChangeLog>

--- a/resources/content/db/lbport.xml
+++ b/resources/content/db/lbport.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+    <property name="mediumtext" value="TEXT" dbms="postgresql" />
+    <property name="mediumtext" value="MEDIUMTEXT" />
+    <changeSet author="alena (generated)" id="dump1">
+        <addColumn tableName="load_balancer_listener">
+            <column name="private_port" type="INT"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/resources/content/schema/base/instance.json
+++ b/resources/content/schema/base/instance.json
@@ -75,6 +75,11 @@
         "systemContainer" : {
             "type": "enum",
             "options": [ "NetworkAgent", "LoadBalancerAgent"]
+        },
+        "expose": {
+            "type": "array[string]",
+            "create": true,
+            "nullable": true
         }
     },
     "resourceActions" : {

--- a/resources/content/schema/base/loadBalancerListener.json
+++ b/resources/content/schema/base/loadBalancerListener.json
@@ -14,8 +14,7 @@
             "type": "int",
             "min": 1,
             "max": 65535,
-            "required": true,
-            "nullable": false
+            "nullable": true
         },
         "targetPort": {
             "type": "int",
@@ -27,6 +26,11 @@
             "options": [ "roundrobin", "leastconn", "source"],
             "nullable": true,
             "default": "roundrobin"
+        },
+        "privatePort": {
+            "type": "int",
+            "min": 1,
+            "max": 65535
         }
     }
 }

--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -83,6 +83,7 @@
         "container.labels" : "cr",
         "container.volumeDriver" : "cr",
         "container.workingDir" : "cr",
+        "container.expose" : "cr",
 
         "containerExec" : "r",
         "containerExec.attachStdin" : "cr",
@@ -267,6 +268,7 @@
         "loadBalancerListener.targetProtocol" : "r",
         "loadBalancerListener.algorithm" : "cr",
         "loadBalancerListener.serviceId" : "r",
+        "loadBalancerListener.privatePort" : "cr",
 
         "loadBalancerConfig" : "r",
         "loadBalancerConfig.healthCheck" : "cru",

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -618,7 +618,8 @@ def test_container_auth(admin_user_client, user_client, project_client):
         'pidMode': 'r',
         'volumeDriver': 'r',
         'extraHosts': 'r',
-        'readOnly': 'r'
+        'readOnly': 'r',
+        'expose': 'r'
     })
 
     auth_check(user_client.schema, 'container', 'r', {
@@ -674,7 +675,8 @@ def test_container_auth(admin_user_client, user_client, project_client):
         'pidMode': 'r',
         'extraHosts': 'r',
         'volumeDriver': 'r',
-        'readOnly': 'r'
+        'readOnly': 'r',
+        'expose': 'r'
     })
 
     auth_check(project_client.schema, 'container', 'crud', {
@@ -730,7 +732,8 @@ def test_container_auth(admin_user_client, user_client, project_client):
         'pidMode': 'cr',
         'extraHosts': 'cr',
         'volumeDriver': 'cr',
-        'readOnly': 'cr'
+        'readOnly': 'cr',
+        'expose': 'cr'
     })
 
     auth_check(project_client.schema, 'dockerBuild', 'cr', {
@@ -1527,5 +1530,44 @@ def test_svc_discovery_consume_map(admin_user_client, user_client,
         'serviceId': 'r',
         'consumedServiceId': 'r',
         'ports': 'r',
+        'accountId': 'r'
+    })
+
+
+def test_lb_listener(admin_user_client, user_client, project_client):
+    auth_check(admin_user_client.schema, 'loadBalancerListener', 'r', {
+        'name': 'r',
+        'sourceProtocol': 'r',
+        'targetProtocol': 'r',
+        'sourcePort': 'r',
+        'targetPort': 'r',
+        'privatePort': 'r',
+        'algorithm': 'r',
+        'data': 'r',
+        'serviceId': 'r',
+        'accountId': 'r'
+    })
+
+    auth_check(user_client.schema, 'loadBalancerListener', 'r', {
+        'name': 'r',
+        'sourceProtocol': 'r',
+        'targetProtocol': 'r',
+        'sourcePort': 'r',
+        'targetPort': 'r',
+        'privatePort': 'r',
+        'algorithm': 'r',
+        'serviceId': 'r',
+        'accountId': 'r'
+    })
+
+    auth_check(project_client.schema, 'loadBalancerListener', 'crud', {
+        'name': 'cru',
+        'sourceProtocol': 'cr',
+        'targetProtocol': 'r',
+        'sourcePort': 'cr',
+        'targetPort': 'r',
+        'privatePort': 'cr',
+        'algorithm': 'cr',
+        'serviceId': 'r',
         'accountId': 'r'
     })

--- a/tests/integration/cattletest/core/test_lb_lifecycle.py
+++ b/tests/integration/cattletest/core/test_lb_lifecycle.py
@@ -11,9 +11,10 @@ def nsp(super_client, sim_context):
     return nsp
 
 
-def test_add_lb_w_host_and_target(super_client, client, context):
-    port = 88
-    port1 = 101
+def test_add_lb_w_host_and_target(super_client, client,
+                                  context, is_public=True):
+    port = 193
+    port1 = 191
     # add host
     agent, lb, uri, instance, config = _create_lb_w_host(super_client,
                                                          client,
@@ -93,8 +94,30 @@ def test_destroy_lb_instance(super_client, client, context):
     assert len(ports) == 1
 
 
-def _create_valid_lb(client, listenerPort):
-    config = _create_config(client, listenerPort)
+def test_private_lb(super_client, client, context):
+    port = 77
+    # add host
+    agent, lb, uri, instance, config = _create_lb_w_host(super_client,
+                                                         client,
+                                                         context,
+                                                         port,
+                                                         is_public=False)
+    # add target to a load balancer
+    image_uuid = context.image_uuid
+    container = client.create_container(imageUuid=image_uuid)
+    container = client.wait_success(container)
+    target = {"instanceId": container.id, "ports": "100"}
+    lb = lb.addtarget(loadBalancerTarget=target)
+    _validate_add_target(container, lb, client)
+
+    # check that port wasn't opened
+    ports = client.list_port(publicPort=port,
+                             instanceId=instance.id, state='active')
+    assert len(ports) == 0
+
+
+def _create_valid_lb(client, listenerPort, is_public=True):
+    config = _create_config(client, listenerPort, is_public)
     default_lb_config = client. \
         create_loadBalancerConfig(name=random_str())
     client.wait_success(default_lb_config)
@@ -105,12 +128,12 @@ def _create_valid_lb(client, listenerPort):
     return test_lb, config
 
 
-def _create_config(client, listenerPort):
+def _create_config(client, listenerPort, is_public=True):
     # create config
     config = client.create_loadBalancerConfig(name=random_str())
     config = client.wait_success(config)
     # create listener
-    listener = _create_valid_listener(client, listenerPort)
+    listener = _create_valid_listener(client, listenerPort, is_public)
     # add listener to config
     config = config.addlistener(loadBalancerListenerId=listener.id)
     _validate_add_listener(config, listener, client)
@@ -118,11 +141,12 @@ def _create_config(client, listenerPort):
     return config
 
 
-def _create_lb_w_host(super_client, client, context, listenerPort):
+def _create_lb_w_host(super_client, client, context,
+                      listenerPort, is_public=True):
     host = context.host
 
     # create lb
-    lb, config = _create_valid_lb(client, listenerPort)
+    lb, config = _create_valid_lb(client, listenerPort, is_public)
 
     # add host to lb
     lb.addhost(hostId=host.id)
@@ -143,9 +167,11 @@ def _create_lb_w_host(super_client, client, context, listenerPort):
     return agent, lb, uri, instance, config
 
 
-def _create_valid_listener(client, sourcePort):
+def _create_valid_listener(client, sourcePort, is_public=True):
     listener = client.create_loadBalancerListener(name=random_str(),
-                                                  sourcePort=sourcePort,
+                                                  privatePort=sourcePort,
+                                                  sourcePort=sourcePort
+                                                  if is_public else None,
                                                   sourceProtocol='http',
                                                   targetProtocol='http')
     listener = client.wait_success(listener)

--- a/tests/integration/cattletest/core/test_svc_discovery_lb.py
+++ b/tests/integration/cattletest/core/test_svc_discovery_lb.py
@@ -613,6 +613,49 @@ def test_set_service_links(client, context):
     _validate_remove_service_link(client, lb_service, service2, ports=["100"])
 
 
+def test_private_lb(client, context):
+    env = client.create_environment(name=random_str())
+    env = client.wait_success(env)
+    assert env.state == "active"
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": image_uuid,
+                     "ports": [8081, '909:1001'],
+                     "expose": [9999, 9998]}
+    service = client.create_loadBalancerService(name=random_str(),
+                                                environmentId=env.id,
+                                                launchConfig=launch_config)
+    service = client.wait_success(service)
+    assert service.state == "inactive"
+    # 1. verify that the service was activated
+    service = client.wait_success(service.activate(), 120)
+    assert service.state == "active"
+    # 2. verify that lb got created
+    lbs = client. \
+        list_loadBalancer(serviceId=service.id)
+    assert len(lbs) == 1
+    lb = client.wait_success(lbs[0])
+    assert lb.state == 'active'
+    listeners = client. \
+        list_loadBalancerListener(serviceId=service.id, privatePort=8081)
+    assert len(listeners) == 1
+    assert listeners[0].sourcePort == 8081
+
+    listeners = client. \
+        list_loadBalancerListener(serviceId=service.id, privatePort=1001)
+    assert len(listeners) == 1
+    assert listeners[0].sourcePort == 909
+
+    listeners = client. \
+        list_loadBalancerListener(serviceId=service.id, privatePort=9999)
+    assert len(listeners) == 1
+    assert listeners[0].sourcePort is None
+
+    listeners = client. \
+        list_loadBalancerListener(serviceId=service.id, privatePort=9998)
+    assert len(listeners) == 1
+    assert listeners[0].sourcePort is None
+
+
 def _wait_until_active_map_count(lb, count, super_client, timeout=30):
     start = time.time()
     host_maps = super_client. \
@@ -684,15 +727,15 @@ def _validate_lb_instance(host, lb, super_client, service):
 
 
 def _validate_create_listener(env, service, source_port,
-                              client, target_port):
-    l_name = env.name + "_" + service.name + "_" + source_port
+                              client, private_port):
+    l_name = env.name + "_" + service.name + "_" + private_port
     listeners = client. \
         list_loadBalancerListener(sourcePort=source_port,
                                   name=l_name)
     assert len(listeners) >= 1
     listener = listeners[0]
     assert listener.sourcePort == int(source_port)
-    assert listener.targetPort == int(target_port)
+    assert listener.privatePort == int(private_port)
     return listener
 
 


### PR DESCRIPTION
API changes:

1) loadBalancerListener.add

* sourcePort is optional now
* new parameter - privatePort - was added.

Either one or another parameter is required; both can be specified as well. 
If sourcePort only is specified, private port is defaulted to it. 

2) loadBalancerService.add

* new parameter is added to launchConfig - "expose". Every port defined in expose,  will get translated to the listener having NULL public port, and port=port from expose set, and Format for expose is: [<port>/[protocol]]. If no protocol is specified, http listener will get created.
* if both ports and expose is specified, for every port defined in the expose, private listener will get created; and for each port - public listener. 