### PR TITLE
Put rancher-metadata to default section of answers.json

### DIFF
--- a/resources/content/config-content/hosts/content-home/etc/cattle/dns/answers.json.ftl
+++ b/resources/content/config-content/hosts/content-home/etc/cattle/dns/answers.json.ftl
@@ -2,7 +2,11 @@
     "default": {
         "recurse": [
             PARENT_DNS
-        ]
+        ],
+        "a": {
+        	"rancher-metadata.": {"answer": ["169.254.169.250"]},
+		"rancher-metadata.rancher.internal.": {"answer": ["169.254.169.250"]}
+		}
     },
 <#if dnsEntries?? >
     <#list dnsEntries as dnsEntry>


### PR DESCRIPTION
So standalone containers can also resolve it