### PR TITLE
remove protocol from api.host setting

### DIFF
--- a/code/implementation/host-api/src/main/java/io/cattle/platform/host/api/HostApiProxyTokenManager.java
+++ b/code/implementation/host-api/src/main/java/io/cattle/platform/host/api/HostApiProxyTokenManager.java
@@ -86,6 +86,7 @@ public class HostApiProxyTokenManager extends AbstractNoOpResourceManager {
         }
 
         String apiProxyScheme = HostApiUtils.HOST_API_PROXY_SCHEME.get();
+        hostAddress = hostAddress.replace("http://", "").replace("https://", "");
         token.setUrl(apiProxyScheme + "://" + hostAddress + "/v1/connectbackend");
         return token;
     }


### PR DESCRIPTION
The api.host setting can begin with a protocol like
`https://mydomain.com`. The host-api token generation code was not
respecting that setting.

Addresses rancher/rancher#1580