### PR TITLE
Program hostname routing rules in order

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/util/LoadBalancerTargetPortSpec.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/util/LoadBalancerTargetPortSpec.java
@@ -74,13 +74,14 @@ public class LoadBalancerTargetPortSpec {
             }
             
             // path assignment
+            if (input.startsWith("/")) {
+                path = input;
+                return;
+            }
             String[] splittedBySlash = StringUtils.split(input, "/", 2);
             if (splittedBySlash.length > 1) {
                 path = "/" + splittedBySlash[1];
                 input = splittedBySlash[0];
-            } else if (input.startsWith("/")) {
-                path = input;
-                return;
             }
 
             // domain name assignment


### PR DESCRIPTION
hostname + path first; then single hostname or path; then default route


https://github.com/rancher/rancher/issues/1621

Also paths should are sorted by length in descending order, so ACLs are configured on haproxy as:

/foo/bar/other
/foo/bar
/foo