### PR TITLE
More metadata bug fixes

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/ServiceMetaData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/ServiceMetaData.java
@@ -127,6 +127,7 @@ public class ServiceMetaData {
         return isPrimaryConfig;
     }
 
+    @JsonIgnore
     public Long getCreate_index() {
         return create_index;
     }

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/ServiceMetaData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/ServiceMetaData.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 public class ServiceMetaData {
     private Long serviceId;
     private boolean isPrimaryConfig;
+    String launchConfigName;
     
     String name;
     String stack_name;
@@ -31,18 +32,17 @@ public class ServiceMetaData {
     List<String> ports = new ArrayList<>();
     Map<String, String> labels;
 
-    public ServiceMetaData(Service service, String serviceName, Environment env, Map<String, String> links,
-            List<String> sidekicks) {
+    public ServiceMetaData(Service service, String serviceName, Environment env, List<String> sidekicks) {
         this.serviceId = service.getId();
         this.name = serviceName;
         this.stack_name = env.getName();
         this.kind = service.getKind();
         this.sidekicks = sidekicks;
-        this.links = links;
         this.vip = service.getVip();
         this.isPrimaryConfig = service.getName().equalsIgnoreCase(serviceName);
         String launchConfigName = this.isPrimaryConfig ? ServiceDiscoveryConstants.PRIMARY_LAUNCH_CONFIG_NAME
                 : serviceName;
+        this.launchConfigName = launchConfigName;
         this.labels = ServiceDiscoveryUtil.getLaunchConfigLabels(service, launchConfigName);
         populateExternalServiceInfo(service);
         populatePortsInfo(service, launchConfigName);
@@ -129,5 +129,14 @@ public class ServiceMetaData {
 
     public Long getCreate_index() {
         return create_index;
+    }
+
+    public void setLinks(Map<String, String> links) {
+        this.links = links;
+    }
+
+    @JsonIgnore
+    public String getLaunchConfigName() {
+        return launchConfigName;
     }
 }

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/ServiceMetadataInfoFactory.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/ServiceMetadataInfoFactory.java
@@ -84,7 +84,10 @@ public class ServiceMetadataInfoFactory extends AbstractAgentBaseContextFactory 
         
         List<ServiceMetaData> servicesMD = new ArrayList<>();
         for (Map<String, ServiceMetaData> service : services.values()) {
-            servicesMD.addAll(service.values());
+            for (ServiceMetaData svcData : service.values()) {
+                setLinksInfo(services, svcData);
+                servicesMD.add(svcData);
+            }
         }
 
         List<StackMetaData> stacksMD = new ArrayList<>();
@@ -191,14 +194,12 @@ public class ServiceMetadataInfoFactory extends AbstractAgentBaseContextFactory 
         String serviceName = isPrimaryConfig ? service.getName()
                 : launchConfigName;
         List<String> sidekicks = new ArrayList<>();
-        Map<String, String> links = new HashMap<>();
         
         if (isPrimaryConfig) {
-            getLinksInfo(idToService, service, links);
             getSidekicksInfo(service, sidekicks, launchConfigNames);
         }
 
-        ServiceMetaData svcMetaData = new ServiceMetaData(service, serviceName, env, links, sidekicks);
+        ServiceMetaData svcMetaData = new ServiceMetaData(service, serviceName, env, sidekicks);
         stackServices.add(svcMetaData);
     }
 
@@ -210,16 +211,20 @@ public class ServiceMetadataInfoFactory extends AbstractAgentBaseContextFactory 
         }
     }
 
-    protected void getLinksInfo(Map<Long, Service> idToService, Service service, Map<String, String> links) {
-        List<? extends ServiceConsumeMap> consumedMaps = consumeMapDao.findConsumedServices(service.getId());
+    protected void setLinksInfo(Map<Long, Map<String, ServiceMetaData>> services,
+            ServiceMetaData serviceMD) {
+        Map<String, String> links = new HashMap<>();
+        List<? extends ServiceConsumeMap> consumedMaps = consumeMapDao.findConsumedServices(serviceMD.getServiceId());
         for (ServiceConsumeMap consumedMap : consumedMaps) {
-            Service consumedService = idToService.get(consumedMap.getConsumedServiceId());
-            if (consumedService == null) {
-                consumedService = objectManager.loadResource(Service.class, consumedMap.getConsumedServiceId());
-                idToService.put(consumedService.getId(), consumedService);
-            }
-            links.put(ServiceDiscoveryUtil.getDnsName(service, consumedMap, null, false), consumedService.getName());
+            Service service = objectManager.loadResource(Service.class, consumedMap.getConsumedServiceId());
+            ServiceMetaData consumedServiceData = services.get(service.getId()).get(
+                    serviceMD.getLaunchConfigName());
+            links.put(
+                    consumedServiceData.getStack_name() + "/"
+                            + ServiceDiscoveryUtil.getDnsName(service, consumedMap, null, false),
+                    consumedMap.getName());
         }
+        serviceMD.setLinks(links);
     }
 
     protected long getInstanceHostId(Instance instance) {

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/ServiceMetadataInfoFactory.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/ServiceMetadataInfoFactory.java
@@ -72,8 +72,8 @@ public class ServiceMetadataInfoFactory extends AbstractAgentBaseContextFactory 
                 Map<String, ServiceMetaData> svcsData = services.get(containerMetaData.getServiceId());
                 if (svcsData != null) {
                     svcData = svcsData.get(configName);
-                    containerMetaData.setStack_name(svcData.getName());
-                    containerMetaData.setService_name(svcData.getStack_name());
+                    containerMetaData.setStack_name(svcData.getStack_name());
+                    containerMetaData.setService_name(svcData.getName());
                     svcData.addToContainer(containerMetaData.getName());
                     stackData = stacks.get(svcData.getStack_name());
                 }
@@ -219,10 +219,9 @@ public class ServiceMetadataInfoFactory extends AbstractAgentBaseContextFactory 
             Service service = objectManager.loadResource(Service.class, consumedMap.getConsumedServiceId());
             ServiceMetaData consumedServiceData = services.get(service.getId()).get(
                     serviceMD.getLaunchConfigName());
+            String linkAlias = ServiceDiscoveryUtil.getDnsName(service, consumedMap, null, false);
             links.put(
-                    consumedServiceData.getStack_name() + "/"
-                            + ServiceDiscoveryUtil.getDnsName(service, consumedMap, null, false),
-                    consumedMap.getName());
+                    consumedServiceData.getStack_name() + "/" + consumedServiceData.getName(), linkAlias);
         }
         serviceMD.setLinks(links);
     }


### PR DESCRIPTION
1) Include stack name to the link name:

https://github.com/rancher/rancher/issues/1887

looks like https://github.com/rancher/rancher/issues/1889 has been fixed along the way

2) Fixed swapped stack_name and service_name for container:

https://github.com/rancher/rancher/issues/1888

3) Don't include createIndex to service metadata, keep it in container metadata only as its more relevant there. We can always add it on per user request later.

https://github.com/rancher/rancher/issues/1891