### PR TITLE
Defer parsing of data JSON until needed

### DIFF
--- a/code/framework/jooq/src/main/java/io/cattle/platform/db/jooq/converter/impl/JsonUnmodifiableMap.java
+++ b/code/framework/jooq/src/main/java/io/cattle/platform/db/jooq/converter/impl/JsonUnmodifiableMap.java
@@ -6,10 +6,16 @@ import io.cattle.platform.util.type.UnmodifiableMap;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class JsonUnmodifiableMap<K, V> implements UnmodifiableMap<K, V> {
+
+    private static final Logger log = LoggerFactory.getLogger(JsonUnmodifiableMap.class);
 
     Map<K, V> map;
     JsonMapper jsonMapper;
@@ -17,84 +23,95 @@ public class JsonUnmodifiableMap<K, V> implements UnmodifiableMap<K, V> {
 
     @SuppressWarnings("unchecked")
     public JsonUnmodifiableMap(JsonMapper mapper, String text) throws IOException {
-        this.map = (Map<K, V>) Collections.unmodifiableMap(mapper.readValue(text));
         this.jsonMapper = mapper;
         this.text = text;
     }
 
     @Override
     public int size() {
-        return map.size();
+        return getMap().size();
     }
 
     @Override
     public boolean isEmpty() {
-        return map.isEmpty();
+        return getMap().isEmpty();
     }
 
     @Override
     public boolean containsKey(Object key) {
-        return map.containsKey(key);
+        return getMap().containsKey(key);
     }
 
     @Override
     public boolean containsValue(Object value) {
-        return map.containsValue(value);
+        return getMap().containsValue(value);
     }
 
     @Override
     public V get(Object key) {
-        return map.get(key);
+        return getMap().get(key);
     }
 
     @Override
     public V put(K key, V value) {
-        return map.put(key, value);
+        return getMap().put(key, value);
     }
 
     @Override
     public V remove(Object key) {
-        return map.remove(key);
+        return getMap().remove(key);
     }
 
     @Override
     public void putAll(Map<? extends K, ? extends V> m) {
-        map.putAll(m);
+        getMap().putAll(m);
     }
 
     @Override
     public void clear() {
-        map.clear();
+        getMap().clear();
     }
 
     @Override
     public Set<K> keySet() {
-        return map.keySet();
+        return getMap().keySet();
     }
 
     @Override
     public Collection<V> values() {
-        return map.values();
+        return getMap().values();
     }
 
     @Override
     public Set<java.util.Map.Entry<K, V>> entrySet() {
-        return map.entrySet();
+        return getMap().entrySet();
     }
 
     @Override
     public boolean equals(Object o) {
-        return map.equals(o);
+        return getMap().equals(o);
     }
 
     @Override
     public int hashCode() {
-        return map.hashCode();
+        return getMap().hashCode();
     }
 
     @Override
     public String toString() {
-        return map.toString();
+        return getMap().toString();
+    }
+
+    protected  Map<K, V> getMap() {
+        if (this.map == null) {
+            try {
+                this.map = (Map<K, V>) Collections.unmodifiableMap(jsonMapper.readValue(text));
+            } catch (IOException e) {
+                log.error("Failed to unmarshall {}", text, e);
+                this.map = (Map<K, V>)Collections.unmodifiableMap(new HashMap<>());
+            }
+        }
+        return this.map;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Once the data field is first accessed we unmarshall the JSON, not when it
is read from the database.