### PR TITLE
For primary config, just use stack_name/service_name

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnit.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnit.java
@@ -317,7 +317,10 @@ public class DeploymentUnit {
 
     protected Map<String, String> getLabels(DeploymentUnitInstance instance) {
         Map<String, String> labels = new HashMap<>();
-        String serviceName = instance.getService().getName() + '/' + instance.getLaunchConfigName();
+        String serviceName = instance.getService().getName();
+        if (!ServiceDiscoveryConstants.PRIMARY_LAUNCH_CONFIG_NAME.equals(instance.getLaunchConfigName())) {
+            serviceName = serviceName + '/' + instance.getLaunchConfigName();
+        }
         String envName = context.objectManager.loadResource(Environment.class, instance.getService().getEnvironmentId())
                 .getName();
         labels.put(ServiceDiscoveryConstants.LABEL_STACK_NAME, envName);

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -1098,16 +1098,14 @@ def test_validate_labels(client, context):
     result_labels_1 = {'affinity': 'container==B', '!affinity': "container==C",
                        'io.rancher.stack.name': env.name,
                        'io.rancher.stack_service.name':
-                           env.name + '/' + service_name1 + '/' +
-                           "io.rancher.service.primary.launch.config"}
+                           env.name + '/' + service_name1}
     instance1 = _validate_compose_instance_start(client, service1, env, "1")
     assert all(item in instance1.labels for item in result_labels_1) is True
 
     # check that only one internal label is set
     result_labels_2 = {'io.rancher.stack.name': env.name,
                        'io.rancher.stack_service.name':
-                           env.name + '/' + service_name2 + '/' +
-                           "io.rancher.service.primary.launch.config"}
+                           env.name + '/' + service_name2}
     instance2 = _validate_compose_instance_start(client, service2, env, "1")
     assert all(item in instance2.labels for item in result_labels_2) is True
 
@@ -1739,8 +1737,7 @@ def test_service_affinity_rules(super_client, new_context):
         "labels": {
             "io.rancher.scheduler.affinity:container_label_ne":
                 "io.rancher.stack_service.name=" +
-                env.name + '/' + service_name + '/' +
-                "io.rancher.service.primary.launch.config"
+                env.name + '/' + service_name
         }
     }
 

--- a/tests/integration/cattletest/core/test_svc_discovery_lb.py
+++ b/tests/integration/cattletest/core/test_svc_discovery_lb.py
@@ -436,8 +436,7 @@ def test_labels(super_client, client, context):
     lb_instance = _validate_lb_instance(host, lb, super_client, service)
     result_labels = {'affinity': "container==B", '!affinity': "container==C",
                      'io.rancher.stack_service.name':
-                         env.name + "/" + service_name + "/" +
-                         "io.rancher.service.primary.launch.config"}
+                         env.name + "/" + service_name}
 
     assert all(item in lb_instance.labels.items()
                for item in result_labels.items()) is True
@@ -459,8 +458,7 @@ def test_labels(super_client, client, context):
                                                 service, client,
                                                 ['8089:8089', '914:914'])
     lb_instance = _validate_lb_instance(host, lb, super_client, service)
-    name = env.name + '/' + service_name + '/' + \
-        "io.rancher.service.primary.launch.config"
+    name = env.name + '/' + service_name
     result_labels = {'io.rancher.stack_service.name': name}
     assert all(item in lb_instance.labels.items()
                for item in result_labels.items()) is True


### PR DESCRIPTION
@alena1108 @ibuildthecloud Can you take a quick look.  This removes that nasty "io.rancher.service.primary.launch.config" part from the ${service_name} macro for the primary config.  secondary config will still have it.  This also allows for backwards compatibility prior to adding the launchConfig name to the service name (for the anti-affinity blocker bug).
