### PR TITLE
Include port number in haproxy config for hdr(host) acl.

### DIFF
--- a/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
+++ b/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
@@ -39,6 +39,7 @@ frontend ${listener.uuid}_frontend
         <#if (listener.sourceProtocol == "http" || listener.sourceProtocol == "https") && (backend.portSpec.domain != "default" || backend.portSpec.path != "default")>
         <#if backend.portSpec.domain != "default">
         acl ${backend.uuid}_host hdr(host) -i ${backend.portSpec.domain}
+        acl ${backend.uuid}_host hdr(host) -i ${backend.portSpec.domain}:${sourcePort}
     	</#if>
     	<#if backend.portSpec.path != "default">
         acl ${backend.uuid}_path path_beg -i ${backend.portSpec.path}


### PR DESCRIPTION
In order for HA proxy to route traffic based on the Host header, when the client includes the port number in the Host header, the acl must also include the port number in order for it to match.

See http://serverfault.com/questions/502443/ignore-port-numbers-in-haproxy-host-header-matches for a related issue that describes the use case this solves.