### PR TITLE
Service discovery bug fixes

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnitInstanceFactoryImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnitInstanceFactoryImpl.java
@@ -171,6 +171,9 @@ public class DeploymentUnitInstanceFactoryImpl implements DeploymentUnitInstance
             Service service) {
         LoadBalancer lb = objectMgr.findOne(LoadBalancer.class, LOAD_BALANCER.SERVICE_ID, service.getId(),
                 LOAD_BALANCER.REMOVED, null);
+        if (lb == null) {
+            return;
+        }
 
         List<? extends LoadBalancerHostMap> hostMaps = mapDao.findNonRemoved(LoadBalancerHostMap.class,
                 LoadBalancer.class, lb.getId());


### PR DESCRIPTION
1) LB service cleanup: skip Lbs in removed/removing states

To avoid the situation when Lb is already being cleaned up, when service
cleanup thread kicks in

https://github.com/rancher/rancher/issues/1769