### PR TITLE
Allow scaleup/scaledown for service in updating-active state

### DIFF
--- a/code/iaas/logic/src/main/resources/META-INF/cattle/core-process/spring-core-processes-context.xml
+++ b/code/iaas/logic/src/main/resources/META-INF/cattle/core-process/spring-core-processes-context.xml
@@ -152,7 +152,7 @@
     <!-- Service Discovery Service -->
     <process:process name="service.create" resourceType="service" start="requested" transitioning="registering" done="inactive" />
     <process:process name="service.activate" resourceType="service" start="inactive" transitioning="activating" done="active" />    
-    <process:process name="service.update" resourceType="service" start="inactive,active" transitioning="inactive=updating-inactive,active=updating-active" done="updating-inactive=inactive,updating-active=active" />
+    <process:process name="service.update" resourceType="service" start="inactive,active,updating-active" transitioning="inactive=updating-inactive,active=updating-active,updating-active=updating-active" done="updating-inactive=inactive,updating-active=active" />
     <process:process name="service.deactivate" resourceType="service" start="active,activating, updating-inactive, updating-active" transitioning="deactivating" done="inactive" />
     <process:process name="service.remove" resourceType="service" start="inactive, registering, active, activating, updating-inactive, updating-active, upgrading, canceling-upgrade, deactivating" transitioning="removing" done="removed" />
     <process:process name="service.upgrade" resourceType="service" start="active" transitioning="upgrading" done="active" />

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServicesReconcileTrigger.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServicesReconcileTrigger.java
@@ -6,6 +6,7 @@ import io.cattle.platform.engine.handler.HandlerResult;
 import io.cattle.platform.engine.process.ProcessInstance;
 import io.cattle.platform.engine.process.ProcessState;
 import io.cattle.platform.process.common.handler.AbstractObjectProcessHandler;
+import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
 import io.cattle.platform.servicediscovery.deployment.DeploymentManager;
 import io.cattle.platform.servicediscovery.service.ServiceLookup;
 
@@ -26,16 +27,20 @@ public class ServicesReconcileTrigger extends AbstractObjectProcessHandler {
     @Override
     public String[] getProcessNames() {
         return new String[] { "instance.updatehealthy", "instance.updateunhealthy", InstanceConstants.PROCESS_STOP,
-                InstanceConstants.PROCESS_REMOVE };
+                InstanceConstants.PROCESS_REMOVE, ServiceDiscoveryConstants.PROCESS_SERVICE_UPDATE };
     }
 
     @Override
     public HandlerResult handle(ProcessState state, ProcessInstance process) {
         List<Service> services = new ArrayList<>();
-        for (ServiceLookup lookup : serviceLookups) {
-            Collection<? extends Service> lookupSvs = lookup.getServices(state.getResource());
-            if (lookupSvs != null) {
-                services.addAll(lookupSvs);
+        if (state.getResource() instanceof Service) {
+            services.add((Service) state.getResource());
+        } else {
+            for (ServiceLookup lookup : serviceLookups) {
+                Collection<? extends Service> lookupSvs = lookup.getServices(state.getResource());
+                if (lookupSvs != null) {
+                    services.addAll(lookupSvs);
+                }
             }
         }
 


### PR DESCRIPTION
So now you can change the scale for the service stuck in updating-active state, w/o deactivating this service first. 

Also fixes https://github.com/rancher/rancher/issues/1757