### PR TITLE
Add map to extensionManager.

### DIFF
--- a/code/framework/extension/src/main/java/io/cattle/platform/extension/ExtensionManager.java
+++ b/code/framework/extension/src/main/java/io/cattle/platform/extension/ExtensionManager.java
@@ -1,6 +1,7 @@
 package io.cattle.platform.extension;
 
 import java.util.List;
+import java.util.Map;
 
 public interface ExtensionManager {
 
@@ -9,6 +10,8 @@ public interface ExtensionManager {
     <T> T first(String key, Class<T> type);
 
     List<?> list(String key);
+
+    Map<String, Object> map(String key);
 
     <T> List<T> getExtensionList(Class<T> type);
 

--- a/code/framework/extension/src/main/java/io/cattle/platform/extension/impl/ExtensionMap.java
+++ b/code/framework/extension/src/main/java/io/cattle/platform/extension/impl/ExtensionMap.java
@@ -1,0 +1,84 @@
+package io.cattle.platform.extension.impl;
+
+import io.cattle.platform.extension.ExtensionManager;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ExtensionMap<K, V> implements Map<K, V> {
+
+    Map<K, V> map;
+    ConcurrentHashMap<K, V> inner;
+    String key;
+    ExtensionManager extensionManager;
+
+    public ExtensionMap(ExtensionManager extensionManager, String key, Map<K, V> map) {
+        this.extensionManager = extensionManager;
+        this.key = key;
+        this.inner = map == null ? new ConcurrentHashMap<K, V>() : new ConcurrentHashMap<>(map);
+        this.map = Collections.unmodifiableMap(inner);
+    }
+
+    @Override
+    public int size() {
+        return map.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return map.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return map.containsValue(value);
+    }
+
+    @Override
+    public V get(Object key) {
+        return map.get(key);
+    }
+
+    @Override
+    public V put(K key, V value) {
+        return map.put(key, value);
+    }
+
+    @Override
+    public V remove(Object key) {
+        return map.remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+        map.putAll(m);
+    }
+
+    @Override
+    public void clear() {
+        map.clear();
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return map.keySet();
+    }
+
+    @Override
+    public Collection<V> values() {
+        return map.values();
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return map.entrySet();
+    }
+}


### PR DESCRIPTION
This allows you to use interfaces to create a map of beans in the extensionmanager instead of a list.

This allows constant time access to beans needed of a certain type, instead of n by iterating over a list.