### PR TITLE
Service discovery fixes

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/LoadBalancerInfoFactory.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/LoadBalancerInfoFactory.java
@@ -134,7 +134,9 @@ public class LoadBalancerInfoFactory extends AbstractAgentBaseContextFactory {
                 LoadBalancerTarget.class);
         Map<String, List<LoadBalancerTargetInfo>> uuidToTargetInfos = new HashMap<>();
         for (LoadBalancerTarget target : targets) {
-            if (!(target.getState().equalsIgnoreCase(CommonStatesConstants.ACTIVATING) || target.getState().equalsIgnoreCase(CommonStatesConstants.ACTIVE))) {
+            if (!(target.getState().equalsIgnoreCase(CommonStatesConstants.ACTIVATING)
+                    || target.getState().equalsIgnoreCase(CommonStatesConstants.ACTIVE) || target.getState()
+                    .equalsIgnoreCase(CommonStatesConstants.UPDATING_ACTIVE))) {
                 continue;
             }
             String ipAddress = target.getIpAddress();

--- a/code/iaas/lb-instance/src/main/resources/META-INF/cattle/system-services/lb-instance-defaults.properties
+++ b/code/iaas/lb-instance/src/main/resources/META-INF/cattle/system-services/lb-instance-defaults.properties
@@ -1,5 +1,5 @@
 lb.instance.name=Lb Agent
 lb.config.items=haproxy
 
-lb.instance.update.config.item.processes=loadbalancerconfiglistenermap.create,loadbalancerconfiglistenermap.remove,loadbalancertarget.create,loadbalancertarget.remove,loadbalancerhostmap.create,instance.start,instance.restart,instance.stop,loadbalancerconfig.update,${lb.instance.update.config.item.processes.extra}
+lb.instance.update.config.item.processes=loadbalancerconfiglistenermap.create,loadbalancerconfiglistenermap.remove,loadbalancertarget.create,loadbalancertarget.remove,loadbalancertarget.update,loadbalancerhostmap.create,instance.start,instance.restart,instance.stop,loadbalancerconfig.update,${lb.instance.update.config.item.processes.extra}
 lb.instance.update.config.item.processes.extra=

--- a/code/iaas/logic/src/main/resources/META-INF/cattle/core-process/spring-core-processes-context.xml
+++ b/code/iaas/logic/src/main/resources/META-INF/cattle/core-process/spring-core-processes-context.xml
@@ -126,7 +126,8 @@
 
     <!-- Load Balancer Target -->
     <process:process name="loadbalancertarget.create" resourceType="loadBalancerTarget" start="requested" transitioning="activating" done="active" />
-    <process:process name="loadbalancertarget.remove" resourceType="loadBalancerTarget" start="active,activating" transitioning="removing" done="removed" />
+    <process:process name="loadbalancertarget.remove" resourceType="loadBalancerTarget" start="active,activating,updating-active" transitioning="removing" done="removed" />
+    <process:process name="loadbalancertarget.update" resourceType="loadBalancerTarget" start="active,activating" transitioning="updating-active" done="active" />
 
     <!-- Load Balancer Host Map -->
     <process:process name="loadbalancerhostmap.create" resourceType="LoadBalancerHostMap" start="requested" transitioning="activating" done="active" />
@@ -163,7 +164,8 @@
     
     <!-- Service Discovery Service/Service map -->
     <process:process name="serviceconsumemap.create" resourceType="serviceConsumeMap" start="requested" transitioning="activating" done="active" />
-    <process:process name="serviceconsumemap.remove" resourceType="serviceConsumeMap" start="active,activating" transitioning="removing" done="removed" />
+    <process:process name="serviceconsumemap.remove" resourceType="serviceConsumeMap" start="active,activating,updating-active" transitioning="removing" done="removed" />
+    <process:process name="serviceconsumemap.update" resourceType="serviceConsumeMap" start="active,activating" transitioning="updating-active" done="active" />
     
       <!-- Instance healthcheck -->
     <process:process name="healthcheckinstance.create" resourceType="healthcheckInstance" start="requested" transitioning="activating" done="active" />

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/action/SetServiceLinksActionHandler.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/action/SetServiceLinksActionHandler.java
@@ -3,7 +3,6 @@ package io.cattle.platform.servicediscovery.api.action;
 import io.cattle.platform.api.action.ActionHandler;
 import io.cattle.platform.core.addon.LoadBalancerServiceLink;
 import io.cattle.platform.core.addon.ServiceLink;
-import io.cattle.platform.core.constants.LoadBalancerConstants;
 import io.cattle.platform.core.model.Service;
 import io.cattle.platform.core.model.ServiceConsumeMap;
 import io.cattle.platform.json.JsonMapper;
@@ -115,18 +114,8 @@ public class SetServiceLinksActionHandler implements ActionHandler {
                 ServiceLink newServiceLink = newServiceLinks.get(existingMap.getConsumedServiceId());
                 
                 boolean namesAreEqual = StringUtils.equalsIgnoreCase(newServiceLink.getName(), existingMap.getName());
-                boolean portsAreEqual = true;
-                if (forLb) {
-                    LoadBalancerServiceLink newLbServiceLink = (LoadBalancerServiceLink) newServiceLink;
-                    List<? extends String> newPorts = newLbServiceLink.getPorts() != null ? newLbServiceLink.getPorts()
-                            : new ArrayList<String>();
-                    List<? extends String> existingPorts = DataAccessor.fields(existingMap).
-                            withKey(LoadBalancerConstants.FIELD_LB_TARGET_PORTS).withDefault(Collections.EMPTY_LIST)
-                            .asList(jsonMapper, String.class);
-                    portsAreEqual = newPorts.containsAll(existingPorts) && existingPorts.containsAll(newPorts);
-                }
 
-                if (!namesAreEqual || !portsAreEqual) {
+                if (!namesAreEqual) {
                     linksToRemove.add(existingLink);
                 }
             }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
@@ -70,6 +70,7 @@ public class ServiceDiscoveryConstants {
 
     public static final String PRIMARY_LAUNCH_CONFIG_NAME = "io.rancher.service.primary.launch.config";
     public static final String LABEL_SIDEKICK = "io.rancher.sidekicks";
+    public static final String LABEL_LB_TARGET = "io.rancher.loadbalancer.target.";
 
     public static final String STATE_UPGRADING = "upgrading";
 }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
@@ -47,6 +47,7 @@ public class ServiceDiscoveryConstants {
     public static final String PROCESS_SERVICE_REMOVE_SERVICE_LINK = "service." + ACTION_SERVICE_REMOVE_SERVICE_LINK;
     public static final String PROCESS_SERVICE_CONSUME_MAP_CREATE = "serviceconsumemap.create";
     public static final String PROCESS_SERVICE_CONSUME_MAP_REMOVE = "serviceconsumemap.remove";
+    public static final String PROCESS_SERVICE_CONSUME_MAP_UPDATE = "serviceconsumemap.update";
     public static final String PROCESS_SERVICE_UPDATE = "service.update";
     public static final String PROCESS_SERVICE_SET_SERVICE_LINKS = "service." + ACTION_SERVICE_SET_SERVICE_LINKS;
     public static final String PROCESS_SERVICE_EXPOSE_MAP_CREATE = "serviceexposemap.create";

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceAddRemoveLinkServiceValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceAddRemoveLinkServiceValidationFilter.java
@@ -67,8 +67,7 @@ public class ServiceAddRemoveLinkServiceValidationFilter extends AbstractDefault
                         ServiceDiscoveryConstants.FIELD_SERVICE_ID);
             }
             Service consumedService = objectManager.loadResource(Service.class, serviceLink.getServiceId());
-            if (service == null || consumedService == null
-                    || !consumedService.getEnvironmentId().equals(service.getEnvironmentId())) {
+            if (service == null || consumedService == null) {
                 ValidationErrorCodes.throwValidationError(ValidationErrorCodes.INVALID_REFERENCE,
                         ServiceDiscoveryConstants.FIELD_SERVICE_ID);
             }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceSetServiceLinksValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceSetServiceLinksValidationFilter.java
@@ -77,8 +77,7 @@ public class ServiceSetServiceLinksValidationFilter extends AbstractDefaultResou
                 }
                 serviceIds.add(serviceLink.getServiceId());
                 Service consumedService = objectManager.loadResource(Service.class, serviceLink.getServiceId());
-                if (service == null || consumedService == null
-                        || !consumedService.getEnvironmentId().equals(service.getEnvironmentId())) {
+                if (service == null || consumedService == null) {
                     ValidationErrorCodes.throwValidationError(ValidationErrorCodes.INVALID_REFERENCE,
                             ServiceDiscoveryConstants.FIELD_SERVICE_ID);
                 }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/resource/ServiceDiscoveryConfigItem.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/resource/ServiceDiscoveryConfigItem.java
@@ -1,6 +1,7 @@
 package io.cattle.platform.servicediscovery.api.resource;
 
 import io.cattle.platform.core.constants.InstanceConstants;
+import io.cattle.platform.core.model.Service;
 import io.cattle.platform.docker.constants.DockerInstanceConstants;
 import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
 import io.cattle.platform.util.type.NamedUtils;
@@ -54,8 +55,7 @@ public class ServiceDiscoveryConfigItem {
             "net");
 
     public static final ServiceDiscoveryConfigItem LABELS = new ServiceDiscoveryConfigItem(
-            InstanceConstants.FIELD_LABELS, InstanceConstants.FIELD_LABELS,
-            true, true);
+            InstanceConstants.FIELD_LABELS, InstanceConstants.FIELD_LABELS);
 
     // CATTLE PARAMETERS
     public static final ServiceDiscoveryConfigItem SCALE = new ServiceDiscoveryConfigItem("scale", "scale",
@@ -137,9 +137,15 @@ public class ServiceDiscoveryConfigItem {
         return null;
     }
 
-    public static ServiceDiscoveryConfigItem getServiceConfigItemByCattleName(String internalName) {
+    public static ServiceDiscoveryConfigItem getServiceConfigItemByCattleName(String internalName, Service service) {
         for (ServiceDiscoveryConfigItem serviceItem : supportedServiceConfigItems) {
             if (serviceItem.getCattleName() != null && serviceItem.getCattleName().equalsIgnoreCase(internalName)) {
+                // special handling for external service hostname
+                if (service.getKind().equalsIgnoreCase(ServiceDiscoveryConstants.KIND.EXTERNALSERVICE.name())
+                        && serviceItem.getCattleName().equalsIgnoreCase(HOSTNAME.cattleName)) {
+                    return new ServiceDiscoveryConfigItem(serviceItem.getCattleName(), serviceItem.getDockerName(),
+                            false, false);
+                }
                 return serviceItem;
             }
         }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/service/impl/ServiceDiscoveryApiServiceImpl.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/service/impl/ServiceDiscoveryApiServiceImpl.java
@@ -122,11 +122,11 @@ public class ServiceDiscoveryApiServiceImpl implements ServiceDiscoveryApiServic
             for (String launchConfigName : launchConfigNames) {
                 boolean isPrimaryConfig = launchConfigName
                         .equals(ServiceDiscoveryConstants.PRIMARY_LAUNCH_CONFIG_NAME);
-                Map<String, Object> rancherServiceData = ServiceDiscoveryUtil.getServiceDataAsMap(service,
+                Map<String, Object> cattleServiceData = ServiceDiscoveryUtil.getServiceDataAsMap(service,
                         launchConfigName, allocatorService);
                 Map<String, Object> composeServiceData = new HashMap<>();
-                for (String rancherService : rancherServiceData.keySet()) {
-                    translateRancherToCompose(forDockerCompose, rancherServiceData, composeServiceData, rancherService);
+                for (String cattleService : cattleServiceData.keySet()) {
+                    translateRancherToCompose(forDockerCompose, cattleServiceData, composeServiceData, cattleService, service);
                 }
 
                 if (forDockerCompose) {
@@ -305,10 +305,10 @@ public class ServiceDiscoveryApiServiceImpl implements ServiceDiscoveryApiServic
     }
 
     protected void translateRancherToCompose(boolean forDockerCompose, Map<String, Object> rancherServiceData,
-            Map<String, Object> composeServiceData, String rancherService) {
-        ServiceDiscoveryConfigItem item = ServiceDiscoveryConfigItem.getServiceConfigItemByCattleName(rancherService);
+            Map<String, Object> composeServiceData, String cattleName, Service service) {
+        ServiceDiscoveryConfigItem item = ServiceDiscoveryConfigItem.getServiceConfigItemByCattleName(cattleName, service);
         if (item != null && item.isDockerComposeProperty() == forDockerCompose) {
-            Object value = rancherServiceData.get(rancherService);
+            Object value = rancherServiceData.get(cattleName);
             boolean export = false;
             if (value instanceof List) {
                 if (!((List<?>) value).isEmpty()) {

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceDiscoveryLoadBalancerTargetAddPostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceDiscoveryLoadBalancerTargetAddPostListener.java
@@ -63,7 +63,8 @@ public class ServiceDiscoveryLoadBalancerTargetAddPostListener extends AbstractO
         return new String[] { InstanceConstants.PROCESS_START,
                 ServiceDiscoveryConstants.PROCESS_SERVICE_CONSUME_MAP_CREATE,
                 ServiceDiscoveryConstants.PROCESS_SERVICE_CREATE,
-                ServiceDiscoveryConstants.PROCESS_SERVICE_EXPOSE_MAP_CREATE };
+                ServiceDiscoveryConstants.PROCESS_SERVICE_EXPOSE_MAP_CREATE,
+                ServiceDiscoveryConstants.PROCESS_SERVICE_CONSUME_MAP_UPDATE };
     }
 
     @Override
@@ -89,7 +90,9 @@ public class ServiceDiscoveryLoadBalancerTargetAddPostListener extends AbstractO
         List<Pair<ServiceExposeMap, Service>> exposeMapToLBService = new ArrayList<>();
         if (process.getName().equalsIgnoreCase(InstanceConstants.PROCESS_START)) {
             getLBServiceForInstance(state, exposeMapToLBService);
-        } else if (process.getName().equalsIgnoreCase(ServiceDiscoveryConstants.PROCESS_SERVICE_CONSUME_MAP_CREATE)) {
+        } else if (process.getName().equalsIgnoreCase(
+                ServiceDiscoveryConstants.PROCESS_SERVICE_CONSUME_MAP_CREATE)
+                || process.getName().equalsIgnoreCase(ServiceDiscoveryConstants.PROCESS_SERVICE_CONSUME_MAP_UPDATE)) {
             getLBServiceForServiceLink(state, exposeMapToLBService);
         } else if (process.getName().equalsIgnoreCase(ServiceDiscoveryConstants.PROCESS_SERVICE_CREATE)) {
             getLBServiceForService(state, exposeMapToLBService);

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -777,16 +777,10 @@ def test_link_services_from_diff_env(client, context):
                                      launchConfig=launch_config)
     service2 = client.wait_success(service2)
 
-    # try to link
-    with pytest.raises(ApiError) as e:
-        service_link = {"serviceId": service2.id}
-        service1.addservicelink(serviceLink=service_link)
-
-    assert e.value.error.status == 422
-    assert e.value.error.code == 'InvalidReference'
-    assert e.value.error.fieldName == 'serviceId'
-
-    env1.remove()
+    # try to link - should work
+    service_link = {"serviceId": service2.id}
+    service1.addservicelink(serviceLink=service_link)
+    _validate_add_service_link(service1, service2, client)
 
 
 def test_set_service_links(client, context):
@@ -839,7 +833,7 @@ def test_set_service_links(client, context):
     service1 = service1.setservicelinks(serviceLinks=[])
     _validate_remove_service_link(service1, service2, client, "link3")
 
-    # try to link to the service from diff environment
+    # try to link to the service from diff environment - should work
     env2 = client.create_environment(name=random_str())
     env2 = client.wait_success(env2)
 
@@ -848,13 +842,8 @@ def test_set_service_links(client, context):
                                      launchConfig=launch_config)
     service4 = client.wait_success(service4)
 
-    with pytest.raises(ApiError) as e:
-        service_link = {"serviceId": service4.id}
-        service1.setservicelinks(serviceLinks=[service_link])
-
-    assert e.value.error.status == 422
-    assert e.value.error.code == 'InvalidReference'
-    assert e.value.error.fieldName == 'serviceId'
+    service_link = {"serviceId": service4.id}
+    service1.setservicelinks(serviceLinks=[service_link])
 
     env1.remove()
     env2.remove()

--- a/tests/integration/cattletest/core/test_svc_discovery_lb.py
+++ b/tests/integration/cattletest/core/test_svc_discovery_lb.py
@@ -591,18 +591,16 @@ def test_set_service_links(client, context):
     service_link2 = {"serviceId": service3.id, "ports": ["a.com:101"]}
     lb_service = lb_service. \
         setservicelinks(serviceLinks=[service_link1, service_link2])
-    _validate_remove_service_link(client, lb_service, service2, 1)
-    _validate_remove_service_link(client, lb_service, service3, 1)
     _validate_add_service_link(client, lb_service, service2,
                                ports=["a.com:100"])
     _validate_add_service_link(client, lb_service, service3,
                                ports=["a.com:101"])
 
-    # set service2 links for service1
+    # remove link for service3 from the list of links
     service_link = {"serviceId": service2.id, "ports": ["a.com:100"]}
     lb_service = lb_service. \
         setservicelinks(serviceLinks=[service_link])
-    _validate_remove_service_link(client, lb_service, service3, 2)
+    _validate_remove_service_link(client, lb_service, service3, 1)
 
     # try to set duplicated service links
     with pytest.raises(ApiError) as e:
@@ -614,7 +612,7 @@ def test_set_service_links(client, context):
 
     # set empty service link set
     lb_service = lb_service.setservicelinks(serviceLinks=[])
-    _validate_remove_service_link(client, lb_service, service2, 2)
+    _validate_remove_service_link(client, lb_service, service2, 1)
 
 
 def test_modify_link(client, context):
@@ -644,7 +642,6 @@ def test_modify_link(client, context):
     service_link = {"serviceId": service.id, "ports": ["b.com:100"]}
     lb_service = lb_service. \
         setservicelinks(serviceLinks=[service_link])
-    _validate_remove_service_link(client, lb_service, service, 1)
     _validate_add_service_link(client, lb_service,
                                service, ports=["b.com:100"])
 
@@ -1056,11 +1053,11 @@ def _validate_add_service_link(client, service, consumedService, ports=None):
         list_serviceConsumeMap(serviceId=service.id,
                                consumedServiceId=consumedService.id)
 
-    assert len(service_maps) > 0
+    assert len(service_maps) == 1
 
     if ports:
         for value in service_maps:
-            if (value.ports == ports):
+            if value.ports == ports:
                 service_map = value
                 break
 


### PR DESCRIPTION
1) Update the lb target instead of removing on ports change. So there is no downtime on haproxy
2) Allow linking services cross stacks
https://github.com/rancher/rancher/issues/1577
3) Generate load balancer labels in exported config
https://github.com/rancher/rancher/issues/1495
4) Put "hostname" for external service to rancher-compose - as for external service, its not a docker property like it is for the normal service where docker containers get started using this param
