### PR TITLE
Make simulator report proper instance state

### DIFF
--- a/code/implementation/simulator/agent-connection/src/main/java/io/cattle/platform/agent/connection/simulator/AgentConnectionSimulator.java
+++ b/code/implementation/simulator/agent-connection/src/main/java/io/cattle/platform/agent/connection/simulator/AgentConnectionSimulator.java
@@ -7,9 +7,9 @@ import io.cattle.platform.eventing.EventProgress;
 import io.cattle.platform.eventing.model.Event;
 import io.cattle.platform.eventing.model.EventVO;
 
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -18,7 +18,7 @@ public class AgentConnectionSimulator implements AgentConnection {
     Agent agent;
     boolean open = true;
     List<AgentSimulatorEventProcessor> processors;
-    Set<String> instances = new HashSet<String>();
+    Map<String, String> instances = new HashMap<String, String>();
 
     public AgentConnectionSimulator(Agent agent, List<AgentSimulatorEventProcessor> processors) {
         super();
@@ -66,7 +66,7 @@ public class AgentConnectionSimulator implements AgentConnection {
         return agent;
     }
 
-    public Set<String> getInstances() {
+    public Map<String, String> getInstances() {
         return instances;
     }
 

--- a/code/implementation/simulator/agent-connection/src/main/java/io/cattle/platform/agent/connection/simulator/impl/SimulatorPingProcessor.java
+++ b/code/implementation/simulator/agent-connection/src/main/java/io/cattle/platform/agent/connection/simulator/impl/SimulatorPingProcessor.java
@@ -50,9 +50,9 @@ public class SimulatorPingProcessor implements AgentSimulatorEventProcessor {
     protected void addInstances(AgentConnectionSimulator simulator, Ping pong, Agent agent) {
         List<Map<String, Object>> resources = pong.getData().getResources();
 
-        for (String instance : simulator.getInstances()) {
+        for (Map.Entry<String, String> kv : simulator.getInstances().entrySet()) {
             Map<String, Object> instanceMap = CollectionUtils.asMap(ObjectMetaDataManager.TYPE_FIELD, InstanceConstants.TYPE, ObjectMetaDataManager.UUID_FIELD,
-                    instance, ObjectMetaDataManager.STATE_FIELD, InstanceConstants.STATE_RUNNING);
+                    kv.getKey(), ObjectMetaDataManager.STATE_FIELD, kv.getValue());
             resources.add(instanceMap);
         }
 

--- a/code/implementation/simulator/agent-connection/src/main/java/io/cattle/platform/agent/connection/simulator/impl/SimulatorStartStopProcessor.java
+++ b/code/implementation/simulator/agent-connection/src/main/java/io/cattle/platform/agent/connection/simulator/impl/SimulatorStartStopProcessor.java
@@ -2,6 +2,7 @@ package io.cattle.platform.agent.connection.simulator.impl;
 
 import io.cattle.platform.agent.connection.simulator.AgentConnectionSimulator;
 import io.cattle.platform.agent.connection.simulator.AgentSimulatorEventProcessor;
+import io.cattle.platform.core.constants.InstanceConstants;
 import io.cattle.platform.eventing.model.Event;
 import io.cattle.platform.eventing.model.EventVO;
 import io.cattle.platform.json.JsonMapper;
@@ -43,8 +44,12 @@ public class SimulatorStartStopProcessor implements AgentSimulatorEventProcessor
 
         final Object uuid = CollectionUtils.getNestedValue(event.getData(), "instanceHostMap", "instance", "uuid");
         if (uuid != null) {
-            if (add && !FORGET.matcher(eventString).matches()) {
-                simulator.getInstances().add(uuid.toString());
+            boolean found = simulator.getInstances().containsKey(uuid.toString());
+            boolean forget = FORGET.matcher(eventString).matches();
+            if (add && !forget) {
+                simulator.getInstances().put(uuid.toString(), InstanceConstants.STATE_RUNNING);
+            } else if (!add && found && !forget) {
+                simulator.getInstances().put(uuid.toString(), InstanceConstants.STATE_STOPPED);
             } else {
                 simulator.getInstances().remove(uuid.toString());
             }


### PR DESCRIPTION
A recent change to the ping logic to delete container that are not on host has exposed a flaw in our agent simulator. It was completely "forgetting" stopped instances and not reporting them, instead of reporting them as stopped.