### PR TITLE
Sidekick fixes

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/addon/RestartPolicy.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/addon/RestartPolicy.java
@@ -5,6 +5,9 @@ import io.github.ibuildthecloud.gdapi.annotation.Type;
 @Type(list = false)
 public class RestartPolicy {
 
+    public static String RESTART_NEVER = "no";
+    public static String RESTART_ALWAYS = "always";
+
     String name;
     int maximumRetryCount;
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/AbstractInstanceUnit.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/AbstractInstanceUnit.java
@@ -57,4 +57,13 @@ public abstract class AbstractInstanceUnit extends DeploymentUnitInstance implem
             });
         }
     }
+
+    @Override
+    public DeploymentUnitInstance startImpl() {
+        if (InstanceConstants.STATE_STOPPED.equals(instance.getState())) {
+            context.objectProcessManager.scheduleProcessInstanceAsync(
+                    InstanceConstants.PROCESS_START, instance, null);
+        }
+        return this;
+    }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
@@ -1,10 +1,13 @@
 package io.cattle.platform.servicediscovery.deployment;
 
+import io.cattle.platform.core.addon.RestartPolicy;
 import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.model.Service;
 import io.cattle.platform.core.model.ServiceExposeMap;
+import io.cattle.platform.docker.constants.DockerInstanceConstants;
 import io.cattle.platform.object.process.StandardProcess;
 import io.cattle.platform.object.resource.ResourcePredicate;
+import io.cattle.platform.servicediscovery.api.util.ServiceDiscoveryUtil;
 import io.cattle.platform.servicediscovery.deployment.impl.DeploymentManagerImpl.DeploymentServiceContext;
 
 import java.util.Map;
