### PR TITLE
SSL Termination bug fixes

### DIFF
--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/ssl/CertificateCreateValidationFilter.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/ssl/CertificateCreateValidationFilter.java
@@ -5,9 +5,11 @@ import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.iaas.api.filter.common.AbstractDefaultResourceManagerFilter;
 import io.cattle.platform.object.util.DataUtils;
 import io.cattle.platform.ssh.common.SslCertificateUtils;
+import io.github.ibuildthecloud.gdapi.exception.ClientVisibleException;
 import io.github.ibuildthecloud.gdapi.exception.ValidationErrorException;
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 import io.github.ibuildthecloud.gdapi.request.resource.ResourceManager;
+import io.github.ibuildthecloud.gdapi.util.ResponseCodes;
 import io.github.ibuildthecloud.gdapi.validation.ValidationErrorCodes;
 
 import org.apache.commons.lang3.StringUtils;
@@ -56,7 +58,8 @@ public class CertificateCreateValidationFilter extends AbstractDefaultResourceMa
             DataUtils.getWritableFields(certificate).put("subjectAlternativeNames",
                     SslCertificateUtils.getSubjectAlternativeNames(cert));
         } catch (Exception e) {
-            throw new ValidationErrorException(ValidationErrorCodes.INVALID_FORMAT, "cert");
+            throw new ClientVisibleException(ResponseCodes.UNPROCESSABLE_ENTITY, ValidationErrorCodes.INVALID_FORMAT,
+                    e.getMessage(), null);
         }
 
         return super.create(type, request, next);
@@ -68,7 +71,8 @@ public class CertificateCreateValidationFilter extends AbstractDefaultResourceMa
                 SslCertificateUtils.verifySelfSignedCertificate(cert, key);
             }
         } catch (Exception e) {
-            throw new ValidationErrorException(ValidationErrorCodes.INVALID_FORMAT, "cert");
+            throw new ClientVisibleException(ResponseCodes.UNPROCESSABLE_ENTITY, ValidationErrorCodes.INVALID_FORMAT,
+                    e.getMessage(), null);
         }
 
         try {
@@ -76,7 +80,8 @@ public class CertificateCreateValidationFilter extends AbstractDefaultResourceMa
                 SslCertificateUtils.verifyCertificateChain(cert, certChain, key);
             }
         } catch (Exception e) {
-            throw new ValidationErrorException(ValidationErrorCodes.INVALID_FORMAT, "certChain");
+            throw new ClientVisibleException(ResponseCodes.UNPROCESSABLE_ENTITY, ValidationErrorCodes.INVALID_FORMAT,
+                    e.getMessage(), null);
         }
     }
 }

--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/ssl/CertificateCreateValidationFilter.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/ssl/CertificateCreateValidationFilter.java
@@ -6,7 +6,6 @@ import io.cattle.platform.iaas.api.filter.common.AbstractDefaultResourceManagerF
 import io.cattle.platform.object.util.DataUtils;
 import io.cattle.platform.ssh.common.SslCertificateUtils;
 import io.github.ibuildthecloud.gdapi.exception.ClientVisibleException;
