### PR TITLE
[WIP] Add upgrade logic for private registry agents

### DIFF
--- a/resources/content/config-content/bootstrap/bootstrap.sh
+++ b/resources/content/config-content/bootstrap/bootstrap.sh
@@ -104,6 +104,11 @@ upgrade()
     fi
 }
 
+get_running_image()
+{
+    echo $(docker inspect -f '{{.Config.Image}}' rancher-agent)
+}
+
 cd $(dirname $0)
 
 for conf_file in "${CONF[@]}"; do
@@ -137,6 +142,7 @@ while [ $# != 0 ]; do
 done
 
 check_debug
+export RANCHER_AGENT_IMAGE="$(get_running_image)"
 print_config
 
 upgrade


### PR DESCRIPTION
This takes the approach that:
1.) the script is running in rancher-agent
2.) A user has started running it on a private registry and had to set the variable.
3.) All future upgrades will be from a private registry, though it could be switched, and this variable would still be used.

upgrade Logic for rancher/rancher#1840