### PR TITLE
 Support serving local archives for download

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/server/agentinclude/impl/AgentIncludeConfigItemFactoryImpl.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/server/agentinclude/impl/AgentIncludeConfigItemFactoryImpl.java
@@ -4,6 +4,7 @@ import io.cattle.platform.configitem.context.ConfigItemContextFactory;
 import io.cattle.platform.configitem.server.agentinclude.AgentIncludeMap;
 import io.cattle.platform.configitem.server.model.ConfigItem;
 import io.cattle.platform.configitem.server.model.ConfigItemFactory;
+import io.cattle.platform.configitem.server.model.impl.LocalArchiveConfigItem;
 import io.cattle.platform.configitem.server.model.util.ConfigItemResourceUtil;
 import io.cattle.platform.configitem.server.resource.FileBasedResourceRoot;
 import io.cattle.platform.configitem.server.resource.ResourceRoot;
@@ -22,7 +23,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import javax.inject.Inject;
 
 public class AgentIncludeConfigItemFactoryImpl implements ConfigItemFactory {
@@ -51,13 +51,20 @@ public class AgentIncludeConfigItemFactoryImpl implements ConfigItemFactory {
 
                 if (value != null && !itemSet.contains(value)) {
                     if (AgentPackagesConfigItem.isDevVersion(value)) {
-                        FileBasedResourceRoot itemResource = new FileBasedResourceRoot(new File(value));
-                        itemResource.scan();
+                        File file = new File(value);
+                        if (file.exists() && ! file.isDirectory()) {
+                            LocalArchiveConfigItem item = new LocalArchiveConfigItem(file, key, versionManager);
+                            item.setDynamicallyApplied(true);
+                            itemList.add(item);
+                        } else{
+                            FileBasedResourceRoot itemResource = new FileBasedResourceRoot(new File(value));
+                            itemResource.scan();
 
-                        TemplatesBasedArchiveItem archiveItem = new TemplatesBasedArchiveItem(key, versionManager, itemResource, templateFactory,
-                                getFactories(key));
-                        archiveItem.setDynamicallyApplied(true);
-                        itemList.add(archiveItem);
+                            TemplatesBasedArchiveItem archiveItem = new TemplatesBasedArchiveItem(key, versionManager, itemResource, templateFactory,
+                                    getFactories(key));
+                            archiveItem.setDynamicallyApplied(true);
+                            itemList.add(archiveItem);
+                        }
                     }
 
                     itemSet.add(value);

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/server/model/impl/LocalArchiveConfigItem.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/server/model/impl/LocalArchiveConfigItem.java
@@ -1,0 +1,63 @@
+package io.cattle.platform.configitem.server.model.impl;
+
+import io.cattle.platform.configitem.server.model.Request;
+import io.cattle.platform.configitem.version.ConfigItemStatusManager;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.output.NullOutputStream;
+
+public class LocalArchiveConfigItem extends AbstractConfigItem {
+
+    File file;
+    String revision;
+
+    public LocalArchiveConfigItem(File file, String name, ConfigItemStatusManager versionManager) throws IOException {
+        super(name, versionManager);
+
+        this.file = file;
+        this.hash();
+    }
+
+    public void hash() throws IOException {
+        DigestOutputStream os = null;
+        try {
+            os = new DigestOutputStream(new NullOutputStream(), MessageDigest.getInstance("SHA-256"));
+            copyFile(os);
+            os.close();
+            revision = Hex.encodeHexString(os.getMessageDigest().digest());
+            os = null;
+        } catch (NoSuchAlgorithmException e) {
+            throw new IOException(e);
+        } finally {
+            IOUtils.closeQuietly(os);
+        }
+    }
+
+    @Override
+    public void handleRequest(Request req) throws IOException {
+        req.setContentType("application/octet-stream");
+        OutputStream os = req.getOutputStream();
+        os.write(String.format("version:%s\n", getVersion(req)).getBytes("UTF-8"));
+        copyFile(os);
+    }
+
+    protected void copyFile(OutputStream os) throws IOException {
+        try (FileInputStream fis = new FileInputStream(file)) {
+            IOUtils.copyLarge(fis, os, new byte[1024 * 128]);
+        }
+    }
+
+    @Override
+    public String getSourceRevision() {
+        return revision;
+    }
+}

--- a/resources/content/config-content/configscripts/common/scripts.sh
+++ b/resources/content/config-content/configscripts/common/scripts.sh
@@ -40,7 +40,7 @@ error()
 
 call_curl()
 {
-    local curl="curl -s --connect-timeout 3"
+    local curl="curl -s --connect-timeout 20"
     if [ "$CURL_AUTH" = "false" ]; then
         $curl "$@"
     elif [ -n "$CATTLE_AGENT_INSTANCE_AUTH" ]; then

--- a/resources/content/config-content/configscripts/config.sh
+++ b/resources/content/config-content/configscripts/config.sh
@@ -118,7 +118,13 @@ download()
     info Downloading $DOWNLOAD_URL "current=$current"
 
     get $get_opts "$DOWNLOAD_URL?current=$current" > $DOWNLOAD_TEMP/download
-    tar xzf $DOWNLOAD_TEMP/download -C $DOWNLOAD_TEMP
+    HEADER=$(cat $DOWNLOAD_TEMP/download | head -n1)
+    if [[ "$HEADER" =~ version:* ]]; then
+        archive_version=$(echo $HEADER | cut -f2 -d:)
+        cat $DOWNLOAD_TEMP/download | sed 1d | tar xzf - -C $DOWNLOAD_TEMP
+    else
+        tar xzf $DOWNLOAD_TEMP/download -C $DOWNLOAD_TEMP
+    fi
     rm $DOWNLOAD_TEMP/download
 
     local dir=$(basename $(ls -1 $DOWNLOAD_TEMP))


### PR DESCRIPTION
In cattle-global.properties you can now point one of the *.url settings
to a local file that is a release from github.  It will be served from
there and not the github location