### PR TITLE
Allow null input for hostname/externalIps

### DIFF
--- a/resources/content/schema/base/externalService.json
+++ b/resources/content/schema/base/externalService.json
@@ -3,7 +3,7 @@
         "externalIpAddresses": {
             "type": "array[string]",
             "required": false,
-            "nullable": false,
+            "nullable": true,
             "attributes" : {
                 "scheduleUpdate" : true
             }
@@ -11,7 +11,7 @@
         "hostname": {
             "type": "string",
             "required": false,
-            "nullable": false,
+            "nullable": true,
             "attributes" : {
                 "scheduleUpdate" : true
             }


### PR DESCRIPTION
In external service. As these 2 params are mutually exclusive now.

W/o this fix, externalService.update will always fail in the UI.