### PR TITLE
Config items

### DIFF
--- a/code/iaas/config-item/common/src/main/resources/META-INF/cattle/system-services/config-item-common-defaults.properties
+++ b/code/iaas/config-item/common/src/main/resources/META-INF/cattle/system-services/config-item-common-defaults.properties
@@ -2,3 +2,4 @@ item.wait.for.event.tries=30
 item.wait.for.event.timeout.millis=2000
 item.sync.batch.size=100
 item.migration.block.on.failure=false
+item.priority=configscripts

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/server/model/impl/AbstractArchiveBasedConfigItem.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/server/model/impl/AbstractArchiveBasedConfigItem.java
@@ -65,7 +65,7 @@ public abstract class AbstractArchiveBasedConfigItem extends AbstractResourceRoo
         }
     }
 
-    protected void writeHashes(final ArchiveContext context) throws IOException {
+    protected static void writeHashes(final ArchiveContext context) throws IOException {
         StringBuilder stringContent = new StringBuilder();
         Map<String, String> hashes = context.getHashes();
         for (Map.Entry<String, String> entry : hashes.entrySet()) {
@@ -96,6 +96,10 @@ public abstract class AbstractArchiveBasedConfigItem extends AbstractResourceRoo
     }
 
     protected void writeContent(final ArchiveContext context) throws IOException {
+        writeVersion(context);
+    }
+
+    protected static void writeVersion(final ArchiveContext context) throws IOException {
         final byte[] content = (context.getVersion() + "\n").getBytes("UTF-8");
         withEntry(context, "version", content.length, new WithEntry() {
             @Override
@@ -105,7 +109,7 @@ public abstract class AbstractArchiveBasedConfigItem extends AbstractResourceRoo
         });
     }
 
-    protected void writeUpToDate(final ArchiveContext context) throws IOException {
+    protected static void writeUpToDate(final ArchiveContext context) throws IOException {
         final byte[] content = (context.getVersion() + "\n").getBytes("UTF-8");
         withEntry(context, "uptodate", content.length, new WithEntry() {
             @Override
@@ -115,7 +119,7 @@ public abstract class AbstractArchiveBasedConfigItem extends AbstractResourceRoo
         });
     }
 
-    protected void withEntry(ArchiveContext context, String entryName, long size, WithEntry with) throws IOException {
+    protected static void withEntry(ArchiveContext context, String entryName, long size, WithEntry with) throws IOException {
         if (size < 0) {
             final ByteArrayOutputStream baos = new ByteArrayOutputStream();
             with.with(baos);
@@ -131,7 +135,7 @@ public abstract class AbstractArchiveBasedConfigItem extends AbstractResourceRoo
         withEntry(context, getDefaultEntry(context, entryName, size), with);
     };
 
-    protected void withEntry(ArchiveContext context, TarArchiveEntry entry, WithEntry with) throws IOException {
+    protected static void withEntry(ArchiveContext context, TarArchiveEntry entry, WithEntry with) throws IOException {
         try {
             TarArchiveOutputStream taos = context.getOutputStream();
             DigestOutputStream dos = new DigestOutputStream(taos, MessageDigest.getInstance("SHA1"));
@@ -147,7 +151,7 @@ public abstract class AbstractArchiveBasedConfigItem extends AbstractResourceRoo
         }
     };
 
-    protected TarArchiveEntry getDefaultEntry(ArchiveContext context, String name, long size) {
+    protected static TarArchiveEntry getDefaultEntry(ArchiveContext context, String name, long size) {
         StringBuilder entryName = new StringBuilder(context.getRequest().getItemName());
         entryName.append("-").append(context.getVersion());
         if (!name.startsWith(File.separator)) {

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/server/model/impl/LocalArchiveConfigItem.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/server/model/impl/LocalArchiveConfigItem.java
@@ -1,5 +1,6 @@
 package io.cattle.platform.configitem.server.model.impl;
 
+import io.cattle.platform.configitem.model.ItemVersion;
 import io.cattle.platform.configitem.server.model.Request;
 import io.cattle.platform.configitem.version.ConfigItemStatusManager;
 
@@ -10,8 +11,10 @@ import java.io.OutputStream;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.zip.GZIPOutputStream;
 
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.NullOutputStream;
 
@@ -45,9 +48,38 @@ public class LocalArchiveConfigItem extends AbstractConfigItem {
     @Override
     public void handleRequest(Request req) throws IOException {
         req.setContentType("application/octet-stream");
-        OutputStream os = req.getOutputStream();
-        os.write(String.format("version:%s\n", getVersion(req)).getBytes("UTF-8"));
-        copyFile(os);
+
+        if (!upToDate(req)) {
+            OutputStream os = req.getOutputStream();
+            os.write(String.format("version:%s\n", getVersion(req)).getBytes("UTF-8"));
+            copyFile(os);
+        }
+    }
+
+    protected boolean upToDate(Request req) throws IOException {
+        ItemVersion current = req.getCurrentVersion();
+        String version = getVersion(req);
+
+        if (current != null && current.toExternalForm().equals(version)) {
+            OutputStream os = req.getOutputStream();
+            GZIPOutputStream gzos = new GZIPOutputStream(os);
+            TarArchiveOutputStream taos = null;
+            try {
+                taos = new TarArchiveOutputStream(gzos);
+                taos.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
+
+                ArchiveContext context = new ArchiveContext(req, taos, version);
+                AbstractArchiveBasedConfigItem.writeUpToDate(context);
+                AbstractArchiveBasedConfigItem.writeVersion(context);
+                AbstractArchiveBasedConfigItem.writeHashes(context);
+            } finally {
+                IOUtils.closeQuietly(taos);
+            }
+
+            return true;
+        }
+
+        return false;
     }
 
     protected void copyFile(OutputStream os) throws IOException {

--- a/resources/content/config-content/configscripts/config.sh
+++ b/resources/content/config-content/configscripts/config.sh
@@ -155,13 +155,16 @@ download()
 
     content_root=${DOWNLOAD}/$name/${dir}
 
+    if [ -e ${DOWNLOAD_TEMP}/${dir}/uptodate ] && [ -e ${DOWNLOAD_TEMP}/${dir}/version ] && [ ! -e ${content_root}/version ]; then
+        cp ${DOWNLOAD_TEMP}/${dir}/version ${content_root}/version
+    fi
+
     if [ -e ${DOWNLOAD_TEMP}/${dir}/uptodate ] && [ -e ${content_root}/version ]; then
         UPTODATE=true
         VERSION=$(<${content_root}/version)
         info "Already up to date"
         return 0
     fi
-
 
     if [ -e ${content_root} ]; then
         rm -rf ${content_root}


### PR DESCRIPTION
This addresses two things.  First, when doing a config.update (or migration) we make sure that `configscripts` is ran first if its in the list of things to update.  Second, we support caching artifacts locally for artifacts that are stored in rancher/server.  For example, before this change `rancher-dns` would always be downloaded even though it didn't change.  After this change we only download if it really changed.