### PR TITLE
Random idea for improving test performance

### DIFF
--- a/code/implementation/simulator/agent-connection/src/main/java/io/cattle/platform/agent/connection/simulator/AgentConnectionSimulator.java
+++ b/code/implementation/simulator/agent-connection/src/main/java/io/cattle/platform/agent/connection/simulator/AgentConnectionSimulator.java
@@ -18,7 +18,7 @@ public class AgentConnectionSimulator implements AgentConnection {
     Agent agent;
     boolean open = true;
     List<AgentSimulatorEventProcessor> processors;
-    Map<String, String> instances = new HashMap<String, String>();
+    Map<String, String[]> instances = new HashMap<String, String[]>();
 
     public AgentConnectionSimulator(Agent agent, List<AgentSimulatorEventProcessor> processors) {
         super();
@@ -66,7 +66,7 @@ public class AgentConnectionSimulator implements AgentConnection {
         return agent;
     }
 
-    public Map<String, String> getInstances() {
+    public Map<String, String[]> getInstances() {
         return instances;
     }
 

--- a/code/implementation/simulator/agent-connection/src/main/java/io/cattle/platform/agent/connection/simulator/impl/SimulatorPingProcessor.java
+++ b/code/implementation/simulator/agent-connection/src/main/java/io/cattle/platform/agent/connection/simulator/impl/SimulatorPingProcessor.java
@@ -50,9 +50,9 @@ public class SimulatorPingProcessor implements AgentSimulatorEventProcessor {
     protected void addInstances(AgentConnectionSimulator simulator, Ping pong, Agent agent) {
         List<Map<String, Object>> resources = pong.getData().getResources();
 
-        for (Map.Entry<String, String> kv : simulator.getInstances().entrySet()) {
+        for (Map.Entry<String, String[]> kv : simulator.getInstances().entrySet()) {
             Map<String, Object> instanceMap = CollectionUtils.asMap(ObjectMetaDataManager.TYPE_FIELD, InstanceConstants.TYPE, ObjectMetaDataManager.UUID_FIELD,
-                    kv.getKey(), ObjectMetaDataManager.STATE_FIELD, kv.getValue());
+                    kv.getKey(), ObjectMetaDataManager.STATE_FIELD, kv.getValue()[0], "dockerId", kv.getValue()[1]);
             resources.add(instanceMap);
         }
 

--- a/tests/integration/cattletest/core/common_fixtures.py
+++ b/tests/integration/cattletest/core/common_fixtures.py
@@ -200,6 +200,7 @@ def create_context(admin_user_client, create_project=False, add_host=False,
 def cleanup_context(admin_user_client, context):
     purge_account(admin_user_client, context.project)
     purge_account(admin_user_client, context.account)
+    purge_containers(context)
 
 
 def purge_account(admin_user_client, account):
@@ -214,6 +215,20 @@ def purge_account(admin_user_client, account):
                 admin_user_client.wait_success(account)
         except:
             pass
+
+
+def purge_containers(context):
+    client = context.client
+    for container in client.list_container():
+        for action in ['stop', 'remove', 'purge']:
+            if action not in container:
+                continue
+            try:
+                container = container[action]()
+                if action != 'purge':
+                    client.wait_success(container)
+            except:
+                pass
 
 
 def register_simulated_host(client_or_context, return_agent=False):

--- a/tests/integration/cattletest/core/test_allocation.py
+++ b/tests/integration/cattletest/core/test_allocation.py
@@ -130,6 +130,10 @@ def test_allocation_failed_on_start(super_client, new_context):
     assert c1.transitioning == 'no'
     assert c1.transitioningMessage is None
 
+    c2 = client.wait_success(c2.remove())
+    c2 = client.wait_success(c2.purge())
+    assert c2.state == 'purged'
+
 
 def test_host_vnet_association(super_client, new_context):
     account = new_context.project


### PR DESCRIPTION
If we explictly purge containers when we clean up a context, maybe
their later deletion and puring wont interfere with other tests.