### PR TITLE
Fix websocket-proxy URL creation for HA mode

### DIFF
--- a/code/implementation/host-api/src/main/java/io/cattle/platform/host/api/HostApiProxyTokenManager.java
+++ b/code/implementation/host-api/src/main/java/io/cattle/platform/host/api/HostApiProxyTokenManager.java
@@ -62,7 +62,7 @@ public class HostApiProxyTokenManager extends AbstractNoOpResourceManager {
             break;
 
         case HOST_API_PROXY_MODE_HA:
-            String scheme = StringUtils.equalsIgnoreCase("https", request.getServletContext().getRequest().getScheme()) ? "wss://" : "ws://";
+            String scheme = StringUtils.startsWithIgnoreCase(request.getResponseUrlBase(), "https") ? "wss://" : "ws://";
             buffer.append(scheme).append(HostApiUtils.HOST_API_PROXY_HOST.get());
             break;
 

--- a/code/implementation/host-api/src/main/java/io/cattle/platform/host/service/impl/HostApiServiceImpl.java
+++ b/code/implementation/host-api/src/main/java/io/cattle/platform/host/service/impl/HostApiServiceImpl.java
@@ -69,7 +69,7 @@ public class HostApiServiceImpl implements HostApiService {
             // TODO Implement HA-aware proxy lookup
             String proxyHost = HostApiUtils.HOST_API_PROXY_HOST.get();
             if (StringUtils.isNotBlank(proxyHost)) {
-                String scheme = StringUtils.equalsIgnoreCase("https", request.getServletContext().getRequest().getScheme()) ? "wss://" : "ws://";
+                String scheme = StringUtils.startsWithIgnoreCase(request.getResponseUrlBase(), "https") ? "wss://" : "ws://";
                 buffer.append(scheme).append(proxyHost);
             }
             break;


### PR DESCRIPTION
Base the protocol off of the official responseUrlBase, not the url of
the incoming request.