### PR TITLE
Ignore hostname routing rules for tcp listeners

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/LoadBalancerTargetsInfo.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/LoadBalancerTargetsInfo.java
@@ -3,6 +3,7 @@ package io.cattle.platform.configitem.context.data;
 import io.cattle.platform.core.addon.InstanceHealthCheck;
 import io.cattle.platform.core.util.LoadBalancerTargetPortSpec;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class LoadBalancerTargetsInfo {
@@ -13,8 +14,12 @@ public class LoadBalancerTargetsInfo {
 
     public LoadBalancerTargetsInfo(List<LoadBalancerTargetInfo> lbTargetInfo, InstanceHealthCheck lbHealthCheck,
             int uuid) {
-        super();
+        this(lbTargetInfo, lbHealthCheck, lbTargetInfo.isEmpty() ? null : lbTargetInfo.get(0).getPortSpec());
         this.uuid = uuid;
+    }
+
+    public LoadBalancerTargetsInfo(List<LoadBalancerTargetInfo> lbTargetInfo, InstanceHealthCheck lbHealthCheck,
+            LoadBalancerTargetPortSpec portSpec) {
         this.targets = lbTargetInfo;
         for (LoadBalancerTargetInfo target : this.targets) {
             if (target.getHealthCheck() != null) {
@@ -28,10 +33,14 @@ public class LoadBalancerTargetsInfo {
         if (this.healthCheck == null && lbHealthCheck != null) {
             this.healthCheck = lbHealthCheck;
         }
+        this.portSpec = portSpec;
+    }
 
-        if (!lbTargetInfo.isEmpty()) {
-            this.portSpec = lbTargetInfo.get(0).getPortSpec();
-        }
+    public LoadBalancerTargetsInfo(LoadBalancerTargetsInfo that) {
+        this.uuid = that.getUuid();
+        this.portSpec = that.getPortSpec();
+        this.targets = that.getTargets();
+        this.healthCheck = that.healthCheck;
     }
 
     public List<LoadBalancerTargetInfo> getTargets() {
@@ -64,5 +73,12 @@ public class LoadBalancerTargetsInfo {
 
     public void setHealthCheck(InstanceHealthCheck healthCheck) {
         this.healthCheck = healthCheck;
+    }
+
+    public void addTargets(List<LoadBalancerTargetInfo> targets) {
+        if (this.targets == null) {
+            this.targets = new ArrayList<>();
+        }
+        this.targets.addAll(targets);
     }
 }

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/LoadBalancerInfoFactory.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/LoadBalancerInfoFactory.java
@@ -89,14 +89,54 @@ public class LoadBalancerInfoFactory extends AbstractAgentBaseContextFactory {
                 return;
             }
         }
+        Map<String, List<LoadBalancerTargetsInfo>> listenerToTargetMap = assignTargetsToListeners(listeners,
+                targetsInfo, lbHealthCheck);
         context.getData().put("listeners", listeners);
         context.getData().put("publicIp", lbMgr.getLoadBalancerInstanceIp(instance).getAddress());
-        context.getData().put("backends", sortTargets(targetsInfo));
+        context.getData().put("backends", listenerToTargetMap);
         context.getData().put("appPolicy", appPolicy);
         context.getData().put("lbPolicy", lbPolicy);
 
         context.getData().put("certs", lbDao.getLoadBalancerCertificates(lb));
         context.getData().put("defaultCert", lbDao.getLoadBalancerDefaultCertificate(lb));
+    }
+
+
+    protected Map<String, List<LoadBalancerTargetsInfo>> assignTargetsToListeners(
+            List<? extends LoadBalancerListener> listeners, List<LoadBalancerTargetsInfo> targetsInfo,
+            InstanceHealthCheck lbHealthCheck) {
+        Map<String, List<LoadBalancerTargetsInfo>> listenerToTargetMap = new HashMap<>();
+        for (LoadBalancerListener listener : listeners) {
+            List<LoadBalancerTargetsInfo> listenerTargets = new ArrayList<>();
+            for (LoadBalancerTargetsInfo info : targetsInfo) {
+                Integer listnerPort = listener.getPrivatePort() == null ? listener.getSourcePort() : listener
+                        .getPrivatePort();
+                if (info.getPortSpec().getSourcePort().equals(listnerPort)) {
+                    if (listener.getSourceProtocol().equalsIgnoreCase("http")) {
+                        listenerTargets.add(new LoadBalancerTargetsInfo(info));
+                    } else if (listener.getSourceProtocol().equalsIgnoreCase("tcp")) {
+                        // special handling for tcp ports - hostname routing rules should be ignored (by resetting the
+                        // rule to Default)
+                        // and all backends should be merged into one
+                        LoadBalancerTargetsInfo tcpTargetsInfo = null;
+                        if (listenerTargets.isEmpty()) {
+                            LoadBalancerTargetPortSpec portSpec = info.getPortSpec();
+                            portSpec.setDomain(LoadBalancerTargetPortSpec.DEFAULT);
+                            portSpec.setPath(LoadBalancerTargetPortSpec.DEFAULT);
+                            tcpTargetsInfo = new LoadBalancerTargetsInfo(info.getTargets(), lbHealthCheck,
+                                    info.getPortSpec());
+                        } else {
+                            tcpTargetsInfo = listenerTargets.get(0);
+                            tcpTargetsInfo.addTargets(info.getTargets());
+                        }
+                        listenerTargets.clear();
+                        listenerTargets.add(tcpTargetsInfo);
+                    }
+                }
+            }
+            listenerToTargetMap.put(listener.getUuid(), sortTargets(listenerTargets));
+        }
+        return listenerToTargetMap;
     }
 
 

--- a/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
+++ b/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
@@ -39,8 +39,7 @@ frontend ${listener.uuid}_frontend
         bind ${publicIp}:${sourcePort}<#if (listener.sourceProtocol == "https" || listener.sourceProtocol == "ssl") && certs?has_content> ssl crt /etc/haproxy/certs/<#if !defaultCert??> strict-sni</#if></#if>
         mode ${protocol}
 
-        <#list backends as backend >
-        <#if backend.portSpec.sourcePort == sourcePort>
+        <#list backends[listener.uuid] as backend >
         <#if (listener.sourceProtocol == "http" || listener.sourceProtocol == "https") && (backend.portSpec.domain != "default" || backend.portSpec.path != "default")>
         <#if backend.portSpec.domain != "default">
         acl ${backend.uuid}_host hdr(host) -i ${backend.portSpec.domain}
@@ -53,11 +52,9 @@ frontend ${listener.uuid}_frontend
         <#elseif backend.portSpec.domain == "default" && backend.portSpec.path == "default">
     	default_backend ${listener.uuid}_${backend.uuid}_backend
         </#if>
-        </#if>
         </#list>
 
-<#list backends as backend >
-<#if backend.portSpec.sourcePort == sourcePort>
+<#list backends[listener.uuid]  as backend >
 backend ${listener.uuid}_${backend.uuid}_backend
         mode ${protocol}
         balance ${listener.data.fields.algorithm}
@@ -79,7 +76,7 @@ backend ${listener.uuid}_${backend.uuid}_backend
          <#if listener.sourceProtocol == "https">
         http-request add-header X-Forwarded-Proto https if { ssl_fc }
         </#if>
-</#if>
+        
 </#list>
 </#list>
 <#else>


### PR DESCRIPTION
Before the fix, when hostname routing rule was defined for the service in tcp listener context, this service used to be excluded from the list of backends - as http related params can be extracted only when "http" mode is on. It made tcp rules application inconvenient for the case when:

* multiple http listeners are defined in LB
* one or more tcp listeners are present too
* user wants hostname routing rules to apply w/o defining the source port in the context so it applies to every listener supporting hostname routing rules. Without the fix its impossible as he has to create the same hostname routing rule for every http source port in order just to exclude tcp port(s). If the user doesn't do this step, his tcp listeners will get configured with hostname acls which will never work, so we will end up with traffic completely blocked.

The better way to handle that is to just ignore hostname routing rules for tcp mode listeners. 


https://github.com/rancher/rancher/issues/1763
https://github.com/rancher/rancher/issues/1762
https://github.com/rancher/rancher/issues/1722