-import io.github.ibuildthecloud.gdapi.exception.ValidationErrorException;
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 import io.github.ibuildthecloud.gdapi.request.resource.ResourceManager;
 import io.github.ibuildthecloud.gdapi.util.ResponseCodes;

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/ServiceMetadataInfoFactory.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/ServiceMetadataInfoFactory.java
@@ -217,7 +217,11 @@ public class ServiceMetadataInfoFactory extends AbstractAgentBaseContextFactory 
         List<? extends ServiceConsumeMap> consumedMaps = consumeMapDao.findConsumedServices(serviceMD.getServiceId());
         for (ServiceConsumeMap consumedMap : consumedMaps) {
             Service service = objectManager.loadResource(Service.class, consumedMap.getConsumedServiceId());
-            ServiceMetaData consumedServiceData = services.get(service.getId()).get(
+            Map<String, ServiceMetaData> consumedService = services.get(service.getId());
+            if (consumedService == null) {
+                continue;
+            }
+            ServiceMetaData consumedServiceData = consumedService.get(
                     serviceMD.getLaunchConfigName());
             String linkAlias = ServiceDiscoveryUtil.getDnsName(service, consumedMap, null, false);
             links.put(

--- a/code/iaas/lb-logic/src/main/resources/META-INF/cattle/system-services/spring-lb-context.xml
+++ b/code/iaas/lb-logic/src/main/resources/META-INF/cattle/system-services/spring-lb-context.xml
@@ -29,7 +29,7 @@
     <bean class="io.cattle.iaas.lb.api.action.LoadBalancerRemoveTargetActionHandler" />
     <bean class="io.cattle.iaas.lb.api.action.LoadBalancerAddHostActionHandler" />
     <bean class="io.cattle.iaas.lb.api.action.LoadBalancerRemoveHostActionHandler" />
-    
+        
     <bean class="io.cattle.iaas.lb.api.service.impl.LoadBalancerApiServiceImpl" />
     
 

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/LoadBalancerServiceCertificateRemoveFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/LoadBalancerServiceCertificateRemoveFilter.java
@@ -13,13 +13,13 @@ import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 import io.github.ibuildthecloud.gdapi.request.resource.ResourceManager;
 import io.github.ibuildthecloud.gdapi.util.ResponseCodes;
 import io.github.ibuildthecloud.gdapi.validation.ValidationErrorCodes;
-import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang.StringUtils;
 
 public class LoadBalancerServiceCertificateRemoveFilter extends AbstractDefaultResourceManagerFilter {
     @Inject

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/LoadBalancerServiceCertificateRemoveFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/LoadBalancerServiceCertificateRemoveFilter.java
@@ -1,0 +1,61 @@
+package io.cattle.platform.servicediscovery.api.filter;
+
+import static io.cattle.platform.core.model.tables.LoadBalancerTable.LOAD_BALANCER;
+import io.cattle.platform.core.dao.GenericMapDao;
+import io.cattle.platform.core.model.Certificate;
+import io.cattle.platform.core.model.LoadBalancer;
+import io.cattle.platform.core.model.LoadBalancerCertificateMap;
+import io.cattle.platform.core.model.Service;
+import io.cattle.platform.iaas.api.filter.common.AbstractDefaultResourceManagerFilter;
+import io.cattle.platform.object.ObjectManager;
+import io.github.ibuildthecloud.gdapi.exception.ClientVisibleException;
+import io.github.ibuildthecloud.gdapi.request.ApiRequest;
+import io.github.ibuildthecloud.gdapi.request.resource.ResourceManager;
+import io.github.ibuildthecloud.gdapi.util.ResponseCodes;
+import io.github.ibuildthecloud.gdapi.validation.ValidationErrorCodes;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+
+public class LoadBalancerServiceCertificateRemoveFilter extends AbstractDefaultResourceManagerFilter {
+    @Inject
+    ObjectManager objectManager;
+    @Inject
+    GenericMapDao mapDao;
+
+    @Override
+    public Class<?>[] getTypeClasses() {
+        return new Class<?>[] { Certificate.class };
+    }
+
+    @Override
+    public Object delete(String type, String id, ApiRequest request, ResourceManager next) {
+        Certificate cert = objectManager.loadResource(Certificate.class, id);
+        List<String> serviceNames = new ArrayList<>();
+        List<? extends LoadBalancerCertificateMap> mapsToRemove = mapDao.findNonRemoved(
+                LoadBalancerCertificateMap.class,
+                Certificate.class, cert.getId());
+        for (LoadBalancerCertificateMap mapToRemove : mapsToRemove) {
+            LoadBalancer lb = objectManager.findOne(LoadBalancer.class, LOAD_BALANCER.ID,
+                    mapToRemove.getLoadBalancerId(), LOAD_BALANCER.REMOVED, null);
+            if (lb == null) {
+                continue;
+            }
+            Service service = objectManager.loadResource(Service.class, lb.getServiceId());
+            if (service != null) {
+                serviceNames.add(service.getName());
+            }
+        }
+        if (!serviceNames.isEmpty()) {
+            String serviceNameStr = StringUtils.join(serviceNames, ",");
+            throw new ClientVisibleException(ResponseCodes.METHOD_NOT_ALLOWED, ValidationErrorCodes.INVALID_ACTION,
+                    "Certificate is in use by load balancer services: " + serviceNameStr, null);
+        }
+
+        return super.delete(type, id, request, next);
+    }
+}

--- a/code/iaas/service-discovery/api/src/main/resources/META-INF/cattle/api-server/spring-service-discovery-api-context.xml
+++ b/code/iaas/service-discovery/api/src/main/resources/META-INF/cattle/api-server/spring-service-discovery-api-context.xml
@@ -19,6 +19,7 @@
        <bean class="io.cattle.platform.servicediscovery.api.filter.ServiceSetServiceLinksValidationFilter" />
        <bean class="io.cattle.platform.servicediscovery.api.filter.ServiceLoadBalancerRemoveValidationFilter" />
        <bean class="io.cattle.platform.servicediscovery.api.filter.ServiceOutputFilter" />
+       <bean class="io.cattle.platform.servicediscovery.api.filter.LoadBalancerServiceCertificateRemoveFilter" />
        
        <bean class="io.cattle.platform.servicediscovery.api.service.impl.ServiceDiscoveryApiServiceImpl" />
        

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceUpdate.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceUpdate.java
@@ -37,16 +37,15 @@ public class LoadBalancerServiceUpdate extends AbstractObjectProcessHandler impl
     public HandlerResult handle(ProcessState state, ProcessInstance process) {
         Service service = (Service) state.getResource();
         if (service.getKind().equalsIgnoreCase(KIND.LOADBALANCERSERVICE.name())) {
-            DataAccessor certIdsObj = DataAccessor.fromMap(state.getData())
-                    .withKey(LoadBalancerConstants.FIELD_LB_CERTIFICATE_IDS);
-            DataAccessor defaultCertIdObj = DataAccessor.fromMap(state.getData())
-                    .withKey(LoadBalancerConstants.FIELD_LB_DEFAULT_CERTIFICATE_ID);
-            if (certIdsObj == null && defaultCertIdObj == null) {
+            if (!state.getData().containsKey(LoadBalancerConstants.FIELD_LB_CERTIFICATE_IDS)
+                    && !state.getData().containsKey(LoadBalancerConstants.FIELD_LB_DEFAULT_CERTIFICATE_ID)) {
                 return null;
             }
 
-            List<? extends Long> certIds = certIdsObj.asList(jsonMapper, Long.class);
-            Long defaultCertId = defaultCertIdObj.as(Long.class);
+            List<? extends Long> certIds = DataAccessor.fromMap(state.getData())
+                    .withKey(LoadBalancerConstants.FIELD_LB_CERTIFICATE_IDS).asList(jsonMapper, Long.class);
+            Long defaultCertId = DataAccessor.fromMap(state.getData())
+                    .withKey(LoadBalancerConstants.FIELD_LB_DEFAULT_CERTIFICATE_ID).as(Long.class);
 
             sdService.updateLoadBalancerService(service, certIds, defaultCertId);
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceUpdate.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceUpdate.java
@@ -14,7 +14,6 @@ import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstan
 import io.cattle.platform.servicediscovery.service.ServiceDiscoveryService;
 import io.cattle.platform.util.type.Priority;
 
-import java.util.Collections;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -38,12 +37,19 @@ public class LoadBalancerServiceUpdate extends AbstractObjectProcessHandler impl
     public HandlerResult handle(ProcessState state, ProcessInstance process) {
         Service service = (Service) state.getResource();
         if (service.getKind().equalsIgnoreCase(KIND.LOADBALANCERSERVICE.name())) {
-            List<? extends Long> certIds = DataAccessor.fromMap(state.getData())
-                    .withKey(LoadBalancerConstants.FIELD_LB_CERTIFICATE_IDS).withDefault(Collections.EMPTY_LIST)
-                    .asList(jsonMapper, Long.class);
-            Long defaultCertId = DataAccessor.fromMap(state.getData())
-                    .withKey(LoadBalancerConstants.FIELD_LB_DEFAULT_CERTIFICATE_ID).as(Long.class);
+            DataAccessor certIdsObj = DataAccessor.fromMap(state.getData())
+                    .withKey(LoadBalancerConstants.FIELD_LB_CERTIFICATE_IDS);
+            DataAccessor defaultCertIdObj = DataAccessor.fromMap(state.getData())
+                    .withKey(LoadBalancerConstants.FIELD_LB_DEFAULT_CERTIFICATE_ID);
+            if (certIdsObj == null && defaultCertIdObj == null) {
+                return null;
+            }
+
+            List<? extends Long> certIds = certIdsObj.asList(jsonMapper, Long.class);
+            Long defaultCertId = defaultCertIdObj.as(Long.class);
+
             sdService.updateLoadBalancerService(service, certIds, defaultCertId);
+
         }
         return null;
     }

--- a/resources/content/config-content/haproxy/apply.sh
+++ b/resources/content/config-content/haproxy/apply.sh
@@ -2,6 +2,7 @@
 
 . ${CATTLE_HOME:-/var/lib/cattle}/common/scripts.sh
 
+rm -rf /etc/haproxy/certs/*
 stage_files
 
 awk '/BEGIN RSA PRIVATE KEY/{i++}{print > "/etc/haproxy/certs/server"i".pem"}' /etc/haproxy/certs/certs.pem

--- a/tests/integration/cattletest/core/test_cert.py
+++ b/tests/integration/cattletest/core/test_cert.py
@@ -40,7 +40,6 @@ def test_create_cert_invalid_key(client):
                                key=key)
     assert e.value.error.status == 422
     assert e.value.error.code == 'InvalidFormat'
-    assert e.value.error.fieldName == 'cert'
 
 
 def test_create_cert_invalid_cert(client):
@@ -53,7 +52,6 @@ def test_create_cert_invalid_cert(client):
                                key=key)
     assert e.value.error.status == 422
     assert e.value.error.code == 'InvalidFormat'
-    assert e.value.error.fieldName == 'cert'
 
 
 def test_create_cert_chain(client):
@@ -83,7 +81,6 @@ def test_invalid_key_cert_in_cert_chain(client):
                                certChain=chain)
     assert e.value.error.status == 422
     assert e.value.error.code == 'InvalidFormat'
-    assert e.value.error.fieldName == 'certChain'
 
 
 def _read_cert(name):

--- a/tests/integration/cattletest/core/test_svc_discovery_lb.py
+++ b/tests/integration/cattletest/core/test_svc_discovery_lb.py
@@ -901,6 +901,20 @@ def test_lb_service_w_certificate(client, context, image_uuid):
     assert lb.defaultCertificateId == cert1.id
     assert lb.certificateIds == [cert1.id, cert2.id]
 
+    # remove the service
+    service = client.wait_success(service.remove())
+    assert service.state == 'removed'
+
+    wait_for_condition(
+            client, lb, _resource_is_removed,
+            lambda x: 'State is: ' + x.state)
+
+    # remove the cert
+    cert1 = client.wait_success(cert1.remove())
+    assert cert1.state == 'removed'
+    cert2 = client.wait_success(cert2.remove())
+    assert cert2.state == 'removed'
+
 
 def test_lb_service_update_certificate(client, context, image_uuid):
     cert1 = _create_cert(client)


### PR DESCRIPTION
1) Schedule LB update on cert.remove only when lb is active

https://github.com/rancher/rancher/issues/1897

2) Propagate error message thrown by certificate validation code to the API

https://github.com/rancher/rancher/issues/1900

3) Bug in update load balancer

https://github.com/rancher/rancher/issues/1899

4) Cleanup certificates dir before applying new certs

https://github.com/rancher/rancher/issues/1904

5) Disallow cert removal when assigned to the LB service

https://github.com/rancher/rancher/issues/1906

Also fixed some NPE noticed in ServiceMetadataInfoFactory.java