### PR TITLE
Setup ssl default params on haproxy only when ssl listeners are present

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/LoadBalancerInfoFactory.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/LoadBalancerInfoFactory.java
@@ -71,11 +71,19 @@ public class LoadBalancerInfoFactory extends AbstractAgentBaseContextFactory {
         InstanceHealthCheck lbHealthCheck = null;
         LoadBalancerAppCookieStickinessPolicy appPolicy = null;
         LoadBalancerCookieStickinessPolicy lbPolicy = null;
+        boolean sslProto = false;
         if (lb != null) {
             // populate targets and listeners
             listeners = lbDao.listActiveListenersForConfig(lb.getLoadBalancerConfigId());
             if (listeners.isEmpty()) {
                 return;
+            }
+            for (LoadBalancerListener listener : listeners) {
+                if (listener.getSourceProtocol().equals("https")
+                        || listener.getSourceProtocol().equalsIgnoreCase("ssl")) {
+                    sslProto = true;
+                    break;
+                }
             }
 
             LoadBalancerConfig config = objectManager.loadResource(LoadBalancerConfig.class, lb.getLoadBalancerConfigId());
@@ -100,6 +108,7 @@ public class LoadBalancerInfoFactory extends AbstractAgentBaseContextFactory {
         context.getData().put("backends", listenerToTargetMap);
         context.getData().put("appPolicy", appPolicy);
         context.getData().put("lbPolicy", lbPolicy);
+        context.getData().put("sslProto", sslProto);
 
         context.getData().put("certs", lbDao.getLoadBalancerCertificates(lb));
         context.getData().put("defaultCert", lbDao.getLoadBalancerDefaultCertificate(lb));

--- a/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
+++ b/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
@@ -3,7 +3,9 @@ global
     	log 127.0.0.1 local1 notice
         maxconn 4096
         maxpipes 1024
-        tune.ssl.default-dh-param 2048
+<#if sslProto?? && sslProto == true>
+	tune.ssl.default-dh-param 2048
+</#if>
 	chroot /var/lib/haproxy
 	user haproxy
 	group haproxy


### PR DESCRIPTION
To fix the upgrade bug

https://github.com/rancher/rancher/issues/1834