### PR TITLE
Metadata fixes

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/MetaDataInfoDao.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/MetaDataInfoDao.java
@@ -6,8 +6,6 @@ import java.util.List;
 
 public interface MetaDataInfoDao {
 
-    List<ContainerMetaData> getServicesContainersData(long accountId);
-
-    List<ContainerMetaData> getStandaloneContainersData(long accountId);
+    List<ContainerMetaData> getContainersData(long accountId);
 
 }

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/MetaDataInfoDaoImpl.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/MetaDataInfoDaoImpl.java
@@ -29,10 +29,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.jooq.JoinType;
+
 @SuppressWarnings("unchecked")
 public class MetaDataInfoDaoImpl extends AbstractJooqDao implements MetaDataInfoDao {
     @Override
-    public List<ContainerMetaData> getServicesContainersData(long accountId) {
+    public List<ContainerMetaData> getContainersData(long accountId) {
         MultiRecordMapper<ContainerMetaData> mapper = new MultiRecordMapper<ContainerMetaData>() {
             @Override
             protected ContainerMetaData map(List<Object> input) {
@@ -80,60 +82,8 @@ public class MetaDataInfoDaoImpl extends AbstractJooqDao implements MetaDataInfo
                 .on(instanceIpAddress.ID.eq(IP_ADDRESS_NIC_MAP.IP_ADDRESS_ID))
                 .join(instance)
                 .on(instance.ID.eq(INSTANCE_HOST_MAP.INSTANCE_ID))
-                .join(exposeMap)
+                .join(exposeMap, JoinType.LEFT_OUTER_JOIN)
                 .on(exposeMap.INSTANCE_ID.eq(instance.ID))
-                .where(host.REMOVED.isNull())
-                .and(instance.ACCOUNT_ID.eq(accountId))
-                .and(instanceIpAddress.ROLE.eq(IpAddressConstants.ROLE_PRIMARY))
-                .and(instance.REMOVED.isNull())
-                .fetch().map(mapper);
-    }
-
-    @Override
-    public List<ContainerMetaData> getStandaloneContainersData(long accountId) {
-        MultiRecordMapper<ContainerMetaData> mapper = new MultiRecordMapper<ContainerMetaData>() {
-            @Override
-            protected ContainerMetaData map(List<Object> input) {
-                ContainerMetaData data = new ContainerMetaData();
-                data.setInstance((Instance) input.get(1));
-                data.setIp((IpAddress) input.get(3));
-                if (input.get(2) != null) {
-                    Host host = (Host) input.get(2);
-                    IpAddress hostIpAddress = (IpAddress) input.get(0);
-                    if (host != null) {
-                        Map<String, String> hostLabels = DataAccessor.fields(host)
-                                .withKey(InstanceConstants.FIELD_LABELS)
-                                .withDefault(Collections.EMPTY_MAP).as(Map.class);
-                        HostMetaData hostMetaData = new HostMetaData(hostIpAddress.getAddress(), host.getName(),
-                                hostLabels, host.getId());
-                        data.setHostMetaData(hostMetaData);
-                    }
-                }
-                return data;
-            }
-        };
-
-        IpAddressTable hostIpAddress = mapper.add(IP_ADDRESS);
-        InstanceTable instance = mapper.add(INSTANCE);
-        HostTable host = mapper.add(HOST);
-        IpAddressTable instanceIpAddress = mapper.add(IP_ADDRESS);
-        return create()
-                .select(mapper.fields())
-                .from(hostIpAddress)
-                .join(HOST_IP_ADDRESS_MAP)
-                .on(HOST_IP_ADDRESS_MAP.IP_ADDRESS_ID.eq(hostIpAddress.ID))
-                .join(host)
-                .on(host.ID.eq(HOST_IP_ADDRESS_MAP.HOST_ID))
-                .join(INSTANCE_HOST_MAP)
-                .on(host.ID.eq(INSTANCE_HOST_MAP.HOST_ID))
-                .join(NIC)
-                .on(NIC.INSTANCE_ID.eq(INSTANCE_HOST_MAP.INSTANCE_ID))
-                .join(IP_ADDRESS_NIC_MAP)
-                .on(IP_ADDRESS_NIC_MAP.NIC_ID.eq(NIC.ID))
-                .join(instanceIpAddress)
-                .on(instanceIpAddress.ID.eq(IP_ADDRESS_NIC_MAP.IP_ADDRESS_ID))
-                .join(instance)
-                .on(instance.ID.eq(INSTANCE_HOST_MAP.INSTANCE_ID))
                 .where(host.REMOVED.isNull())
                 .and(instance.ACCOUNT_ID.eq(accountId))
                 .and(instanceIpAddress.ROLE.eq(IpAddressConstants.ROLE_PRIMARY))

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/MetaDataInfoDaoImpl.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/MetaDataInfoDaoImpl.java
@@ -39,8 +39,8 @@ public class MetaDataInfoDaoImpl extends AbstractJooqDao implements MetaDataInfo
             @Override
             protected ContainerMetaData map(List<Object> input) {
                 ContainerMetaData data = new ContainerMetaData();
-                data.setInstance((Instance) input.get(1));
                 data.setIp((IpAddress) input.get(3));
+                HostMetaData hostMetaData = null;
                 if (input.get(2) != null) {
                     Host host = (Host) input.get(2);
                     IpAddress hostIpAddress = (IpAddress) input.get(0);
@@ -48,11 +48,12 @@ public class MetaDataInfoDaoImpl extends AbstractJooqDao implements MetaDataInfo
                         Map<String, String> hostLabels = DataAccessor.fields(host)
                                 .withKey(InstanceConstants.FIELD_LABELS)
                                 .withDefault(Collections.EMPTY_MAP).as(Map.class);
-                        HostMetaData hostMetaData = new HostMetaData(hostIpAddress.getAddress(), host.getName(),
+                        hostMetaData = new HostMetaData(hostIpAddress.getAddress(), host.getName(),
                                 hostLabels, host.getId());
-                        data.setHostMetaData(hostMetaData);
                     }
                 }
+                data.setInstanceAndHostMetadata((Instance) input.get(1), hostMetaData);
+
                 if (input.get(4) != null) {
                     data.setExposeMap((ServiceExposeMap) input.get(4));
                 }

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/ContainerMetaData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/ContainerMetaData.java
@@ -66,7 +66,8 @@ public class ContainerMetaData {
     }
 
     @SuppressWarnings("unchecked")
-    public void setInstance(Instance instance) {
+    public void setInstanceAndHostMetadata(Instance instance, HostMetaData hostMetaData) {
+        this.hostMetaData = hostMetaData;
         this.name = instance.getName();
         Map<String, String> labels = DataAccessor.fields(instance).withKey(InstanceConstants.FIELD_LABELS)
                 .withDefault(Collections.EMPTY_MAP).as(Map.class);
@@ -93,10 +94,6 @@ public class ContainerMetaData {
 
     public void setStack_name(String stack_name) {
         this.stack_name = stack_name;
-    }
-
-    public void setHostMetaData(HostMetaData hostMetaData) {
-        this.hostMetaData = hostMetaData;
     }
 
     public void setExposeMap(ServiceExposeMap exposeMap) {

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/ServiceMetaData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/ServiceMetaData.java
@@ -45,7 +45,7 @@ public class ServiceMetaData {
                 : serviceName;
         this.labels = ServiceDiscoveryUtil.getLaunchConfigLabels(service, launchConfigName);
         populateExternalServiceInfo(service);
-        populatePortsInfo(service, serviceName);
+        populatePortsInfo(service, launchConfigName);
         this.create_index = service.getCreateIndex();
     }
 

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/ServiceMetadataInfoFactory.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/ServiceMetadataInfoFactory.java
@@ -55,8 +55,7 @@ public class ServiceMetadataInfoFactory extends AbstractAgentBaseContextFactory 
     @Override
     protected void populateContext(Agent agent, Instance instance, ConfigItem item, ArchiveContext context) {
         Account account = objectManager.loadResource(Account.class, instance.getAccountId());
-        List<ContainerMetaData> containersMetaData = metaDataInfoDao.getServicesContainersData(account.getId());
-        containersMetaData.addAll(metaDataInfoDao.getStandaloneContainersData(account.getId()));
+        List<ContainerMetaData> containersMetaData = metaDataInfoDao.getContainersData(account.getId());
 
         Map<String, StackMetaData> stacks = new HashMap<>();
         Map<Long, Map<String, ServiceMetaData>> services = new HashMap<>();
@@ -64,6 +63,7 @@ public class ServiceMetadataInfoFactory extends AbstractAgentBaseContextFactory 
         populateStacksServicesInfo(account, stacks, services);
         for (ContainerMetaData containerMetaData : containersMetaData) {
             ServiceMetaData svcData = null;
+            StackMetaData stackData = null;
             if (containerMetaData.getServiceId() != null) {
                 String configName = containerMetaData.getDnsPrefix();
                 if (configName == null) {
@@ -74,14 +74,12 @@ public class ServiceMetadataInfoFactory extends AbstractAgentBaseContextFactory 
                     svcData = svcsData.get(configName);
                     containerMetaData.setStack_name(svcData.getName());
                     containerMetaData.setService_name(svcData.getStack_name());
-                    addContainerToSelf(self, containerMetaData, svcData, stacks.get(svcData.getStack_name()), getInstanceHostId(instance));
                     svcData.addToContainer(containerMetaData.getName());
+                    stackData = stacks.get(svcData.getStack_name());
                 }
             }
 
-            if (svcData == null) {
-                addContainerToSelf(self, containerMetaData, null, null, getInstanceHostId(instance));
-            }
+            addContainerToSelf(self, containerMetaData, svcData, stackData, getInstanceHostId(instance));
         }
         
         List<ServiceMetaData> servicesMD = new ArrayList<>();


### PR DESCRIPTION
1) Populate stack and service info for the instance.
Also use one method for getting service and non service instance using outer join with service/instance map table, instead of having separate methods. Because latter caused the bug when service instance was returned as a standalone one, and it caused duplicated entries for the same instance to be present in the answers.json file

https://github.com/rancher/rancher/issues/1880
https://github.com/rancher/rancher/issues/1882

2) Fixed bug in setting ports metadata for service and container

https://github.com/rancher/rancher/issues/1883