@@ -21,6 +24,8 @@ public abstract class DeploymentUnitInstance {
     protected ServiceExposeMap exposeMap;
     protected String launchConfigName;
     protected Service service;
+    protected boolean autoRestart = true;
+    protected boolean firstStart = true;
 
     public abstract boolean isError();
 
@@ -42,21 +47,60 @@ public abstract class DeploymentUnitInstance {
 
     public abstract void stop();
 
+    @SuppressWarnings("unchecked")
     protected DeploymentUnitInstance(DeploymentServiceContext context, String uuid, Service service,
             String launchConfigName) {
         this.context = context;
         this.uuid = uuid;
         this.launchConfigName = launchConfigName;
         this.service = service;
+        Object policy = ServiceDiscoveryUtil.getLaunchConfigObject(service, launchConfigName,
+                DockerInstanceConstants.FIELD_RESTART_POLICY);
+
+        if (policy != null && ((Map<String, String>) policy).get("name").equalsIgnoreCase(RestartPolicy.RESTART_NEVER)) {
+            autoRestart = false;
+        }
     }
 
-    public abstract DeploymentUnitInstance start(Map<String, Object> deployParams);
+    public DeploymentUnitInstance createAndStart(Map<String, Object> deployParams) {
+        if (!this.createNew()) {
+            firstStart = false;
+        }
+        this.create(deployParams);
+        this.start();
+        return this;
+    }
+
+    protected abstract DeploymentUnitInstance create(Map<String, Object> deployParams);
+
+    protected DeploymentUnitInstance start() {
+        if (this.isStarted()) {
+            return this;
+        }
+        return this.startImpl();
+    }
+
+    protected abstract DeploymentUnitInstance startImpl();
 
     public abstract boolean createNew();
 
-    public abstract DeploymentUnitInstance waitForStart();
+    public DeploymentUnitInstance waitForStart() {
+        if (this.isStarted()) {
+            return this;
+        }
+        return this.waitForStartImpl();
+    }
 
-    public abstract boolean isStarted();
+    protected abstract DeploymentUnitInstance waitForStartImpl();
+
+    public boolean isStarted() {
+        if (!firstStart && !autoRestart) {
+            return true;
+        }
+        return isStartedImpl();
+    }
+
+    protected abstract boolean isStartedImpl();
 
     public abstract boolean isUnhealthy();
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
@@ -12,6 +12,8 @@ import io.cattle.platform.servicediscovery.deployment.impl.DeploymentManagerImpl
 
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
+
 /**
  * TODO: Since the majority of the system references DeploymentUnitInstance and not InstanceUnit
  * and majority of the functions in DeploymentUnitInstance are abstract, we should really just combine
@@ -57,7 +59,9 @@ public abstract class DeploymentUnitInstance {
         Object policy = ServiceDiscoveryUtil.getLaunchConfigObject(service, launchConfigName,
                 DockerInstanceConstants.FIELD_RESTART_POLICY);
 
-        if (policy != null && ((Map<String, String>) policy).get("name").equalsIgnoreCase(RestartPolicy.RESTART_NEVER)) {
+        if (policy != null
+                && StringUtils
+                        .equalsIgnoreCase(RestartPolicy.RESTART_NEVER, ((Map<String, String>) policy).get("name"))) {
             autoRestart = false;
         }
     }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/ServiceDeploymentPlanner.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/ServiceDeploymentPlanner.java
@@ -62,7 +62,7 @@ public abstract class ServiceDeploymentPlanner {
         return false;
     }
 
-    public abstract boolean needToReconcileDeploymentImpl();
+    protected abstract boolean needToReconcileDeploymentImpl();
 
     public void addUnits(List<DeploymentUnit> units) {
         this.healthyUnits.addAll(units);

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/ServiceDeploymentPlanner.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/ServiceDeploymentPlanner.java
@@ -20,6 +20,7 @@ public abstract class ServiceDeploymentPlanner {
     protected List<DeploymentUnit> healthyUnits = new ArrayList<>();
     private List<DeploymentUnit> unhealthyUnits = new ArrayList<>();
     private List<DeploymentUnit> badUnits = new ArrayList<>();
+    private List<DeploymentUnit> incompleteUnits = new ArrayList<>();
     protected DeploymentServiceContext context;
 
     public ServiceDeploymentPlanner(List<Service> services, List<DeploymentUnit> units,
@@ -37,6 +38,9 @@ public abstract class ServiceDeploymentPlanner {
                     } else {
                         healthyUnits.add(unit);
                     }
+                    if (!unit.isComplete()) {
+                        incompleteUnits.add(unit);
+                    }
                 }
             }
         }
@@ -49,7 +53,8 @@ public abstract class ServiceDeploymentPlanner {
     protected abstract List<DeploymentUnit> deployHealthyUnits();
 
     public boolean needToReconcileDeployment() {
-        return unhealthyUnits.size() > 0 || badUnits.size() > 0 || needToReconcileDeploymentImpl()
+        return unhealthyUnits.size() > 0 || badUnits.size() > 0 || incompleteUnits.size() > 0
+                || needToReconcileDeploymentImpl()
                 || ifHealthyUnitsNeedReconcile();
     }
     
@@ -78,5 +83,9 @@ public abstract class ServiceDeploymentPlanner {
 
     public List<Service> getServices() {
         return services;
+    }
+
+    public List<DeploymentUnit> getIncompleteUnits() {
+        return incompleteUnits;
     }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DefaultDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DefaultDeploymentUnitInstance.java
@@ -53,7 +53,7 @@ public class DefaultDeploymentUnitInstance extends AbstractInstanceUnit {
     }
 
     @Override
-    public DeploymentUnitInstance start(Map<String, Object> deployParams) {
+    public DeploymentUnitInstance create(Map<String, Object> deployParams) {
         if (createNew()) {
             Map<String, Object> launchConfigData = ServiceDiscoveryUtil.buildServiceInstanceLaunchData(service,
                     deployParams, launchConfigName, context.allocatorService);
@@ -74,10 +74,6 @@ public class DefaultDeploymentUnitInstance extends AbstractInstanceUnit {
                     null);
         }
 
-        if (InstanceConstants.STATE_STOPPED.equals(instance.getState())) {
-            context.objectProcessManager.scheduleProcessInstanceAsync(
-                            InstanceConstants.PROCESS_START, instance, null);
-        }
         this.instance = context.objectManager.reload(this.instance);
         return this;
     }
@@ -88,7 +84,7 @@ public class DefaultDeploymentUnitInstance extends AbstractInstanceUnit {
     }
 
     @Override
-    public DeploymentUnitInstance waitForStart() {
+    public DeploymentUnitInstance waitForStartImpl() {
         this.instance = context.resourceMonitor.waitFor(this.instance,
                 new ResourcePredicate<Instance>() {
             @Override
@@ -100,7 +96,7 @@ public class DefaultDeploymentUnitInstance extends AbstractInstanceUnit {
     }
 
     @Override
-    public boolean isStarted() {
+    protected boolean isStartedImpl() {
         return context.objectManager.reload(this.instance).getState().equalsIgnoreCase(InstanceConstants.STATE_RUNNING);
     }
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentManagerImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentManagerImpl.java
@@ -12,6 +12,7 @@ import io.cattle.platform.core.model.Service;
 import io.cattle.platform.engine.idempotent.IdempotentRetryException;
 import io.cattle.platform.eventing.EventService;
 import io.cattle.platform.eventing.model.EventVO;
+import io.cattle.platform.json.JsonMapper;
 import io.cattle.platform.lb.instance.service.LoadBalancerInstanceManager;
 import io.cattle.platform.lock.LockCallback;
 import io.cattle.platform.lock.LockCallbackNoReturn;
@@ -36,6 +37,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import javax.inject.Inject;
 
 public class DeploymentManagerImpl implements DeploymentManager {
@@ -68,6 +70,8 @@ public class DeploymentManagerImpl implements DeploymentManager {
     ConfigItemStatusManager itemManager;
     @Inject
     EventService eventService;
+    @Inject
+    JsonMapper mapper;
 
     @Override
     public boolean isHealthy(Service service) {
@@ -311,5 +315,6 @@ public class DeploymentManagerImpl implements DeploymentManager {
         final public LoadBalancerService lbService = lbSvc;
         final public DeploymentUnitInstanceFactory deploymentUnitInstanceFactory = unitInstanceFactory;
         final public AllocatorService allocatorService = allocatorSvc;
+        final public JsonMapper jsonMapper = mapper;
     }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentManagerImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentManagerImpl.java
@@ -179,6 +179,11 @@ public class DeploymentManagerImpl implements DeploymentManager {
         deleteBadUnits(planner);
 
         /*
+         * Cleanup incomplete units
+         */
+        cleanupIncompleteUnits(planner);
+
+        /*
          * Activate all the units
          */
         startUnits(planner);
@@ -233,6 +238,14 @@ public class DeploymentManagerImpl implements DeploymentManager {
 
         for (DeploymentUnit badUnit : badUnits) {
             badUnit.remove();
+        }
+    }
+
+    protected void cleanupIncompleteUnits(ServiceDeploymentPlanner planner) {
+        List<DeploymentUnit> incompleteUnits = planner.getIncompleteUnits();
+
+        for (DeploymentUnit incompleteUnit : incompleteUnits) {
+            incompleteUnit.cleanupUnit();
         }
     }
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnit.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnit.java
@@ -186,7 +186,7 @@ public class DeploymentUnit {
         Integer networkContainerId = getNetworkContainerId(launchConfigName, service);
         getDeploymentUnitInstance(service, launchConfigName).waitForNotTransitioning();
         getDeploymentUnitInstance(service, launchConfigName)
-                .start(
+                .createAndStart(
                         populateDeployParams(getDeploymentUnitInstance(service, launchConfigName),
                                 volumesFromInstanceIds,
                                 networkContainerId));
@@ -219,7 +219,7 @@ public class DeploymentUnit {
                         volumesFromUnitInstance = createInstance(volumesFromUnitInstance.getLaunchConfigName(), service);
                     }
                     // wait for start
-                    volumesFromUnitInstance.start(new HashMap<String, Object>());
+                    volumesFromUnitInstance.createAndStart(new HashMap<String, Object>());
                     volumesFromUnitInstance.waitForStart();
                     volumesFromInstanceIds.add(((InstanceUnit) volumesFromUnitInstance).getInstance().getId()
                             .intValue());
@@ -256,7 +256,7 @@ public class DeploymentUnit {
                     networkFromUnitInstance = createInstance(networkFromUnitInstance.getLaunchConfigName(), service);
                 }
                 // wait for start
-                networkFromUnitInstance.start(new HashMap<String, Object>());
+                networkFromUnitInstance.createAndStart(new HashMap<String, Object>());
                 networkFromUnitInstance.waitForStart();
                 networkContainerId = ((InstanceUnit) networkFromUnitInstance).getInstance().getId().intValue();
             }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnitService.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnitService.java
@@ -17,6 +17,7 @@ public class DeploymentUnitService {
     Service service;
     Map<String, DeploymentUnitInstance> launchConfigToInstance = new HashMap<>();
     List<String> launchConfigNames = new ArrayList<>();
+    Map<String, List<String>> sidekickUsedByMap = new HashMap<>();
     DeploymentServiceContext context;
     Environment env;
 
@@ -25,6 +26,16 @@ public class DeploymentUnitService {
         this.env = context.objectManager.findOne(Environment.class, ENVIRONMENT.ID, service.getEnvironmentId());
         this.launchConfigNames = launchConfigNames;
         this.context = context;
+        for (String launchConfigName : launchConfigNames) {
+            for (String sidekick : getSidekickRefs(launchConfigName)) {
+                List<String> usedBy = sidekickUsedByMap.get(sidekick);
+                if (usedBy == null) {
+                    usedBy = new ArrayList<>();
+                }
+                usedBy.add(launchConfigName);
+                sidekickUsedByMap.put(sidekick, usedBy);
+            }
+        }
     }
 
     public void addDeploymentInstance(String launchConfig, DeploymentUnitInstance instance) {
@@ -66,6 +77,29 @@ public class DeploymentUnitService {
         }
     }
 
+    public void cleanupInstancesWithMissingDependencies() {
+        for (String launchConfigName : launchConfigNames) {
+            if (!launchConfigToInstance.containsKey(launchConfigName)) {
+                cleanupInstanceWithMissingDep(launchConfigName);
+            }
+        }
+    }
+
+    protected void cleanupInstanceWithMissingDep(String launchConfigName) {
+        List<String> usedInLaunchConfigs = sidekickUsedByMap.get(launchConfigName);
+        if (usedInLaunchConfigs == null) {
+            return;
+        }
+        for (String usedInLaunchConfig : usedInLaunchConfigs) {
+            DeploymentUnitInstance usedByInstance = launchConfigToInstance.get(usedInLaunchConfig);
+            if (usedByInstance == null) {
+                continue;
+            }
+            usedByInstance.remove();
+            cleanupInstanceWithMissingDep(usedInLaunchConfig);
+        }
+    }
+
     public List<String> getLaunchConfigNames() {
         return launchConfigNames;
     }
@@ -74,4 +108,20 @@ public class DeploymentUnitService {
         return service;
     }
 
+    @SuppressWarnings("unchecked")
+    public List<String> getSidekickRefs(String launchConfigName) {
+        List<String> sidekicksLaunchConfigIds = new ArrayList<>();
+        for (DeploymentUnit.SidekickType sidekickType : DeploymentUnit.SidekickType.supportedTypes) {
+            Object sidekicksLaunchConfigObj = ServiceDiscoveryUtil.getLaunchConfigObject(service, launchConfigName,
+                    sidekickType.launchConfigType);
+            if (sidekicksLaunchConfigObj != null) {
+                if (sidekickType.isList) {
+                    sidekicksLaunchConfigIds.addAll((List<String>) sidekicksLaunchConfigObj);
+                } else {
+                    sidekicksLaunchConfigIds.add(sidekicksLaunchConfigObj.toString());
+                }
+            }
+        }
+        return sidekicksLaunchConfigIds;
+    }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/ExternalDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/ExternalDeploymentUnitInstance.java
@@ -61,7 +61,7 @@ public class ExternalDeploymentUnitInstance extends DeploymentUnitInstance {
     }
 
     @Override
-    public DeploymentUnitInstance start(Map<String, Object> deployParams) {
+    public DeploymentUnitInstance create(Map<String, Object> deployParams) {
         if (createNew()) {
             if (this.ipAddress != null) {
                 this.exposeMap = context.exposeMapDao.createIpToServiceMap(this.service, this.ipAddress);
@@ -85,7 +85,7 @@ public class ExternalDeploymentUnitInstance extends DeploymentUnitInstance {
     }
 
     @Override
-    public DeploymentUnitInstance waitForStart() {
+    public DeploymentUnitInstance waitForStartImpl() {
         this.exposeMap = context.resourceMonitor.waitFor(this.exposeMap, new ResourcePredicate<ServiceExposeMap>() {
             @Override
             public boolean evaluate(ServiceExposeMap obj) {
@@ -96,7 +96,7 @@ public class ExternalDeploymentUnitInstance extends DeploymentUnitInstance {
     }
 
     @Override
-    public boolean isStarted() {
+    protected boolean isStartedImpl() {
         return this.exposeMap != null && this.exposeMap.getState().equalsIgnoreCase(CommonStatesConstants.ACTIVE);
     }
 
@@ -119,5 +119,10 @@ public class ExternalDeploymentUnitInstance extends DeploymentUnitInstance {
 
     public boolean isHealthCheckInitializing() {
         return false;
+    }
+
+    @Override
+    protected DeploymentUnitInstance startImpl() {
+        return this;
     }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/LoadBalancerDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/LoadBalancerDeploymentUnitInstance.java
@@ -51,7 +51,7 @@ public class LoadBalancerDeploymentUnitInstance extends AbstractInstanceUnit {
     }
 
     @Override
-    public DeploymentUnitInstance start(Map<String, Object> deployParams) {
+    public DeploymentUnitInstance create(Map<String, Object> deployParams) {
         if (createNew()) {
             LoadBalancer lb = context.objectManager.findAny(LoadBalancer.class, LOAD_BALANCER.SERVICE_ID,
                     service.getId(),
@@ -62,11 +62,6 @@ public class LoadBalancerDeploymentUnitInstance extends AbstractInstanceUnit {
             this.hostMap = context.lbService.addHostWLaunchConfigToLoadBalancer(lb, launchConfig);
             this.instance = context.lbInstanceMgr.getLoadBalancerInstance(this.hostMap);
             this.exposeMap = context.exposeMapDao.findInstanceExposeMap(this.instance);
-        } else if (this.instance != null) {
-            if (InstanceConstants.STATE_STOPPED.equals(instance.getState())) {
-                context.objectProcessManager.scheduleProcessInstanceAsync(
-                        InstanceConstants.PROCESS_START, instance, null);
-            }
         }
         return this;
     }
@@ -77,7 +72,7 @@ public class LoadBalancerDeploymentUnitInstance extends AbstractInstanceUnit {
     }
 
     @Override
-    public DeploymentUnitInstance waitForStart() {
+    public DeploymentUnitInstance waitForStartImpl() {
         this.hostMap = context.resourceMonitor.waitFor(this.hostMap, new ResourcePredicate<LoadBalancerHostMap>() {
             @Override
             public boolean evaluate(LoadBalancerHostMap obj) {
@@ -89,7 +84,7 @@ public class LoadBalancerDeploymentUnitInstance extends AbstractInstanceUnit {
     }
     
     @Override
-    public boolean isStarted() {
+    protected boolean isStartedImpl() {
         boolean mapActive = this.hostMap.getState().equalsIgnoreCase(CommonStatesConstants.ACTIVE);
         boolean instanceRunning = this.instance != null
                 && this.instance.getState().equalsIgnoreCase(InstanceConstants.STATE_RUNNING);

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceCreate.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceCreate.java
@@ -32,5 +32,4 @@ public class ServiceCreate extends AbstractObjectProcessHandler {
 
         return null;
     }
-
 }


### PR DESCRIPTION
1) Restart service's stopped containers only when RestartPolicy is explicitly set to "No" on the service.

https://github.com/rancher/rancher/issues/1596

@vincent99 the UI by default passes restartPolicy=No. If its not possible not to send restartPolicy unless user choses to use it, we might change the default to be Always, so the default behavior is "always restart"

2) Don't destroy service's container, unless its:

* unhealthy 
* in error state
* references sidekick container that is being dead

Before the fix, we've re-created all deployment unit's containers if at least one of them was dead. After the fix, we are more deliberate about what containers have to be recreated based on the dependencies (networkFrom/dataVolumesFrom within the deployment unit)