### PR TITLE
Virtual IP (VIP) support for service

### DIFF
--- a/code/framework/utils/pom.xml
+++ b/code/framework/utils/pom.xml
@@ -8,5 +8,9 @@
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/code/framework/utils/src/main/java/io/cattle/platform/util/net/NetUtils.java
+++ b/code/framework/utils/src/main/java/io/cattle/platform/util/net/NetUtils.java
@@ -1,5 +1,7 @@
 package io.cattle.platform.util.net;
 
+import org.apache.commons.lang3.tuple.Pair;
+
 public class NetUtils {
 
     public static long ip2Long(String ipAddress) {
@@ -44,6 +46,24 @@ public class NetUtils {
         long end = (ip & ~mask) + (long) Math.pow(2, 32 - cidrSize) - 6;
 
         return long2Ip(end);
+    }
+
+    public static boolean isIpInSubnet(String cidr, String ipAddress) {
+        Pair<String, Integer> cidrPair = getCidrAndSize(cidr);
+        String startIp = NetUtils.getDefaultStartAddress(cidrPair.getLeft(), cidrPair.getRight());
+        long start = NetUtils.ip2Long(startIp);
+        String endIp = NetUtils.getDefaultEndAddress(cidrPair.getLeft(), cidrPair.getRight());
+        long end = NetUtils.ip2Long(endIp);
+        long ip = NetUtils.ip2Long(ipAddress);
+        if (start <= ip && ip <= end)
+            return true;
+
+        return false;
+    }
+
+    public static Pair<String, Integer> getCidrAndSize(String cidrInput) {
+        String[] cidrAndSize = cidrInput.split("/");
+        return Pair.of(cidrAndSize[0], Integer.valueOf(cidrAndSize[1]));
     }
 
 }

--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/VIPProviderNicLookup.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/VIPProviderNicLookup.java
@@ -1,0 +1,56 @@
+package io.cattle.platform.agent.instance.service.impl;
+
+import static io.cattle.platform.core.model.tables.InstanceHostMapTable.INSTANCE_HOST_MAP;
+import static io.cattle.platform.core.model.tables.InstanceTable.INSTANCE;
+import static io.cattle.platform.core.model.tables.NetworkServiceProviderInstanceMapTable.NETWORK_SERVICE_PROVIDER_INSTANCE_MAP;
+import static io.cattle.platform.core.model.tables.NetworkServiceTable.NETWORK_SERVICE;
+import static io.cattle.platform.core.model.tables.NicTable.NIC;
+import io.cattle.platform.agent.instance.service.InstanceNicLookup;
+import io.cattle.platform.core.constants.NetworkServiceConstants;
+import io.cattle.platform.core.model.InstanceHostMap;
+import io.cattle.platform.core.model.NetworkServiceProviderInstanceMap;
+import io.cattle.platform.core.model.Nic;
+import io.cattle.platform.core.model.tables.records.InstanceHostMapRecord;
+import io.cattle.platform.core.model.tables.records.NicRecord;
+import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
+
+import java.util.List;
+
+public class VIPProviderNicLookup extends AbstractJooqDao implements InstanceNicLookup {
+    @Override
+    public List<? extends Nic> getNics(Object obj) {
+        if (!(obj instanceof NetworkServiceProviderInstanceMap)) {
+            return null;
+        }
+
+        NetworkServiceProviderInstanceMap instanceMap = (NetworkServiceProviderInstanceMap) obj;
+        List<? extends InstanceHostMap> hostMaps = create()
+                .select(INSTANCE_HOST_MAP.fields())
+                .from(INSTANCE_HOST_MAP)
+                .join(NETWORK_SERVICE_PROVIDER_INSTANCE_MAP)
+                .on(NETWORK_SERVICE_PROVIDER_INSTANCE_MAP.INSTANCE_ID.eq(INSTANCE_HOST_MAP.INSTANCE_ID))
+                .join(NETWORK_SERVICE)
+                .on(NETWORK_SERVICE.NETWORK_SERVICE_PROVIDER_ID
+                        .eq(NETWORK_SERVICE_PROVIDER_INSTANCE_MAP.NETWORK_SERVICE_PROVIDER_ID))
+                .where(NETWORK_SERVICE.KIND.eq(NetworkServiceConstants.KIND_VIP)
+                        .and(NETWORK_SERVICE_PROVIDER_INSTANCE_MAP.ID.eq(instanceMap.getId())))
+                .fetchInto(InstanceHostMapRecord.class);
+
+        if (hostMaps == null || hostMaps.isEmpty()) {
+            return null;
+        }
+
+        long hostId = hostMaps.get(0).getHostId();
+        return create()
+                .select(NIC.fields())
+                .from(NIC)
+                .join(INSTANCE)
+                .on(INSTANCE.ID.eq(NIC.INSTANCE_ID))
+                .join(INSTANCE_HOST_MAP)
+                .on(INSTANCE_HOST_MAP.INSTANCE_ID.eq(INSTANCE.ID))
+                .where(INSTANCE_HOST_MAP.HOST_ID.eq(hostId)
+                        .and(NIC.REMOVED.isNull())
+                        .and(INSTANCE.REMOVED.isNull()))
+                .fetchInto(NicRecord.class);
+    }
+}

--- a/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/agent-instance-defaults.properties
+++ b/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/agent-instance-defaults.properties
@@ -6,7 +6,7 @@ agent.instance.start.items.increment=agent-instance-startup
 
 agent.instance.services.base.items=${agent.instance.start.items.apply},${agent.instance.start.items.increment}
 
-agent.instance.services.processes=nic.activate,nic.deactivate,instancelink.update,instancelink.activate,hostipaddressmap.activate,serviceexposemap.create,serviceconsumemap.create,serviceconsumemap.remove,service.activate,service.deactivate,service.update,healthcheckinstancehostmap.create
+agent.instance.services.processes=nic.activate,nic.deactivate,instancelink.update,instancelink.activate,hostipaddressmap.activate,serviceexposemap.create,serviceconsumemap.create,serviceconsumemap.remove,service.activate,service.deactivate,service.update,healthcheckinstancehostmap.create,networkserviceproviderinstancemap.activate,networkserviceproviderinstancemap.remove
 
 nic.activate.agentInstanceProvider.base.items=true
 
@@ -57,6 +57,10 @@ service.deactivate.agentInstanceProvider.dnsService.apply=hosts
 service.deactivate.agentInstanceProvider.dnsService.increment=hosts
 service.update.agentInstanceProvider.dnsService.apply=hosts
 service.update.agentInstanceProvider.dnsService.increment=hosts
+networkserviceproviderinstancemap.activate.agentInstanceProvider.dnsService.apply=hosts
+networkserviceproviderinstancemap.activate.agentInstanceProvider.dnsService.increment=hosts
+networkserviceproviderinstancemap.remove.agentInstanceProvider.dnsService.apply=hosts
+networkserviceproviderinstancemap.remove.agentInstanceProvider.dnsService.increment=hosts
 
 nic.activate.agentInstanceProvider.healthCheckService.apply=healthcheck
 nic.activate.agentInstanceProvider.healthCheckService.increment=healthcheck

--- a/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/spring-agent-instance-context.xml
+++ b/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/spring-agent-instance-context.xml
@@ -27,6 +27,7 @@
     <bean class="io.cattle.platform.agent.instance.service.impl.ServiceExposeMapCreateNicLookup" />
     <bean class="io.cattle.platform.agent.instance.service.impl.ServiceConsumeMapCreateNicLookup" />
     <bean class="io.cattle.platform.agent.instance.service.impl.ConsumedServiceNicLookup" />
+    <bean class="io.cattle.platform.agent.instance.service.impl.VIPProviderNicLookup" />
 
     <bean id="AgentInstanceTypes" class="io.cattle.platform.object.meta.TypeSet" >
         <property name="typeNames">

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/DnsInfoDao.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/DnsInfoDao.java
@@ -8,11 +8,11 @@ import java.util.List;
 public interface DnsInfoDao {
     List<DnsEntryData> getInstanceLinksHostDnsData(Instance instance);
 
-    List<DnsEntryData> getServiceHostDnsData(Instance instance);
+    List<DnsEntryData> getServiceHostDnsData(Instance instance, boolean isVIPProvider);
 
-    List<DnsEntryData> getSelfServiceLinks(Instance instance);
+    List<DnsEntryData> getSelfServiceLinks(Instance instance, boolean isVIPProvider);
 
     List<DnsEntryData> getExternalServiceDnsData(Instance instance);
 
-    List<DnsEntryData> getDnsServiceLinks(Instance instance);
+    List<DnsEntryData> getDnsServiceLinks(Instance instance, boolean isVIPProvider);
 }

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/DnsInfoFactory.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/DnsInfoFactory.java
@@ -1,12 +1,18 @@
 package io.cattle.platform.configitem.context.impl;
 
+import static io.cattle.platform.core.model.tables.InstanceHostMapTable.INSTANCE_HOST_MAP;
 import io.cattle.platform.configitem.context.dao.DnsInfoDao;
 import io.cattle.platform.configitem.context.data.DnsEntryData;
 import io.cattle.platform.configitem.server.model.ConfigItem;
 import io.cattle.platform.configitem.server.model.impl.ArchiveContext;
+import io.cattle.platform.core.constants.NetworkServiceConstants;
+import io.cattle.platform.core.dao.NetworkDao;
 import io.cattle.platform.core.model.Agent;
 import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.InstanceHostMap;
+import io.cattle.platform.core.model.Nic;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -22,21 +28,23 @@ import com.google.common.collect.Lists;
 public class DnsInfoFactory extends AbstractAgentBaseContextFactory {
     @Inject
     DnsInfoDao dnsInfoDao;
+    @Inject
+    NetworkDao networkDao;
 
     @Override
     protected void populateContext(Agent agent, Instance instance, ConfigItem item, ArchiveContext context) {
+        boolean isVIPProviderConfigured = isVIPProviderConfigured(instance);
+        List<DnsEntryData> dnsEntries = new ArrayList<DnsEntryData>();
         // 1. retrieve all instance links for the hosts
-        List<DnsEntryData> dnsEntries = dnsInfoDao.getInstanceLinksHostDnsData(instance);
+        dnsEntries.addAll(dnsInfoDao.getInstanceLinksHostDnsData(instance));
         // 2. retrieve all service links for the host
-        dnsEntries.addAll(dnsInfoDao.getServiceHostDnsData(instance));
+        dnsEntries.addAll(dnsInfoDao.getServiceHostDnsData(instance, isVIPProviderConfigured));
         // 3. retrieve self service links
-        dnsEntries.addAll(dnsInfoDao.getSelfServiceLinks(instance));
-
+        dnsEntries.addAll(dnsInfoDao.getSelfServiceLinks(instance, isVIPProviderConfigured));
         // 4. retrieve external service links
         dnsEntries.addAll(dnsInfoDao.getExternalServiceDnsData(instance));
-
         // 5. get dns service links
-        dnsEntries.addAll(dnsInfoDao.getDnsServiceLinks(instance));
+        dnsEntries.addAll(dnsInfoDao.getDnsServiceLinks(instance, isVIPProviderConfigured));
 
         // 6. aggregate the links based on the source ip address
         Map<String, DnsEntryData> processedDnsEntries = new HashMap<>();
@@ -76,5 +84,18 @@ public class DnsInfoFactory extends AbstractAgentBaseContextFactory {
             }
             newData.setResolveCname(resolveCname);
         }
+    }
+
+    protected boolean isVIPProviderConfigured(Instance instance) {
+        Nic primaryNic = networkDao.getPrimaryNic(instance.getId());
+        if (primaryNic == null) {
+            return false;
+        }
+        List<? extends InstanceHostMap> hostMaps = objectManager.find(InstanceHostMap.class,
+                INSTANCE_HOST_MAP.INSTANCE_ID,
+                instance.getId());
+
+        return networkDao.getServiceProviderInstanceOnHost(NetworkServiceConstants.KIND_VIP,
+                hostMaps.get(0).getHostId()) != null;
     }
 }

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceRemoveDeregisterNspProviders.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceRemoveDeregisterNspProviders.java
@@ -1,0 +1,49 @@
+package io.cattle.platform.process.instance;
+
+import io.cattle.platform.core.constants.InstanceConstants;
+import io.cattle.platform.core.dao.NetworkDao;
+import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.NetworkServiceProviderInstanceMap;
+import io.cattle.platform.engine.handler.HandlerResult;
+import io.cattle.platform.engine.handler.ProcessPreListener;
+import io.cattle.platform.engine.process.ProcessInstance;
+import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.json.JsonMapper;
+import io.cattle.platform.process.common.handler.AbstractObjectProcessLogic;
+import io.cattle.platform.util.type.Priority;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named
+public class InstanceRemoveDeregisterNspProviders extends AbstractObjectProcessLogic implements ProcessPreListener,
+        Priority {
+    @Inject
+    NetworkDao ntwkDao;
+    @Inject
+    JsonMapper jsonMapper;
+
+    @Override
+    public String[] getProcessNames() {
+        return new String[] { InstanceConstants.PROCESS_REMOVE };
+    }
+
+    @Override
+    public HandlerResult handle(ProcessState state, ProcessInstance process) {
+        Instance instance = (Instance) state.getResource();
+        List<NetworkServiceProviderInstanceMap> maps = ntwkDao.findNspInstanceMaps(
+                instance);
+        for (NetworkServiceProviderInstanceMap map : maps) {
+            deactivateThenRemove(map, state.getData());
+        }
+        return null;
+    }
+
+    @Override
+    public int getPriority() {
+        return Priority.DEFAULT;
+    }
+
+}

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceStartRegisterAsNspProvider.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceStartRegisterAsNspProvider.java
@@ -1,0 +1,67 @@
+package io.cattle.platform.process.instance;
+
+import io.cattle.platform.core.constants.InstanceConstants;
+import io.cattle.platform.core.constants.NetworkServiceConstants;
+import io.cattle.platform.core.constants.NetworkServiceProviderConstants;
+import io.cattle.platform.core.dao.NetworkDao;
+import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.engine.handler.HandlerResult;
+import io.cattle.platform.engine.handler.ProcessPreListener;
+import io.cattle.platform.engine.process.ProcessInstance;
+import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.json.JsonMapper;
+import io.cattle.platform.object.util.DataAccessor;
+import io.cattle.platform.process.common.handler.AbstractObjectProcessLogic;
+import io.cattle.platform.util.type.Priority;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named
+public class InstanceStartRegisterAsNspProvider extends AbstractObjectProcessLogic implements ProcessPreListener, Priority {
+    @Inject
+    NetworkDao ntwkDao;
+    @Inject
+    JsonMapper jsonMapper;
+
+    @Override
+    public String[] getProcessNames() {
+        return new String[] { InstanceConstants.PROCESS_START };
+    }
+
+    @Override
+    public HandlerResult handle(ProcessState state, ProcessInstance process) {
+        Instance instance = (Instance) state.getResource();
+        List<String> services = getProvidedServices(instance);
+        if (services.isEmpty()) {
+            return null;
+        }
+        ntwkDao.registerNspInstance(NetworkServiceProviderConstants.KIND_EXTERNAL_PROVIDER, instance, services);
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected List<String> getProvidedServices(Instance instance) {
+        Map<String, String> labels = DataAccessor.fields(instance).withKey(InstanceConstants.FIELD_LABELS)
+                .withDefault(Collections.EMPTY_MAP).as(Map.class);
+        String label = labels.get(NetworkServiceConstants.LABEL_PROVIDED_SERVICES);
+
+        List<String> services = new ArrayList<>();
+        if (label != null) {
+            services.addAll(Arrays.asList(label.split(",")));
+        }
+        return services;
+    }
+
+    @Override
+    public int getPriority() {
+        return Priority.DEFAULT;
+    }
+
+}

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/NetworkConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/NetworkConstants.java
@@ -10,5 +10,6 @@ public class NetworkConstants {
 
     public static final String KIND_HOSTONLY = "hostOnlyNetwork";
     public static final String KIND_NETWORK = "network";
+    public static final String KIND_VIP_NETWORK = "vipNetwork";
 
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/NetworkServiceConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/NetworkServiceConstants.java
@@ -10,8 +10,11 @@ public class NetworkServiceConstants {
     public static final String KIND_PORT_SERVICE = "portService";
     public static final String KIND_HOST_NAT_GATEWAY = "hostNatGatewayService";
     public static final String KIND_HEALTH_CHECK = "healthCheckService";
+    public static final String KIND_VIP = "vipService";
 
     public static final String FIELD_PRIVATE_LINK = "privateLinks";
     public static final String FIELD_CONFIG_DRIVE = "configDrive";
+
+    public static final String LABEL_PROVIDED_SERVICES = "io.rancher.network.services";
 
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/NetworkServiceProviderConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/NetworkServiceProviderConstants.java
@@ -5,5 +5,5 @@ public class NetworkServiceProviderConstants {
     public static final String KIND_AGENT_INSTANCE = "agentInstanceProvider";
     public static final String FIELD_AGENT_ACCOUNT_OWNED = "agentInstanceAccountOwned";
     public static final String FIELD_AGENT_INSTANCE_IMAGE_UUID = "agentInstanceImageUuid";
-
+    public static final String KIND_EXTERNAL_PROVIDER = "externalProvider";
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/SubnetConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/SubnetConstants.java
@@ -4,5 +4,6 @@ public class SubnetConstants {
 
     public static final String KIND_IP_POOL_SUBNET = "ipPoolSubnet";
     public static final String FIELD_NETWORK_ID = "networkId";
+    public static final String KIND_VIP_SUBNET = "vipSubnet";
 
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/NetworkDao.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/NetworkDao.java
@@ -1,8 +1,12 @@
 package io.cattle.platform.core.dao;
 
+import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.Network;
 import io.cattle.platform.core.model.NetworkService;
+import io.cattle.platform.core.model.NetworkServiceProvider;
+import io.cattle.platform.core.model.NetworkServiceProviderInstanceMap;
 import io.cattle.platform.core.model.Nic;
+import io.cattle.platform.core.model.Subnet;
 
 import java.util.List;
 
@@ -17,5 +21,21 @@ public interface NetworkDao {
     List<? extends Network> getNetworksForAccount(long accountId, String kind);
 
     Network getNetworkForObject(Object object, String networkKind);
+
+    void registerNspInstance(String providerKind, Instance instance, List<String> services);
+
+    List<NetworkServiceProviderInstanceMap> findNspInstanceMaps(Instance instance);
+
+    Instance getServiceProviderInstanceOnHostForNetwork(long networkId, String serviceKind, long hostId);
+
+    Instance getServiceProviderInstanceOnHost(String serviceKind, long hostId);
+
+    Subnet addVIPSubnet(long accountId);
+
+    Subnet addManagedNetworkSubnet(Network network);
+    
+    NetworkServiceProvider createNsp(Network network, List<String> servicesKinds, String providerKind);
+
+    String getVIPSubnetCidr();
 
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/LabelsDaoImpl.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/LabelsDaoImpl.java
@@ -36,7 +36,7 @@ public class LabelsDaoImpl extends AbstractJooqDao implements LabelsDao {
                     .and(HOST_LABEL_MAP.REMOVED.isNull())
                 .fetchInto(Label.class);
     }
-
+    
     @Override
     public Label getLabelForInstance(long instanceId, String labelKey) {
         List<Label> labels = create()
@@ -49,7 +49,6 @@ public class LabelsDaoImpl extends AbstractJooqDao implements LabelsDao {
                 .and(LABEL.KEY.eq(labelKey))
                 .and(INSTANCE_LABEL_MAP.REMOVED.isNull())
                 .fetchInto(Label.class);
-
         if (labels.isEmpty()) {
             return null;
         }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/NetworkDaoImpl.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/NetworkDaoImpl.java
@@ -1,38 +1,74 @@
 package io.cattle.platform.core.dao.impl;
 
 
+
+import static io.cattle.platform.core.model.tables.InstanceHostMapTable.INSTANCE_HOST_MAP;
+import static io.cattle.platform.core.model.tables.InstanceTable.INSTANCE;
 import static io.cattle.platform.core.model.tables.NetworkServiceProviderInstanceMapTable.NETWORK_SERVICE_PROVIDER_INSTANCE_MAP;
 import static io.cattle.platform.core.model.tables.NetworkServiceProviderTable.NETWORK_SERVICE_PROVIDER;
 import static io.cattle.platform.core.model.tables.NetworkServiceTable.NETWORK_SERVICE;
 import static io.cattle.platform.core.model.tables.NetworkTable.NETWORK;
 import static io.cattle.platform.core.model.tables.NicTable.NIC;
+import static io.cattle.platform.core.model.tables.SubnetTable.SUBNET;
+import io.cattle.platform.archaius.util.ArchaiusUtil;
+import io.cattle.platform.core.constants.InstanceConstants;
 import io.cattle.platform.core.constants.NetworkServiceProviderConstants;
+import io.cattle.platform.core.constants.SubnetConstants;
 import io.cattle.platform.core.dao.AccountDao;
+import io.cattle.platform.core.dao.GenericResourceDao;
 import io.cattle.platform.core.dao.NetworkDao;
+import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.Network;
 import io.cattle.platform.core.model.NetworkService;
+import io.cattle.platform.core.model.NetworkServiceProvider;
+import io.cattle.platform.core.model.NetworkServiceProviderInstanceMap;
 import io.cattle.platform.core.model.Nic;
+import io.cattle.platform.core.model.Subnet;
+import io.cattle.platform.core.model.tables.records.InstanceRecord;
 import io.cattle.platform.core.model.tables.records.NetworkRecord;
+import io.cattle.platform.core.model.tables.records.NetworkServiceProviderRecord;
 import io.cattle.platform.core.model.tables.records.NetworkServiceRecord;
 import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
+import io.cattle.platform.lock.LockCallback;
+import io.cattle.platform.lock.LockManager;
 import io.cattle.platform.object.ObjectManager;
+import io.cattle.platform.object.process.ObjectProcessManager;
 import io.cattle.platform.object.util.DataAccessor;
 import io.cattle.platform.object.util.ObjectUtils;
+import io.cattle.platform.util.net.NetUtils;
+import io.cattle.platform.util.type.CollectionUtils;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.jooq.Condition;
 import org.jooq.impl.DSL;
 
+import com.netflix.config.DynamicStringListProperty;
+
 public class NetworkDaoImpl extends AbstractJooqDao implements NetworkDao {
+    DynamicStringListProperty DOCKER_NETWORK_SUBNET_CIDR = ArchaiusUtil.getList("docker.network.subnet.cidr");
+    DynamicStringListProperty DOCKER_VIP_SUBNET_CIDR = ArchaiusUtil.getList("docker.vip.subnet.cidr");
 
     @Inject
     ObjectManager objectManager;
 
     @Inject
     AccountDao accountDao;
+
+    @Inject
+    GenericResourceDao resourceDao;
+
+    @Inject
+    ObjectProcessManager objectProcessManager;
+
+    @Inject
+    LockManager lockManager;
 
     @Override
     public List<? extends NetworkService> getAgentInstanceNetworkService(long instanceId, String serviceKind) {
@@ -123,5 +159,196 @@ public class NetworkDaoImpl extends AbstractJooqDao implements NetworkDao {
             return null;
         }
         return systemNetworks.get(0);
+    }
+
+    @Override
+    public void registerNspInstance(String providerKind, Instance instance, List<String> services) {
+        Network network = getInstancePrimaryNetwork(instance);
+        NetworkServiceProvider provider = getNetworkServiceProviderForInstance(network, providerKind, services,
+                instance);
+        if (provider == null) {
+            // create provider on demand
+            provider = createNsp(network, services, providerKind);
+        }
+        resourceDao.createAndSchedule(NetworkServiceProviderInstanceMap.class,
+                    NETWORK_SERVICE_PROVIDER_INSTANCE_MAP.INSTANCE_ID, instance.getId(),
+                    NETWORK_SERVICE_PROVIDER_INSTANCE_MAP.NETWORK_SERVICE_PROVIDER_ID, provider.getId());
+    }
+
+    protected Network getInstancePrimaryNetwork(Instance instance) {
+        Nic primaryNic = getPrimaryNic(instance.getId());
+        return objectManager.loadResource(Network.class, primaryNic.getNetworkId());
+    }
+
+    @Override
+    public List<NetworkServiceProviderInstanceMap> findNspInstanceMaps(Instance instance) {
+        return objectManager.find(NetworkServiceProviderInstanceMap.class,
+                NETWORK_SERVICE_PROVIDER_INSTANCE_MAP.INSTANCE_ID, instance.getId(),
+                NETWORK_SERVICE_PROVIDER_INSTANCE_MAP.REMOVED, null);
+    }
+
+    protected NetworkServiceProvider getNetworkServiceProviderForInstance(Network network, String providerKind,
+            List<String> services, Instance instance) {
+        return getNetworkServiceProvider(providerKind, network.getId(), services);
+    }
+
+    protected NetworkServiceProvider getNetworkServiceProvider(String providerKind, long networkId,
+            List<String> services) {
+        List<? extends NetworkServiceProvider> providers = create()
+                .select(NETWORK_SERVICE_PROVIDER.fields())
+                .from(NETWORK_SERVICE_PROVIDER)
+                .join(NETWORK_SERVICE)
+                .on(NETWORK_SERVICE_PROVIDER.ID.eq(NETWORK_SERVICE.NETWORK_SERVICE_PROVIDER_ID))
+                .where(NETWORK_SERVICE.NETWORK_ID.eq(networkId)
+                        .and(NETWORK_SERVICE.KIND.in(services))
+                        .and(NETWORK_SERVICE_PROVIDER.KIND.eq(providerKind)))
+                .fetchInto(NetworkServiceProviderRecord.class);
+        
+        return providers.isEmpty() ? null : providers.get(0);
+    }
+
+    @Override
+    public Instance getServiceProviderInstanceOnHostForNetwork(long networkId, String serviceKind, long hostId) {
+        List<? extends Instance> instances = create()
+                .select(INSTANCE.fields())
+                .from(INSTANCE)
+                .join(NETWORK_SERVICE_PROVIDER_INSTANCE_MAP)
+                .on(NETWORK_SERVICE_PROVIDER_INSTANCE_MAP.INSTANCE_ID.eq(INSTANCE.ID))
+                .join(NETWORK_SERVICE)
+                .on(NETWORK_SERVICE.NETWORK_SERVICE_PROVIDER_ID
+                        .eq(NETWORK_SERVICE_PROVIDER_INSTANCE_MAP.NETWORK_SERVICE_PROVIDER_ID))
+                .join(INSTANCE_HOST_MAP)
+                .on(INSTANCE_HOST_MAP.INSTANCE_ID.eq(INSTANCE.ID))
+                .where(NETWORK_SERVICE.NETWORK_ID.eq(networkId)
+                        .and(NETWORK_SERVICE.KIND.eq(serviceKind))
+                        .and(INSTANCE_HOST_MAP.HOST_ID.eq(hostId))
+                        .and(INSTANCE.STATE.in(InstanceConstants.STATE_STARTING, InstanceConstants.STATE_RESTARTING,
+                                InstanceConstants.STATE_RUNNING))
+                        .and(NETWORK_SERVICE_PROVIDER_INSTANCE_MAP.REMOVED.isNull()))
+                .fetchInto(InstanceRecord.class);
+
+        return instances.isEmpty() ? null : instances.get(0);
+    }
+
+    @Override
+    public Subnet addManagedNetworkSubnet(Network network) {
+        List<Subnet> subnets = objectManager.children(network, Subnet.class);
+        if (subnets.size() > 0) {
+            return subnets.get(0);
+        }
+
+        Pair<String, Integer> cidr = NetUtils.getCidrAndSize(DOCKER_NETWORK_SUBNET_CIDR.get().get(0));
+
+        return resourceDao.createAndSchedule(Subnet.class,
+                SUBNET.ACCOUNT_ID, network.getAccountId(),
+                SUBNET.CIDR_SIZE, cidr.getRight(),
+                SUBNET.NETWORK_ADDRESS, cidr.getLeft(),
+                SUBNET.NETWORK_ID, network.getId());
+    }
+
+    @Override
+    public Subnet addVIPSubnet(final long accountId) {
+        return lockManager.lock(new SubnetCreateLock(accountId), new LockCallback<Subnet>() {
+            @Override
+            public Subnet doWithLock() {
+                List<Subnet> subnets = objectManager.find(Subnet.class, SUBNET.ACCOUNT_ID, accountId, SUBNET.KIND,
+                        SubnetConstants.KIND_VIP_SUBNET);
+                if (subnets.size() > 0) {
+                    return subnets.get(0);
+                }
+
+                Pair<String, Integer> cidr = NetUtils.getCidrAndSize(DOCKER_VIP_SUBNET_CIDR.get().get(0));
+
+                return resourceDao.createAndSchedule(Subnet.class,
+                        SUBNET.ACCOUNT_ID, accountId,
+                        SUBNET.CIDR_SIZE, cidr.getRight(),
+                        SUBNET.NETWORK_ADDRESS, cidr.getLeft(),
+                        SUBNET.KIND, SubnetConstants.KIND_VIP_SUBNET);
+            }
+        });
+    }
+
+
+
+    protected NetworkServiceProvider addNsp(Network network, String providerKind) {
+        List<NetworkServiceProvider> nsps = objectManager.children(network, NetworkServiceProvider.class);
+
+        for (NetworkServiceProvider nsp : nsps) {
+            if (nsp.getKind().equalsIgnoreCase(providerKind)) {
+                return nsp;
+            }
+        }
+
+        return resourceDao.createAndSchedule(NetworkServiceProvider.class,
+                NETWORK_SERVICE_PROVIDER.ACCOUNT_ID, network.getAccountId(),
+                NETWORK_SERVICE_PROVIDER.KIND, providerKind,
+                NETWORK_SERVICE_PROVIDER.NETWORK_ID, network.getId());
+    }
+
+    protected void addService(Map<String, NetworkService> services, NetworkServiceProvider nsp, String kind,
+            Object... keyValue) {
+        if (services.containsKey(kind)) {
+            return;
+        }
+
+        Map<Object, Object> data = new HashMap<>();
+        if (keyValue != null && keyValue.length > 1) {
+            data = CollectionUtils.asMap(keyValue[0], ArrayUtils.subarray(keyValue, 1, keyValue.length));
+        }
+
+        data.put(NETWORK_SERVICE.KIND, kind);
+        data.put(NETWORK_SERVICE.ACCOUNT_ID, nsp.getAccountId());
+        data.put(NETWORK_SERVICE.NETWORK_ID, nsp.getNetworkId());
+        data.put(NETWORK_SERVICE.NETWORK_SERVICE_PROVIDER_ID, nsp.getId());
+
+        resourceDao.createAndSchedule(NetworkService.class,
+                objectManager.convertToPropertiesFor(NetworkService.class, data));
+    }
+
+    @Override
+    public NetworkServiceProvider createNsp(Network network, List<String> servicesKinds, String providerKind) {
+        NetworkServiceProvider nsp = addNsp(network, providerKind);
+        Map<String, NetworkService> initialServices = collectionNetworkServices(network);
+        for (String serviceKind : servicesKinds) {
+            addService(initialServices, nsp, serviceKind);
+        }
+        return nsp;
+    }
+
+    protected Map<String, NetworkService> collectionNetworkServices(Network network) {
+        Map<String, NetworkService> services = new HashMap<>();
+
+        for (NetworkService service : objectManager.children(network, NetworkService.class)) {
+            services.put(service.getKind(), service);
+        }
+
+        return services;
+    }
+
+    @Override
+    public Instance getServiceProviderInstanceOnHost(String serviceKind, long hostId) {
+        List<? extends Instance> instances = create()
+                .select(INSTANCE.fields())
+                .from(INSTANCE)
+                .join(NETWORK_SERVICE_PROVIDER_INSTANCE_MAP)
+                .on(NETWORK_SERVICE_PROVIDER_INSTANCE_MAP.INSTANCE_ID.eq(INSTANCE.ID))
+                .join(NETWORK_SERVICE)
+                .on(NETWORK_SERVICE.NETWORK_SERVICE_PROVIDER_ID
+                        .eq(NETWORK_SERVICE_PROVIDER_INSTANCE_MAP.NETWORK_SERVICE_PROVIDER_ID))
+                .join(INSTANCE_HOST_MAP)
+                .on(INSTANCE_HOST_MAP.INSTANCE_ID.eq(INSTANCE.ID))
+                .where(NETWORK_SERVICE.KIND.eq(serviceKind)
+                        .and(INSTANCE_HOST_MAP.HOST_ID.eq(hostId))
+                        .and(INSTANCE.STATE.in(InstanceConstants.STATE_STARTING, InstanceConstants.STATE_RESTARTING,
+                                InstanceConstants.STATE_RUNNING))
+                        .and(NETWORK_SERVICE_PROVIDER_INSTANCE_MAP.REMOVED.isNull()))
+                .fetchInto(InstanceRecord.class);
+
+        return instances.isEmpty() ? null : instances.get(0);
+    }
+
+    @Override
+    public String getVIPSubnetCidr() {
+        return DOCKER_VIP_SUBNET_CIDR.get().get(0);
     }
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/SubnetCreateLock.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/SubnetCreateLock.java
@@ -1,0 +1,10 @@
+package io.cattle.platform.core.dao.impl;
+
+import io.cattle.platform.lock.definition.AbstractBlockingLockDefintion;
+
+public class SubnetCreateLock extends AbstractBlockingLockDefintion {
+
+    public SubnetCreateLock(long accountId) {
+        super("SUBNET.CREATE." + accountId);
+    }
+}

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/Service.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/Service.java
@@ -146,6 +146,17 @@ public interface Service extends java.io.Serializable {
 	@javax.persistence.Column(name = "environment_id", precision = 19)
 	public java.lang.Long getEnvironmentId();
 
+	/**
+	 * Setter for <code>cattle.service.vip</code>.
+	 */
+	public void setVip(java.lang.String value);
+
+	/**
+	 * Getter for <code>cattle.service.vip</code>.
+	 */
+	@javax.persistence.Column(name = "vip", length = 255)
+	public java.lang.String getVip();
+
 	// -------------------------------------------------------------------------
 	// FROM and INTO
 	// -------------------------------------------------------------------------

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/ServiceExposeMapTable.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/ServiceExposeMapTable.java
@@ -11,7 +11,7 @@ package io.cattle.platform.core.model.tables;
 @java.lang.SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class ServiceExposeMapTable extends org.jooq.impl.TableImpl<io.cattle.platform.core.model.tables.records.ServiceExposeMapRecord> {
 
-	private static final long serialVersionUID = -1228776039;
+	private static final long serialVersionUID = -2039587769;
 
 	/**
 	 * The singleton instance of <code>cattle.service_expose_map</code>

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/ServiceTable.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/ServiceTable.java
@@ -11,7 +11,7 @@ package io.cattle.platform.core.model.tables;
 @java.lang.SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class ServiceTable extends org.jooq.impl.TableImpl<io.cattle.platform.core.model.tables.records.ServiceRecord> {
 
-	private static final long serialVersionUID = -2109411108;
+	private static final long serialVersionUID = 1432198915;
 
 	/**
 	 * The singleton instance of <code>cattle.service</code>
@@ -85,6 +85,11 @@ public class ServiceTable extends org.jooq.impl.TableImpl<io.cattle.platform.cor
 	 * The column <code>cattle.service.environment_id</code>.
 	 */
 	public final org.jooq.TableField<io.cattle.platform.core.model.tables.records.ServiceRecord, java.lang.Long> ENVIRONMENT_ID = createField("environment_id", org.jooq.impl.SQLDataType.BIGINT, this, "");
+
+	/**
+	 * The column <code>cattle.service.vip</code>.
+	 */
+	public final org.jooq.TableField<io.cattle.platform.core.model.tables.records.ServiceRecord, java.lang.String> VIP = createField("vip", org.jooq.impl.SQLDataType.VARCHAR.length(255), this, "");
 
 	/**
 	 * Create a <code>cattle.service</code> table reference

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/records/ServiceExposeMapRecord.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/records/ServiceExposeMapRecord.java
@@ -13,7 +13,7 @@ package io.cattle.platform.core.model.tables.records;
 @javax.persistence.Table(name = "service_expose_map", schema = "cattle")
 public class ServiceExposeMapRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.platform.core.model.tables.records.ServiceExposeMapRecord> implements io.cattle.platform.db.jooq.utils.TableRecordJaxb, org.jooq.Record16<java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.Long, java.lang.Long, java.lang.String, java.lang.String, java.lang.String>, io.cattle.platform.core.model.ServiceExposeMap {
 
-	private static final long serialVersionUID = -231406703;
+	private static final long serialVersionUID = 1661673531;
 
 	/**
 	 * Setter for <code>cattle.service_expose_map.id</code>.

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/records/ServiceRecord.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/records/ServiceRecord.java
@@ -11,9 +11,9 @@ package io.cattle.platform.core.model.tables.records;
 @java.lang.SuppressWarnings({ "all", "unchecked", "rawtypes" })
 @javax.persistence.Entity
 @javax.persistence.Table(name = "service", schema = "cattle")
-public class ServiceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.platform.core.model.tables.records.ServiceRecord> implements io.cattle.platform.db.jooq.utils.TableRecordJaxb, org.jooq.Record12<java.lang.Long, java.lang.String, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long>, io.cattle.platform.core.model.Service {
+public class ServiceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.platform.core.model.tables.records.ServiceRecord> implements io.cattle.platform.db.jooq.utils.TableRecordJaxb, org.jooq.Record13<java.lang.Long, java.lang.String, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.String>, io.cattle.platform.core.model.Service {
 
-	private static final long serialVersionUID = 1168884007;
+	private static final long serialVersionUID = -1337172202;
 
 	/**
 	 * Setter for <code>cattle.service.id</code>.
@@ -220,6 +220,23 @@ public class ServiceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.p
 		return (java.lang.Long) getValue(11);
 	}
 
+	/**
+	 * Setter for <code>cattle.service.vip</code>.
+	 */
+	@Override
+	public void setVip(java.lang.String value) {
+		setValue(12, value);
+	}
+
+	/**
+	 * Getter for <code>cattle.service.vip</code>.
+	 */
+	@javax.persistence.Column(name = "vip", length = 255)
+	@Override
+	public java.lang.String getVip() {
+		return (java.lang.String) getValue(12);
+	}
+
 	// -------------------------------------------------------------------------
 	// Primary key information
 	// -------------------------------------------------------------------------
@@ -233,23 +250,23 @@ public class ServiceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.p
 	}
 
 	// -------------------------------------------------------------------------
-	// Record12 type implementation
+	// Record13 type implementation
 	// -------------------------------------------------------------------------
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-	public org.jooq.Row12<java.lang.Long, java.lang.String, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long> fieldsRow() {
-		return (org.jooq.Row12) super.fieldsRow();
+	public org.jooq.Row13<java.lang.Long, java.lang.String, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.String> fieldsRow() {
+		return (org.jooq.Row13) super.fieldsRow();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-	public org.jooq.Row12<java.lang.Long, java.lang.String, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long> valuesRow() {
-		return (org.jooq.Row12) super.valuesRow();
+	public org.jooq.Row13<java.lang.Long, java.lang.String, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.String> valuesRow() {
+		return (org.jooq.Row13) super.valuesRow();
 	}
 
 	/**
@@ -352,6 +369,14 @@ public class ServiceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.p
 	 * {@inheritDoc}
 	 */
 	@Override
+	public org.jooq.Field<java.lang.String> field13() {
+		return io.cattle.platform.core.model.tables.ServiceTable.SERVICE.VIP;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	public java.lang.Long value1() {
 		return getId();
 	}
@@ -442,6 +467,14 @@ public class ServiceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.p
 	@Override
 	public java.lang.Long value12() {
 		return getEnvironmentId();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public java.lang.String value13() {
+		return getVip();
 	}
 
 	/**
@@ -556,7 +589,16 @@ public class ServiceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.p
 	 * {@inheritDoc}
 	 */
 	@Override
-	public ServiceRecord values(java.lang.Long value1, java.lang.String value2, java.lang.Long value3, java.lang.String value4, java.lang.String value5, java.lang.String value6, java.lang.String value7, java.util.Date value8, java.util.Date value9, java.util.Date value10, java.util.Map<String,Object> value11, java.lang.Long value12) {
+	public ServiceRecord value13(java.lang.String value) {
+		setVip(value);
+		return this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public ServiceRecord values(java.lang.Long value1, java.lang.String value2, java.lang.Long value3, java.lang.String value4, java.lang.String value5, java.lang.String value6, java.lang.String value7, java.util.Date value8, java.util.Date value9, java.util.Date value10, java.util.Map<String,Object> value11, java.lang.Long value12, java.lang.String value13) {
 		return this;
 	}
 
@@ -581,6 +623,7 @@ public class ServiceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.p
 		setRemoveTime(from.getRemoveTime());
 		setData(from.getData());
 		setEnvironmentId(from.getEnvironmentId());
+		setVip(from.getVip());
 	}
 
 	/**
@@ -606,7 +649,7 @@ public class ServiceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.p
 	/**
 	 * Create a detached, initialised ServiceRecord
 	 */
-	public ServiceRecord(java.lang.Long id, java.lang.String name, java.lang.Long accountId, java.lang.String kind, java.lang.String uuid, java.lang.String description, java.lang.String state, java.util.Date created, java.util.Date removed, java.util.Date removeTime, java.util.Map<String,Object> data, java.lang.Long environmentId) {
+	public ServiceRecord(java.lang.Long id, java.lang.String name, java.lang.Long accountId, java.lang.String kind, java.lang.String uuid, java.lang.String description, java.lang.String state, java.util.Date created, java.util.Date removed, java.util.Date removeTime, java.util.Map<String,Object> data, java.lang.Long environmentId, java.lang.String vip) {
 		super(io.cattle.platform.core.model.tables.ServiceTable.SERVICE);
 
 		setValue(0, id);
@@ -621,5 +664,6 @@ public class ServiceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.p
 		setValue(9, removeTime);
 		setValue(10, data);
 		setValue(11, environmentId);
+		setValue(12, vip);
 	}
 }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
@@ -26,6 +26,7 @@ public class ServiceDiscoveryConstants {
     public static final String FIELD_WAIT_FOR_CONSUMED_SERVICES_IDS = "waitForConsumedServicesIds";
     public static final String FIELD_SERVICE_LINK = "serviceLink";
     public static final String FIELD_HOSTNAME = "hostname";
+    public static final String FIELD_VIP = "vip";
 
     public static final String ACTION_SERVICE_ACTIVATE = "activate";
     public static final String ACTION_SERVICE_CREATE = "create";

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceCreate.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceCreate.java
@@ -1,5 +1,6 @@
 package io.cattle.platform.servicediscovery.process;
 
+import io.cattle.platform.core.dao.NetworkDao;
 import io.cattle.platform.core.model.Service;
 import io.cattle.platform.engine.handler.HandlerResult;
 import io.cattle.platform.engine.process.ProcessInstance;
@@ -18,6 +19,9 @@ public class ServiceCreate extends AbstractObjectProcessHandler {
     @Inject
     ServiceDiscoveryService sdService;
 
+    @Inject
+    NetworkDao ntwkDao;
+
     @Override
     public String[] getProcessNames() {
         return new String[] { ServiceDiscoveryConstants.PROCESS_SERVICE_CREATE };
@@ -29,7 +33,8 @@ public class ServiceCreate extends AbstractObjectProcessHandler {
         if (service.getKind().equalsIgnoreCase(KIND.LOADBALANCERSERVICE.name())) {
             sdService.createLoadBalancerService(service);
         }
-
+        
+        sdService.setVIP(service);
         return null;
     }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceRemove.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceRemove.java
@@ -38,6 +38,8 @@ public class ServiceRemove extends AbstractObjectProcessHandler {
             sdService.cleanupLoadBalancerService(service);
         }
 
+        sdService.releaseVip(service);
+
         return null;
     }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
@@ -21,4 +21,8 @@ public interface ServiceDiscoveryService {
 
     void cloneConsumingServices(Service fromService, Service toService);
 
+    void setVIP(Service service);
+
+    void releaseVip(Service service);
+
 }

--- a/code/implementation/docker/compute/src/main/resources/META-INF/cattle/docker-compute/defaults.properties
+++ b/code/implementation/docker/compute/src/main/resources/META-INF/cattle/docker-compute/defaults.properties
@@ -1,2 +1,4 @@
 docker.compute.auto.add.host.ip=true
 docker.network.create.account.types=project
+docker.network.subnet.cidr=10.42.0.0/16
+docker.vip.subnet.cidr=169.254.64.0/18

--- a/resources/content/db/changelog.xml
+++ b/resources/content/db/changelog.xml
@@ -60,4 +60,5 @@
     <include file="db/core-053.xml"/>
     <include file="db/core-054.xml"/>
     <include file="db/core-055.xml"/>
+    <include file="db/core-056.xml"/>
 </databaseChangeLog>

--- a/resources/content/db/core-056.xml
+++ b/resources/content/db/core-056.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+    <property name="mediumtext" value="TEXT" dbms="postgresql" />
+    <property name="mediumtext" value="MEDIUMTEXT" />
+    <changeSet author="alena (generated)" id="dump1">
+        <addColumn tableName="service">
+            <column name="vip" type="VARCHAR(255)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -371,6 +371,7 @@
         "service.launchConfig" : "cr",
         "service.upgrade" : "r",
         "service.secondaryLaunchConfigs" : "cr",
+        "service.vip" : "cr",
 
         "addRemoveServiceLinkInput" : "r",
         "addRemoveServiceLinkInput.serviceLink" : "cr",
@@ -426,11 +427,13 @@
         "externalService.scale" : "",
         "externalService.secondaryLaunchConfigs" : "",
         "externalService.hostname" : "cru",
+        "externalService.vip" : "",
 
         "dnsService" : "r",
         "dnsService.launchConfig" : "",
         "dnsService.scale" : "",
         "dnsService.secondaryLaunchConfigs" : "",
+        "dnsService.vip" : "",
 
         "serviceEvent" : "r",
         "serviceEvent.instanceId" : "r",

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -1436,7 +1436,8 @@ def test_svc_discovery_service(admin_user_client, user_client, project_client):
         'accountId': 'r',
         'data': 'r',
         'upgrade': 'r',
-        'secondaryLaunchConfigs': 'r'
+        'secondaryLaunchConfigs': 'r',
+        'vip': 'r'
     })
 
     auth_check(user_client.schema, 'service', 'r', {
@@ -1446,7 +1447,8 @@ def test_svc_discovery_service(admin_user_client, user_client, project_client):
         'launchConfig': 'r',
         'accountId': 'r',
         'upgrade': 'r',
-        'secondaryLaunchConfigs': 'r'
+        'secondaryLaunchConfigs': 'r',
+        'vip': 'r'
     })
 
     auth_check(project_client.schema, 'service', 'crud', {
@@ -1456,7 +1458,8 @@ def test_svc_discovery_service(admin_user_client, user_client, project_client):
         'launchConfig': 'cr',
         'accountId': 'r',
         'upgrade': 'r',
-        'secondaryLaunchConfigs': 'cr'
+        'secondaryLaunchConfigs': 'cr',
+        'vip': 'cr'
     })
 
 
@@ -1490,6 +1493,7 @@ def test_svc_discovery_lb_service(admin_user_client, user_client,
         'data': 'r',
         'upgrade': 'r',
         'loadBalancerConfig': 'r',
+        'vip': 'r'
     })
 
     auth_check(user_client.schema, 'loadBalancerService', 'r', {
@@ -1500,6 +1504,7 @@ def test_svc_discovery_lb_service(admin_user_client, user_client,
         'accountId': 'r',
         'upgrade': 'r',
         'loadBalancerConfig': 'r',
+        'vip': 'r'
     })
 
     auth_check(project_client.schema, 'loadBalancerService', 'crud', {
@@ -1510,6 +1515,7 @@ def test_svc_discovery_lb_service(admin_user_client, user_client,
         'accountId': 'r',
         'upgrade': 'r',
         'loadBalancerConfig': 'cr',
+        'vip': 'cr'
     })
 
 

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -6,3 +6,4 @@ flake8
 pytest==2.7.1
 pytest-xdist
 pyyaml
+netaddr


### PR DESCRIPTION
Feature flow:

1) Every service/loadBalancer service gets a VIP (Virtual IP) from the Link Local ip range (configurable)
2) On DNS update, we check if the host provides VIP service (internally we look up the VIP provider on the host). If there is not, DNS is configured the usual way. If there is, DNS is configured with the <serviceName> : <serviceVIP> A record.
3) In order for container to be registered as VIP service provider in cattle, it has to be configured with the label:

"io.rancher.network.services=vipService"

For services instances, the label has to be put on the service defined in *compose.yml file.

Each VIP provider can have its own way of implementing VIP service; the implementation details are unknown to Rancher.

@ibuildthecloud label supports specifying list of services. So in the future we can specify more than just a VIP if we decide to delegate more services to the external provider. 
