### PR TITLE
Up the mysql max connection pool.

### DIFF
--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -24,6 +24,7 @@ install_build_tools
 
 if [ "${CATTLE_DB_CATTLE_DATABASE}" == "mysql" ]; then
     sed -i "0,/3306/! {0,/3306/ s/3306/${CATTLE_DB_CATTLE_MYSQL_PORT}/}" /etc/mysql/my.cnf
+    sed -i 's/^#\(max_connections.*\)/\1/;s/100/1000/' /etc/mysql/my.cnf
     service mysql start
 
     set +e


### PR DESCRIPTION
When running in build master or local contexts you can run out of SQL connections. This mimics rancher/server setting.