### PR TITLE
Service selectors

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/Service.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/Service.java
@@ -168,6 +168,28 @@ public interface Service extends java.io.Serializable {
 	@javax.persistence.Column(name = "create_index", precision = 19)
 	public java.lang.Long getCreateIndex();
 
+	/**
+	 * Setter for <code>cattle.service.selector_link</code>.
+	 */
+	public void setSelectorLink(java.lang.String value);
+
+	/**
+	 * Getter for <code>cattle.service.selector_link</code>.
+	 */
+	@javax.persistence.Column(name = "selector_link", length = 4096)
+	public java.lang.String getSelectorLink();
+
+	/**
+	 * Setter for <code>cattle.service.selector_container</code>.
+	 */
+	public void setSelectorContainer(java.lang.String value);
+
+	/**
+	 * Getter for <code>cattle.service.selector_container</code>.
+	 */
+	@javax.persistence.Column(name = "selector_container", length = 4096)
+	public java.lang.String getSelectorContainer();
+
 	// -------------------------------------------------------------------------
 	// FROM and INTO
 	// -------------------------------------------------------------------------

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/ServiceExposeMap.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/ServiceExposeMap.java
@@ -190,6 +190,17 @@ public interface ServiceExposeMap extends java.io.Serializable {
 	@javax.persistence.Column(name = "host_name", length = 255)
 	public java.lang.String getHostName();
 
+	/**
+	 * Setter for <code>cattle.service_expose_map.managed</code>.
+	 */
+	public void setManaged(java.lang.Boolean value);
+
+	/**
+	 * Getter for <code>cattle.service_expose_map.managed</code>.
+	 */
+	@javax.persistence.Column(name = "managed", nullable = false, precision = 1)
+	public java.lang.Boolean getManaged();
+
 	// -------------------------------------------------------------------------
 	// FROM and INTO
 	// -------------------------------------------------------------------------

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/ServiceExposeMapTable.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/ServiceExposeMapTable.java
@@ -11,7 +11,7 @@ package io.cattle.platform.core.model.tables;
 @java.lang.SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class ServiceExposeMapTable extends org.jooq.impl.TableImpl<io.cattle.platform.core.model.tables.records.ServiceExposeMapRecord> {
 
-	private static final long serialVersionUID = -2039587769;
+	private static final long serialVersionUID = -2120396440;
 
 	/**
 	 * The singleton instance of <code>cattle.service_expose_map</code>
@@ -105,6 +105,11 @@ public class ServiceExposeMapTable extends org.jooq.impl.TableImpl<io.cattle.pla
 	 * The column <code>cattle.service_expose_map.host_name</code>.
 	 */
 	public final org.jooq.TableField<io.cattle.platform.core.model.tables.records.ServiceExposeMapRecord, java.lang.String> HOST_NAME = createField("host_name", org.jooq.impl.SQLDataType.VARCHAR.length(255), this, "");
+
+	/**
+	 * The column <code>cattle.service_expose_map.managed</code>.
+	 */
+	public final org.jooq.TableField<io.cattle.platform.core.model.tables.records.ServiceExposeMapRecord, java.lang.Boolean> MANAGED = createField("managed", org.jooq.impl.SQLDataType.BIT.nullable(false).defaulted(true), this, "");
 
 	/**
 	 * Create a <code>cattle.service_expose_map</code> table reference

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/ServiceTable.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/ServiceTable.java
@@ -11,7 +11,7 @@ package io.cattle.platform.core.model.tables;
 @java.lang.SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class ServiceTable extends org.jooq.impl.TableImpl<io.cattle.platform.core.model.tables.records.ServiceRecord> {
 
-	private static final long serialVersionUID = -1114100580;
+	private static final long serialVersionUID = 902897883;
 
 	/**
 	 * The singleton instance of <code>cattle.service</code>
@@ -95,6 +95,16 @@ public class ServiceTable extends org.jooq.impl.TableImpl<io.cattle.platform.cor
 	 * The column <code>cattle.service.create_index</code>.
 	 */
 	public final org.jooq.TableField<io.cattle.platform.core.model.tables.records.ServiceRecord, java.lang.Long> CREATE_INDEX = createField("create_index", org.jooq.impl.SQLDataType.BIGINT, this, "");
+
+	/**
+	 * The column <code>cattle.service.selector_link</code>.
+	 */
+	public final org.jooq.TableField<io.cattle.platform.core.model.tables.records.ServiceRecord, java.lang.String> SELECTOR_LINK = createField("selector_link", org.jooq.impl.SQLDataType.VARCHAR.length(4096), this, "");
+
+	/**
+	 * The column <code>cattle.service.selector_container</code>.
+	 */
+	public final org.jooq.TableField<io.cattle.platform.core.model.tables.records.ServiceRecord, java.lang.String> SELECTOR_CONTAINER = createField("selector_container", org.jooq.impl.SQLDataType.VARCHAR.length(4096), this, "");
 
 	/**
 	 * Create a <code>cattle.service</code> table reference

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/records/ServiceExposeMapRecord.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/records/ServiceExposeMapRecord.java
@@ -11,9 +11,9 @@ package io.cattle.platform.core.model.tables.records;
 @java.lang.SuppressWarnings({ "all", "unchecked", "rawtypes" })
 @javax.persistence.Entity
 @javax.persistence.Table(name = "service_expose_map", schema = "cattle")
-public class ServiceExposeMapRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.platform.core.model.tables.records.ServiceExposeMapRecord> implements io.cattle.platform.db.jooq.utils.TableRecordJaxb, org.jooq.Record16<java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.Long, java.lang.Long, java.lang.String, java.lang.String, java.lang.String>, io.cattle.platform.core.model.ServiceExposeMap {
+public class ServiceExposeMapRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.platform.core.model.tables.records.ServiceExposeMapRecord> implements io.cattle.platform.db.jooq.utils.TableRecordJaxb, org.jooq.Record17<java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.Long, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.Boolean>, io.cattle.platform.core.model.ServiceExposeMap {
 
-	private static final long serialVersionUID = 1661673531;
+	private static final long serialVersionUID = -178347309;
 
 	/**
 	 * Setter for <code>cattle.service_expose_map.id</code>.
@@ -288,6 +288,23 @@ public class ServiceExposeMapRecord extends org.jooq.impl.UpdatableRecordImpl<io
 		return (java.lang.String) getValue(15);
 	}
 
+	/**
+	 * Setter for <code>cattle.service_expose_map.managed</code>.
+	 */
+	@Override
+	public void setManaged(java.lang.Boolean value) {
+		setValue(16, value);
+	}
+
+	/**
+	 * Getter for <code>cattle.service_expose_map.managed</code>.
+	 */
+	@javax.persistence.Column(name = "managed", nullable = false, precision = 1)
+	@Override
+	public java.lang.Boolean getManaged() {
+		return (java.lang.Boolean) getValue(16);
+	}
+
 	// -------------------------------------------------------------------------
 	// Primary key information
 	// -------------------------------------------------------------------------
@@ -301,23 +318,23 @@ public class ServiceExposeMapRecord extends org.jooq.impl.UpdatableRecordImpl<io
 	}
 
 	// -------------------------------------------------------------------------
-	// Record16 type implementation
+	// Record17 type implementation
 	// -------------------------------------------------------------------------
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-	public org.jooq.Row16<java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.Long, java.lang.Long, java.lang.String, java.lang.String, java.lang.String> fieldsRow() {
-		return (org.jooq.Row16) super.fieldsRow();
+	public org.jooq.Row17<java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.Long, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.Boolean> fieldsRow() {
+		return (org.jooq.Row17) super.fieldsRow();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-	public org.jooq.Row16<java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.Long, java.lang.Long, java.lang.String, java.lang.String, java.lang.String> valuesRow() {
-		return (org.jooq.Row16) super.valuesRow();
+	public org.jooq.Row17<java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.Long, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.Boolean> valuesRow() {
+		return (org.jooq.Row17) super.valuesRow();
 	}
 
 	/**
@@ -452,6 +469,14 @@ public class ServiceExposeMapRecord extends org.jooq.impl.UpdatableRecordImpl<io
 	 * {@inheritDoc}
 	 */
 	@Override
+	public org.jooq.Field<java.lang.Boolean> field17() {
+		return io.cattle.platform.core.model.tables.ServiceExposeMapTable.SERVICE_EXPOSE_MAP.MANAGED;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	public java.lang.Long value1() {
 		return getId();
 	}
@@ -574,6 +599,14 @@ public class ServiceExposeMapRecord extends org.jooq.impl.UpdatableRecordImpl<io
 	@Override
 	public java.lang.String value16() {
 		return getHostName();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public java.lang.Boolean value17() {
+		return getManaged();
 	}
 
 	/**
@@ -724,7 +757,16 @@ public class ServiceExposeMapRecord extends org.jooq.impl.UpdatableRecordImpl<io
 	 * {@inheritDoc}
 	 */
 	@Override
-	public ServiceExposeMapRecord values(java.lang.Long value1, java.lang.String value2, java.lang.String value3, java.lang.String value4, java.lang.String value5, java.lang.String value6, java.util.Date value7, java.util.Date value8, java.util.Date value9, java.util.Map<String,Object> value10, java.lang.Long value11, java.lang.Long value12, java.lang.Long value13, java.lang.String value14, java.lang.String value15, java.lang.String value16) {
+	public ServiceExposeMapRecord value17(java.lang.Boolean value) {
+		setManaged(value);
+		return this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public ServiceExposeMapRecord values(java.lang.Long value1, java.lang.String value2, java.lang.String value3, java.lang.String value4, java.lang.String value5, java.lang.String value6, java.util.Date value7, java.util.Date value8, java.util.Date value9, java.util.Map<String,Object> value10, java.lang.Long value11, java.lang.Long value12, java.lang.Long value13, java.lang.String value14, java.lang.String value15, java.lang.String value16, java.lang.Boolean value17) {
 		return this;
 	}
 
@@ -753,6 +795,7 @@ public class ServiceExposeMapRecord extends org.jooq.impl.UpdatableRecordImpl<io
 		setIpAddress(from.getIpAddress());
 		setDnsPrefix(from.getDnsPrefix());
 		setHostName(from.getHostName());
+		setManaged(from.getManaged());
 	}
 
 	/**
@@ -778,7 +821,7 @@ public class ServiceExposeMapRecord extends org.jooq.impl.UpdatableRecordImpl<io
 	/**
 	 * Create a detached, initialised ServiceExposeMapRecord
 	 */
-	public ServiceExposeMapRecord(java.lang.Long id, java.lang.String name, java.lang.String kind, java.lang.String uuid, java.lang.String description, java.lang.String state, java.util.Date created, java.util.Date removed, java.util.Date removeTime, java.util.Map<String,Object> data, java.lang.Long serviceId, java.lang.Long instanceId, java.lang.Long accountId, java.lang.String ipAddress, java.lang.String dnsPrefix, java.lang.String hostName) {
+	public ServiceExposeMapRecord(java.lang.Long id, java.lang.String name, java.lang.String kind, java.lang.String uuid, java.lang.String description, java.lang.String state, java.util.Date created, java.util.Date removed, java.util.Date removeTime, java.util.Map<String,Object> data, java.lang.Long serviceId, java.lang.Long instanceId, java.lang.Long accountId, java.lang.String ipAddress, java.lang.String dnsPrefix, java.lang.String hostName, java.lang.Boolean managed) {
 		super(io.cattle.platform.core.model.tables.ServiceExposeMapTable.SERVICE_EXPOSE_MAP);
 
 		setValue(0, id);
@@ -797,5 +840,6 @@ public class ServiceExposeMapRecord extends org.jooq.impl.UpdatableRecordImpl<io
 		setValue(13, ipAddress);
 		setValue(14, dnsPrefix);
 		setValue(15, hostName);
+		setValue(16, managed);
 	}
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/records/ServiceRecord.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/records/ServiceRecord.java
@@ -11,9 +11,9 @@ package io.cattle.platform.core.model.tables.records;
 @java.lang.SuppressWarnings({ "all", "unchecked", "rawtypes" })
 @javax.persistence.Entity
 @javax.persistence.Table(name = "service", schema = "cattle")
-public class ServiceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.platform.core.model.tables.records.ServiceRecord> implements io.cattle.platform.db.jooq.utils.TableRecordJaxb, org.jooq.Record14<java.lang.Long, java.lang.String, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.String, java.lang.Long>, io.cattle.platform.core.model.Service {
+public class ServiceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.platform.core.model.tables.records.ServiceRecord> implements io.cattle.platform.db.jooq.utils.TableRecordJaxb, org.jooq.Record16<java.lang.Long, java.lang.String, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.String, java.lang.Long, java.lang.String, java.lang.String>, io.cattle.platform.core.model.Service {
 
-	private static final long serialVersionUID = -390288825;
+	private static final long serialVersionUID = 893070192;
 
 	/**
 	 * Setter for <code>cattle.service.id</code>.
@@ -254,6 +254,40 @@ public class ServiceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.p
 		return (java.lang.Long) getValue(13);
 	}
 
+	/**
+	 * Setter for <code>cattle.service.selector_link</code>.
+	 */
+	@Override
+	public void setSelectorLink(java.lang.String value) {
+		setValue(14, value);
+	}
+
+	/**
+	 * Getter for <code>cattle.service.selector_link</code>.
+	 */
+	@javax.persistence.Column(name = "selector_link", length = 4096)
+	@Override
+	public java.lang.String getSelectorLink() {
+		return (java.lang.String) getValue(14);
+	}
+
+	/**
+	 * Setter for <code>cattle.service.selector_container</code>.
+	 */
+	@Override
+	public void setSelectorContainer(java.lang.String value) {
+		setValue(15, value);
+	}
+
+	/**
+	 * Getter for <code>cattle.service.selector_container</code>.
+	 */
+	@javax.persistence.Column(name = "selector_container", length = 4096)
+	@Override
+	public java.lang.String getSelectorContainer() {
+		return (java.lang.String) getValue(15);
+	}
+
 	// -------------------------------------------------------------------------
 	// Primary key information
 	// -------------------------------------------------------------------------
@@ -267,23 +301,23 @@ public class ServiceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.p
 	}
 
 	// -------------------------------------------------------------------------
-	// Record14 type implementation
+	// Record16 type implementation
 	// -------------------------------------------------------------------------
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-	public org.jooq.Row14<java.lang.Long, java.lang.String, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.String, java.lang.Long> fieldsRow() {
-		return (org.jooq.Row14) super.fieldsRow();
+	public org.jooq.Row16<java.lang.Long, java.lang.String, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.String, java.lang.Long, java.lang.String, java.lang.String> fieldsRow() {
+		return (org.jooq.Row16) super.fieldsRow();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-	public org.jooq.Row14<java.lang.Long, java.lang.String, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.String, java.lang.Long> valuesRow() {
-		return (org.jooq.Row14) super.valuesRow();
+	public org.jooq.Row16<java.lang.Long, java.lang.String, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date, java.util.Date, java.util.Date, java.util.Map<String,Object>, java.lang.Long, java.lang.String, java.lang.Long, java.lang.String, java.lang.String> valuesRow() {
+		return (org.jooq.Row16) super.valuesRow();
 	}
 
 	/**
@@ -402,6 +436,22 @@ public class ServiceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.p
 	 * {@inheritDoc}
 	 */
 	@Override
+	public org.jooq.Field<java.lang.String> field15() {
+		return io.cattle.platform.core.model.tables.ServiceTable.SERVICE.SELECTOR_LINK;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public org.jooq.Field<java.lang.String> field16() {
+		return io.cattle.platform.core.model.tables.ServiceTable.SERVICE.SELECTOR_CONTAINER;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	public java.lang.Long value1() {
 		return getId();
 	}
@@ -508,6 +558,22 @@ public class ServiceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.p
 	@Override
 	public java.lang.Long value14() {
 		return getCreateIndex();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public java.lang.String value15() {
+		return getSelectorLink();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public java.lang.String value16() {
+		return getSelectorContainer();
 	}
 
 	/**
@@ -640,7 +706,25 @@ public class ServiceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.p
 	 * {@inheritDoc}
 	 */
 	@Override
-	public ServiceRecord values(java.lang.Long value1, java.lang.String value2, java.lang.Long value3, java.lang.String value4, java.lang.String value5, java.lang.String value6, java.lang.String value7, java.util.Date value8, java.util.Date value9, java.util.Date value10, java.util.Map<String,Object> value11, java.lang.Long value12, java.lang.String value13, java.lang.Long value14) {
+	public ServiceRecord value15(java.lang.String value) {
+		setSelectorLink(value);
+		return this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public ServiceRecord value16(java.lang.String value) {
+		setSelectorContainer(value);
+		return this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public ServiceRecord values(java.lang.Long value1, java.lang.String value2, java.lang.Long value3, java.lang.String value4, java.lang.String value5, java.lang.String value6, java.lang.String value7, java.util.Date value8, java.util.Date value9, java.util.Date value10, java.util.Map<String,Object> value11, java.lang.Long value12, java.lang.String value13, java.lang.Long value14, java.lang.String value15, java.lang.String value16) {
 		return this;
 	}
 
@@ -667,6 +751,8 @@ public class ServiceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.p
 		setEnvironmentId(from.getEnvironmentId());
 		setVip(from.getVip());
 		setCreateIndex(from.getCreateIndex());
+		setSelectorLink(from.getSelectorLink());
+		setSelectorContainer(from.getSelectorContainer());
 	}
 
 	/**
@@ -692,7 +778,7 @@ public class ServiceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.p
 	/**
 	 * Create a detached, initialised ServiceRecord
 	 */
-	public ServiceRecord(java.lang.Long id, java.lang.String name, java.lang.Long accountId, java.lang.String kind, java.lang.String uuid, java.lang.String description, java.lang.String state, java.util.Date created, java.util.Date removed, java.util.Date removeTime, java.util.Map<String,Object> data, java.lang.Long environmentId, java.lang.String vip, java.lang.Long createIndex) {
+	public ServiceRecord(java.lang.Long id, java.lang.String name, java.lang.Long accountId, java.lang.String kind, java.lang.String uuid, java.lang.String description, java.lang.String state, java.util.Date created, java.util.Date removed, java.util.Date removeTime, java.util.Map<String,Object> data, java.lang.Long environmentId, java.lang.String vip, java.lang.Long createIndex, java.lang.String selectorLink, java.lang.String selectorContainer) {
 		super(io.cattle.platform.core.model.tables.ServiceTable.SERVICE);
 
 		setValue(0, id);
@@ -709,5 +795,7 @@ public class ServiceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.p
 		setValue(11, environmentId);
 		setValue(12, vip);
 		setValue(13, createIndex);
+		setValue(14, selectorLink);
+		setValue(15, selectorContainer);
 	}
 }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
@@ -77,4 +77,9 @@ public class ServiceDiscoveryConstants {
     public static final String LABEL_OVERRIDE_HOSTNAME = "io.rancher.container.hostname_override";
     public static final String LABEL_LB_SSL_PORTS = "io.rancher.loadbalancer.ssl.ports";
     public static final String STATE_UPGRADING = "upgrading";
+
+    public static final String LABEL_SELECTOR_CONTAINER = "io.rancher.service.selector.container";
+    public static final String LABEL_SELECTOR_LINK = "io.rancher.service.selector.link";
+
+    public static final String IMAGE_NONE = "rancher/none";
 }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/dao/ServiceExposeMapDao.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/dao/ServiceExposeMapDao.java
@@ -22,13 +22,11 @@ public interface ServiceExposeMapDao {
      */
     Pair<Instance, ServiceExposeMap> createServiceInstance(Map<String, Object> properties, Service service);
 
-    List<? extends Instance> listServiceInstances(long serviceId);
-
-    List<? extends ServiceExposeMap> getNonRemovedServiceInstanceMap(long serviceId);
+    List<? extends Instance> listServiceManagedInstances(long serviceId);
 
     ServiceExposeMap findInstanceExposeMap(Instance instance);
 
-    ServiceExposeMap createServiceInstanceMap(Service service, Instance instance);
+    ServiceExposeMap createServiceInstanceMap(Service service, Instance instance, boolean managed);
 
     ServiceExposeMap createIpToServiceMap(Service service, String ipAddress);
 
@@ -37,6 +35,8 @@ public interface ServiceExposeMapDao {
     List<? extends Service> getActiveServices(long accountId);
 
     List<? extends ServiceExposeMap> getNonRemovedServiceIpMaps(long serviceId);
+
+    List<? extends ServiceExposeMap> getNonRemovedUnmanagedServiceInstanceMap(long serviceId);
 
     Host getHostForInstance(long instanceId);
 
@@ -51,4 +51,6 @@ public interface ServiceExposeMapDao {
     List<? extends ServiceExposeMap> getNonRemovedServiceHostnameMaps(long serviceId);
 
     Service getIpAddressService(String ipAddress, long accountId);
+
+    ServiceExposeMap getServiceInstanceMap(Service service, Instance instance);
 }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceCreateValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceCreateValidationFilter.java
@@ -89,7 +89,7 @@ public class ServiceCreateValidationFilter extends AbstractDefaultResourceManage
         List<Map<String, Object>> launchConfigs = populateLaunchConfigs(service, request);
         for (Map<String, Object> launchConfig : launchConfigs) {
             Object imageUuid = launchConfig.get(InstanceConstants.FIELD_IMAGE_UUID);
-            if (imageUuid != null) {
+            if (imageUuid != null && !imageUuid.toString().equalsIgnoreCase(ServiceDiscoveryConstants.IMAGE_NONE)) {
                 if (!storageService.isValidUUID(imageUuid.toString())) {
                     throw new ValidationErrorException(ValidationErrorCodes.INVALID_REFERENCE,
                             InstanceConstants.FIELD_IMAGE_UUID);

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/service/impl/ServiceDiscoveryApiServiceImpl.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/service/impl/ServiceDiscoveryApiServiceImpl.java
@@ -137,6 +137,7 @@ public class ServiceDiscoveryApiServiceImpl implements ServiceDiscoveryApiServic
                     addExtraComposeParameters(service, launchConfigName, composeServiceData);
                     populateSidekickLabels(service, composeServiceData, isPrimaryConfig);
                     populateLoadBalancerServiceLabels(service, launchConfigName, composeServiceData);
+                    populateSelectorServiceLabels(service, launchConfigName, composeServiceData);
                 }
                 if (!composeServiceData.isEmpty()) {
                     data.put(isPrimaryConfig ? service.getName() : launchConfigName, composeServiceData);
@@ -188,6 +189,31 @@ public class ServiceDiscoveryApiServiceImpl implements ServiceDiscoveryApiServic
             if (bldr.length() > 0) {
                 labels.put(labelName, bldr.toString().substring(0, bldr.length() - 1));
             }
+        }
+
+        if (!labels.isEmpty()) {
+            composeServiceData.put(InstanceConstants.FIELD_LABELS, labels);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    protected void populateSelectorServiceLabels(Service service,
+            String launchConfigName, Map<String, Object> composeServiceData) {
+        String selectorContainer = service.getSelectorContainer();
+        String selectorLink = service.getSelectorLink();
+        if (selectorContainer == null && selectorLink == null) {
+            return;
+        }
+
+        Map<String, String> labels = new HashMap<>();
+        if (composeServiceData.get(InstanceConstants.FIELD_LABELS) != null) {
+            labels.putAll((HashMap<String, String>) composeServiceData.get(InstanceConstants.FIELD_LABELS));
+        }
+        if (selectorLink != null) {
+            labels.put(ServiceDiscoveryConstants.LABEL_SELECTOR_LINK, selectorLink);
+        }
+        if (selectorContainer != null) {
+            labels.put(ServiceDiscoveryConstants.LABEL_SELECTOR_CONTAINER, selectorContainer);
         }
 
         if (!labels.isEmpty()) {

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnitInstanceFactoryImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnitInstanceFactoryImpl.java
@@ -200,7 +200,7 @@ public class DeploymentUnitInstanceFactoryImpl implements DeploymentUnitInstance
     protected void collectDefaultServiceInstances(DeploymentServiceContext context,
             Map<String, Map<String, String>> uuidToLabels, Map<String, List<DeploymentUnitInstance>> uuidToInstances,
             Service service) {
-        List<? extends Instance> serviceContainers = expMapDao.listServiceInstances(service.getId());
+        List<? extends Instance> serviceContainers = expMapDao.listServiceManagedInstances(service.getId());
         for (Instance serviceContainer : serviceContainers) {
             Map<String, String> instanceLabels = DataAccessor.fields(serviceContainer)
                     .withKey(InstanceConstants.FIELD_LABELS).withDefault(Collections.EMPTY_MAP).as(Map.class);

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/NoOpServiceDeploymentPlanner.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/NoOpServiceDeploymentPlanner.java
@@ -6,9 +6,9 @@ import io.cattle.platform.servicediscovery.deployment.impl.DeploymentManagerImpl
 
 import java.util.List;
 
-public class ExternalServiceDeploymentPlanner extends ServiceDeploymentPlanner {
+public class NoOpServiceDeploymentPlanner extends ServiceDeploymentPlanner {
 
-    public ExternalServiceDeploymentPlanner(List<Service> services, List<DeploymentUnit> units,
+    public NoOpServiceDeploymentPlanner(List<Service> services, List<DeploymentUnit> units,
             DeploymentServiceContext context) {
         super(services, units, context);
     }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/ServiceInstanceLock.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/ServiceInstanceLock.java
@@ -1,0 +1,12 @@
+package io.cattle.platform.servicediscovery.deployment.impl;
+
+import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.Service;
+import io.cattle.platform.lock.definition.AbstractLockDefinition;
+
+public class ServiceInstanceLock extends AbstractLockDefinition {
+
+    public ServiceInstanceLock(Service service, Instance instance) {
+        super("SERVICE." + service.getId() + ".INSTANCE." + instance.getId());
+    }
+}

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/SelectorInstanceCreatePostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/SelectorInstanceCreatePostListener.java
@@ -1,0 +1,80 @@
+package io.cattle.platform.servicediscovery.process;
+
+import static io.cattle.platform.core.model.tables.ServiceTable.SERVICE;
+import io.cattle.platform.core.constants.CommonStatesConstants;
+import io.cattle.platform.core.constants.InstanceConstants;
+import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.Service;
+import io.cattle.platform.core.model.ServiceExposeMap;
+import io.cattle.platform.engine.handler.HandlerResult;
+import io.cattle.platform.engine.handler.ProcessPostListener;
+import io.cattle.platform.engine.process.ProcessInstance;
+import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.lock.LockCallbackNoReturn;
+import io.cattle.platform.lock.LockManager;
+import io.cattle.platform.object.process.StandardProcess;
+import io.cattle.platform.process.common.handler.AbstractObjectProcessLogic;
+import io.cattle.platform.servicediscovery.api.dao.ServiceExposeMapDao;
+import io.cattle.platform.servicediscovery.deployment.impl.ServiceInstanceLock;
+import io.cattle.platform.servicediscovery.service.ServiceDiscoveryService;
+import io.cattle.platform.util.type.Priority;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+public class SelectorInstanceCreatePostListener extends AbstractObjectProcessLogic implements ProcessPostListener,
+        Priority {
+    @Inject
+    ServiceDiscoveryService sdService;
+
+    @Inject
+    ServiceExposeMapDao exposeMapDao;
+
+    @Inject
+    LockManager lockManager;
+
+    @Override
+    public String[] getProcessNames() {
+        return new String[] { InstanceConstants.PROCESS_CREATE };
+    }
+
+    @Override
+    public HandlerResult handle(ProcessState state, ProcessInstance process) {
+        final Instance instance = (Instance) state.getResource();
+        List<Service> services = objectManager.find(Service.class, SERVICE.ACCOUNT_ID, instance.getAccountId(),
+                SERVICE.REMOVED, null);
+
+        for (final Service service : services) {
+            if (sdService.isServiceInstance(service, instance)) {
+                continue;
+            }
+            if (sdService.isSelectorContainerMatch(service, instance.getId())) {
+
+                lockManager.lock(new ServiceInstanceLock(service, instance), new LockCallbackNoReturn() {
+                    @Override
+                    public void doWithLockNoResult() {
+                        ServiceExposeMap exposeMap = exposeMapDao.createServiceInstanceMap(service, instance, false);
+                        if (exposeMap.getState().equalsIgnoreCase(CommonStatesConstants.REQUESTED)) {
+                            objectProcessManager.scheduleStandardProcessAsync(StandardProcess.CREATE, exposeMap,
+                                    null);
+                        }
+                    }
+                });
+
+                ServiceExposeMap exposeMap = exposeMapDao.createServiceInstanceMap(service, instance, false);
+                if (exposeMap.getState().equalsIgnoreCase(CommonStatesConstants.REQUESTED)) {
+                    objectProcessManager.scheduleStandardProcessAsync(StandardProcess.CREATE, exposeMap,
+                            null);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public int getPriority() {
+        return Priority.DEFAULT;
+    }
+}

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/SelectorServiceCreatePostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/SelectorServiceCreatePostListener.java
@@ -1,0 +1,97 @@
+package io.cattle.platform.servicediscovery.process;
+
+
+import static io.cattle.platform.core.model.tables.InstanceTable.INSTANCE;
+import static io.cattle.platform.core.model.tables.ServiceTable.SERVICE;
+import io.cattle.platform.core.addon.ServiceLink;
+import io.cattle.platform.core.constants.CommonStatesConstants;
+import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.Service;
+import io.cattle.platform.core.model.ServiceExposeMap;
+import io.cattle.platform.engine.handler.HandlerResult;
+import io.cattle.platform.engine.handler.ProcessPostListener;
+import io.cattle.platform.engine.process.ProcessInstance;
+import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.lock.LockCallbackNoReturn;
+import io.cattle.platform.lock.LockManager;
+import io.cattle.platform.object.process.StandardProcess;
+import io.cattle.platform.process.common.handler.AbstractObjectProcessLogic;
+import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
+import io.cattle.platform.servicediscovery.api.dao.ServiceExposeMapDao;
+import io.cattle.platform.servicediscovery.deployment.impl.ServiceInstanceLock;
+import io.cattle.platform.servicediscovery.service.ServiceDiscoveryService;
+import io.cattle.platform.util.type.Priority;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+public class SelectorServiceCreatePostListener extends AbstractObjectProcessLogic implements ProcessPostListener,
+        Priority {
+
+    @Inject
+    ServiceDiscoveryService sdService;
+
+    @Inject
+    ServiceExposeMapDao exposeMapDao;
+
+    @Inject
+    LockManager lockManager;
+
+    @Override
+    public String[] getProcessNames() {
+        return new String[] { ServiceDiscoveryConstants.PROCESS_SERVICE_CREATE };
+    }
+
+    @Override
+    public HandlerResult handle(ProcessState state, ProcessInstance process) {
+        Service service = (Service)state.getResource();
+        registerServiceLinks(service);
+        registerInstances(service);
+        return null;
+    }
+
+    protected void registerServiceLinks(Service service) {
+        List<Service> services = objectManager.find(Service.class, SERVICE.ACCOUNT_ID, service.getAccountId(),
+                SERVICE.REMOVED, null);
+
+        for (Service targetService : services) {
+            // skip itself
+            if (targetService.getId().equals(service.getId())) {
+                continue;
+            }
+            if (sdService.isSelectorLinkMatch(service, targetService)) {
+                sdService.addServiceLink(service, new ServiceLink(targetService.getId(), null));
+            }
+            if (sdService.isSelectorLinkMatch(targetService, service)) {
+                sdService.addServiceLink(targetService, new ServiceLink(service.getId(), null));
+            }
+        }
+    }
+
+    protected void registerInstances(final Service service) {
+        List<Instance> instances = objectManager.find(Instance.class, INSTANCE.ACCOUNT_ID, service.getAccountId(),
+                INSTANCE.REMOVED, null);
+
+        for (final Instance instance : instances) {
+            if (sdService.isSelectorContainerMatch(service, instance.getId())) {
+                lockManager.lock(new ServiceInstanceLock(service, instance), new LockCallbackNoReturn() {
+                    @Override
+                    public void doWithLockNoResult() {
+                        ServiceExposeMap exposeMap = exposeMapDao.createServiceInstanceMap(service, instance, false);
+                        if (exposeMap.getState().equalsIgnoreCase(CommonStatesConstants.REQUESTED)) {
+                            objectProcessManager.scheduleStandardProcessAsync(StandardProcess.CREATE, exposeMap,
+                                    null);
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    @Override
+    public int getPriority() {
+        return Priority.DEFAULT;
+    }
+
+}

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceDiscoveryInstanceStartPostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceDiscoveryInstanceStartPostListener.java
@@ -67,7 +67,7 @@ public class ServiceDiscoveryInstanceStartPostListener extends AbstractObjectPro
 
                 if (instanceServiceMap == null) {
                     instanceServiceMap = exposeMapDao.createServiceInstanceMap(
-                            objectManager.loadResource(Service.class, serviceId), instance);
+                            objectManager.loadResource(Service.class, serviceId), instance, true);
                 }
 
                 if (instanceServiceMap.getState().equalsIgnoreCase(CommonStatesConstants.REQUESTED)) {

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceExposeMapCreate.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceExposeMapCreate.java
@@ -1,0 +1,62 @@
+package io.cattle.platform.servicediscovery.process;
+
+import io.cattle.platform.core.dao.NetworkDao;
+import io.cattle.platform.core.model.Service;
+import io.cattle.platform.core.model.ServiceExposeMap;
+import io.cattle.platform.engine.handler.HandlerResult;
+import io.cattle.platform.engine.process.ProcessInstance;
+import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.eventing.EventService;
+import io.cattle.platform.eventing.model.Event;
+import io.cattle.platform.eventing.model.EventVO;
+import io.cattle.platform.framework.event.FrameworkEvents;
+import io.cattle.platform.json.JsonMapper;
+import io.cattle.platform.object.meta.ObjectMetaDataManager;
+import io.cattle.platform.process.common.handler.AbstractObjectProcessHandler;
+import io.cattle.platform.servicediscovery.service.ServiceDiscoveryService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+public class ServiceExposeMapCreate extends AbstractObjectProcessHandler {
+    @Inject
+    ServiceDiscoveryService sdService;
+    @Inject
+    JsonMapper jsonMapper;
+
+    @Inject
+    NetworkDao ntwkDao;
+
+    @Inject
+    EventService eventService;
+
+    @Override
+    public String[] getProcessNames() {
+        return new String[] { "serviceexposemap.create" };
+    }
+
+    @Override
+    public HandlerResult handle(ProcessState state, ProcessInstance process) {
+        ServiceExposeMap exposeMap = (ServiceExposeMap) state.getResource();
+        if (exposeMap.getManaged()) {
+            return null;
+        }
+        Service service = objectManager.loadResource(Service.class, exposeMap.getServiceId());
+        publishEvent(service);
+        return null;
+    }
+
+    protected void publishEvent(Service service) {
+        Map<String, Object> data = new HashMap<>();
+        data.put(ObjectMetaDataManager.ACCOUNT_FIELD, service.getAccountId());
+
+        Event event = EventVO.newEvent(FrameworkEvents.STATE_CHANGE)
+                .withData(data)
+                .withResourceType(service.getKind())
+                .withResourceId(service.getId().toString());
+
+        eventService.publish(event);
+    }
+}

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/selector/SelectorConstraint.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/selector/SelectorConstraint.java
@@ -1,0 +1,39 @@
+package io.cattle.platform.servicediscovery.selector;
+
+import java.util.Map;
+
+public abstract class SelectorConstraint<T> {
+    public enum Op {
+        NEQ("!="),
+        EQ("="),
+        NOTIN(" notin "),
+        IN(" in "),
+        NOOP("");
+
+        String selectorSymbol;
+        boolean isList;
+
+        private Op(String selectorSymbol) {
+            this.selectorSymbol = selectorSymbol;
+        }
+
+        public String getSelectorSymbol() {
+            return selectorSymbol;
+        }
+    }
+
+    protected String key;
+    protected T value;
+
+    public SelectorConstraint(String key, T value) {
+        super();
+        this.key = key;
+        this.value = value;
+    }
+
+    public abstract boolean isMatch(Map<String, String> toCompare);
+
+    public T getValue() {
+        return value;
+    }
+}

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/selector/SelectorUtils.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/selector/SelectorUtils.java
@@ -1,0 +1,129 @@
+package io.cattle.platform.servicediscovery.selector;
+
+import io.cattle.platform.servicediscovery.selector.SelectorConstraint.Op;
+import io.cattle.platform.servicediscovery.selector.impl.SelectorConstraintEq;
+import io.cattle.platform.servicediscovery.selector.impl.SelectorConstraintIn;
+import io.cattle.platform.servicediscovery.selector.impl.SelectorConstraintNeq;
+import io.cattle.platform.servicediscovery.selector.impl.SelectorConstraintNoop;
+import io.cattle.platform.servicediscovery.selector.impl.SelectorConstraintNotIn;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+public class SelectorUtils {
+    private static Cache<String, List<SelectorConstraint<?>>> cache = CacheBuilder.newBuilder()
+            .expireAfterWrite(3600, TimeUnit.SECONDS).build();
+
+    public static boolean isSelectorMatch(String selector, Map<String, String> labels) {
+        if (StringUtils.isEmpty(selector)) {
+            return false;
+        }
+        List<SelectorConstraint<?>> constraints = getSelectorConstraints(selector);
+        if (constraints.isEmpty()) {
+            return false;
+        }
+
+        int found = 0;
+        for (SelectorConstraint<?> constraint : constraints) {
+            if (constraint.isMatch(labels)) {
+                found++;
+            }
+        }
+        if (found != constraints.size()) {
+            return false;
+        }
+        return true;
+    }
+
+    private static List<SelectorConstraint<?>> getSelectorConstraints(String selector) {
+        List<SelectorConstraint<?>> cachedConstraints = cache.getIfPresent(selector);
+        if (cachedConstraints != null) {
+            return cachedConstraints;
+        }
+        List<SelectorConstraint<?>> constraints = new ArrayList<>();
+        List<String> selectorConstraints = new ArrayList<>();
+
+        // as selector format is:
+        // key in (value1, value2)
+        // key notin (value1, value2)
+        // key
+        // key = value
+        // key != value
+        // and any combination of them can be specified in coma separated way:
+        // key != value, key in (value1, value2), key = value
+
+        boolean inList = false;
+        StringBuffer selectorConstraint = new StringBuffer();
+        for (int i = 0; i < selector.length(); i++) {
+            boolean finishConstraint = (i == selector.length() - 1);
+            char currentC = selector.charAt(i);
+            if (currentC == '(') {
+                inList = true;
+            } else if (currentC == ')') {
+                inList = false;
+            } else if (currentC == ',') {
+                if (inList) {
+                    selectorConstraint.append(currentC);
+                } else {
+                    finishConstraint = true;
+                }
+            } else {
+                selectorConstraint.append(currentC);
+            }
+            if (finishConstraint) {
+                selectorConstraints.add(selectorConstraint.toString());
+                selectorConstraint = new StringBuffer();
+            }
+        }
+
+        for (String constraint : selectorConstraints) {
+            constraints.add(getSelectorConstraint(constraint));
+        }
+        cache.put(selector, constraints);
+        return constraints;
+    }
+
+    private static SelectorConstraint<?> getSelectorConstraint(String selector) {
+        SelectorConstraint.Op finalOp = Op.NOOP;
+        String key = StringUtils.EMPTY;
+        String value = StringUtils.EMPTY;
+        for (SelectorConstraint.Op op : SelectorConstraint.Op.values()) {
+            if (op == Op.NOOP) {
+                continue;
+            }
+            String[] exp = selector.split(op.getSelectorSymbol(), 2);
+            if (exp.length == 2) {
+                finalOp = op;
+                key = exp[0].trim();
+                value = exp[1].trim();
+                break;
+            }
+        }
+        if (finalOp == SelectorConstraint.Op.EQ) {
+            return new SelectorConstraintEq(key, value);
+        } else if (finalOp == SelectorConstraint.Op.NEQ) {
+            return new SelectorConstraintNeq(key, value);
+        } else if (finalOp == SelectorConstraint.Op.IN) {
+            return new SelectorConstraintIn(key, splitValues(value));
+        } else if (finalOp == SelectorConstraint.Op.NOTIN) {
+            return new SelectorConstraintNotIn(key, splitValues(value));
+        } else {
+            return new SelectorConstraintNoop(selector.trim(), null);
+        }
+    }
+
+    protected static List<String> splitValues(String value) {
+        List<String> values = new ArrayList<>();
+        for (String valueStr : value.split(",")) {
+            values.add(valueStr.trim().toLowerCase());
+        }
+        return values;
+    }
+}

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/selector/impl/SelectorConstraintEq.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/selector/impl/SelectorConstraintEq.java
@@ -1,0 +1,27 @@
+package io.cattle.platform.servicediscovery.selector.impl;
+
+import io.cattle.platform.servicediscovery.selector.SelectorConstraint;
+
+import java.util.Map;
+
+public class SelectorConstraintEq extends SelectorConstraint<String> {
+
+    public SelectorConstraintEq(String key, String value) {
+        super(key, value);
+    }
+
+    @Override
+    public boolean isMatch(Map<String, String> toCompare) {
+        boolean found = false;
+        for (String key : toCompare.keySet()) {
+            if (this.key.equalsIgnoreCase(key)) {
+                if (this.value.equalsIgnoreCase(toCompare.get(key))) {
+                    found = true;
+                    break;
+                }
+            }
+        }
+        return found;
+    }
+
+}

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/selector/impl/SelectorConstraintIn.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/selector/impl/SelectorConstraintIn.java
@@ -1,0 +1,27 @@
+package io.cattle.platform.servicediscovery.selector.impl;
+
+import io.cattle.platform.servicediscovery.selector.SelectorConstraint;
+
+import java.util.List;
+import java.util.Map;
+
+public class SelectorConstraintIn extends SelectorConstraint<List<String>> {
+
+    public SelectorConstraintIn(String key, List<String> value) {
+        super(key, value);
+    }
+
+    @Override
+    public boolean isMatch(Map<String, String> toCompare) {
+        boolean found = false;
+        for (String key : toCompare.keySet()) {
+            if (this.key.equalsIgnoreCase(key)) {
+                if (this.getValue().contains(toCompare.get(key).toLowerCase())) {
+                    found = true;
+                    break;
+                }
+            }
+        }
+        return found;
+    }
+}

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/selector/impl/SelectorConstraintNeq.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/selector/impl/SelectorConstraintNeq.java
@@ -1,0 +1,26 @@
+package io.cattle.platform.servicediscovery.selector.impl;
+
+import io.cattle.platform.servicediscovery.selector.SelectorConstraint;
+
+import java.util.Map;
+
+public class SelectorConstraintNeq extends SelectorConstraint<String> {
+
+    public SelectorConstraintNeq(String key, String value) {
+        super(key, value);
+    }
+
+    @Override
+    public boolean isMatch(Map<String, String> toCompare) {
+        boolean found = false;
+        for (String key : toCompare.keySet()) {
+            if (this.key.equalsIgnoreCase(key)) {
+                if (!this.value.equalsIgnoreCase(toCompare.get(key))) {
+                    found = true;
+                }
+            }
+        }
+        return found;
+    }
+
+}

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/selector/impl/SelectorConstraintNoop.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/selector/impl/SelectorConstraintNoop.java
@@ -1,0 +1,18 @@
+package io.cattle.platform.servicediscovery.selector.impl;
+
+import io.cattle.platform.servicediscovery.selector.SelectorConstraint;
+
+import java.util.Map;
+
+public class SelectorConstraintNoop extends SelectorConstraint<String> {
+
+    public SelectorConstraintNoop(String key, String value) {
+        super(key, value);
+    }
+
+    @Override
+    public boolean isMatch(Map<String, String> toCompare) {
+        return toCompare.containsKey(key);
+    }
+
+}

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/selector/impl/SelectorConstraintNotIn.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/selector/impl/SelectorConstraintNotIn.java
@@ -1,0 +1,26 @@
+package io.cattle.platform.servicediscovery.selector.impl;
+
+import io.cattle.platform.servicediscovery.selector.SelectorConstraint;
+
+import java.util.List;
+import java.util.Map;
+
+public class SelectorConstraintNotIn extends SelectorConstraint<List<String>> {
+    public SelectorConstraintNotIn(String key, List<String> value) {
+        super(key, value);
+    }
+
+    @Override
+    public boolean isMatch(Map<String, String> toCompare) {
+        boolean found = false;
+        for (String key : toCompare.keySet()) {
+            if (this.key.equalsIgnoreCase(key)) {
+                if (!this.getValue().contains(toCompare.get(key).toLowerCase())) {
+                    found = true;
+                    break;
+                }
+            }
+        }
+        return found;
+    }
+}

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
@@ -1,5 +1,7 @@
 package io.cattle.platform.servicediscovery.service;
 
+import io.cattle.platform.core.addon.ServiceLink;
+import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.Service;
 import io.cattle.platform.core.model.ServiceExposeMap;
 
@@ -26,5 +28,13 @@ public interface ServiceDiscoveryService {
     void releaseVip(Service service);
 
     void updateLoadBalancerService(Service service, List<? extends Long> certIds, Long defaultCertId);
+
+    void addServiceLink(Service service, ServiceLink serviceLink);
+
+    boolean isSelectorLinkMatch(Service sourceService, Service targetService);
+
+    boolean isSelectorContainerMatch(Service sourceService, long instanceId);
+
+    boolean isServiceInstance(Service service, Instance instance);
 
 }

--- a/code/iaas/service-discovery/server/src/main/resources/META-INF/cattle/system-services/spring-service-discovery-server-context.xml
+++ b/code/iaas/service-discovery/server/src/main/resources/META-INF/cattle/system-services/spring-service-discovery-server-context.xml
@@ -19,6 +19,9 @@
     <bean class="io.cattle.platform.servicediscovery.process.ServiceUpgrade" />
     <bean class="io.cattle.platform.servicediscovery.process.ServiceCancelupgrade" />
     <bean class="io.cattle.platform.servicediscovery.process.NetworkFromInstanceStop" />
+    <bean class="io.cattle.platform.servicediscovery.process.SelectorServiceCreatePostListener" />
+    <bean class="io.cattle.platform.servicediscovery.process.SelectorInstanceCreatePostListener" />
+    <bean class="io.cattle.platform.servicediscovery.process.ServiceExposeMapCreate" />
 
     <bean class="io.cattle.platform.servicediscovery.process.EnvironmentRemove" />
 

--- a/code/iaas/service-discovery/server/src/test/java/io/cattle/platform/servicediscovery/selector/SelectorTest.java
+++ b/code/iaas/service-discovery/server/src/test/java/io/cattle/platform/servicediscovery/selector/SelectorTest.java
@@ -1,0 +1,106 @@
+package io.cattle.platform.servicediscovery.selector;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class SelectorTest {
+
+    @Test
+    public void testEq() {
+        Map<String, String> labels = new HashMap<>();
+        labels.put("foo", "bar");
+        boolean result = SelectorUtils.isSelectorMatch("foo=bar", labels);
+        assertEquals(result, true);
+
+        // test with spaces
+        result = SelectorUtils.isSelectorMatch("foo = bar", labels);
+        assertEquals(result, true);
+
+        labels.put("foo", "bar1");
+        result = SelectorUtils.isSelectorMatch("foo=bar", labels);
+        assertEquals(result, false);
+    }
+
+    @Test
+    public void testNeq() {
+        Map<String, String> labels = new HashMap<>();
+        labels.put("foo", "bar");
+        boolean result = SelectorUtils.isSelectorMatch("foo!=bar", labels);
+        assertEquals(result, false);
+
+        labels.put("foo", "bar1");
+        result = SelectorUtils.isSelectorMatch("foo!=bar", labels);
+        assertEquals(result, true);
+    }
+
+    @Test
+    public void testIn() {
+        Map<String, String> labels = new HashMap<>();
+        labels.put("foo", "bar");
+        labels.put("a", "b");
+        boolean result = SelectorUtils.isSelectorMatch("foo in (bar,bar1)", labels);
+        assertEquals(result, true);
+
+        labels.put("foo", "bar2");
+        labels.put("a", "b");
+        result = SelectorUtils.isSelectorMatch("foo in (bar,bar1)", labels);
+        assertEquals(result, false);
+    }
+
+    @Test
+    public void testNotIn() {
+        Map<String, String> labels = new HashMap<>();
+        labels.put("foo", "bar");
+        labels.put("a", "b");
+        boolean result = SelectorUtils.isSelectorMatch("foo notin (bar,bar1)", labels);
+        assertEquals(result, false);
+
+        labels.put("foo", "bar2");
+        labels.put("a", "b");
+        result = SelectorUtils.isSelectorMatch("foo notin (bar,bar1)", labels);
+        assertEquals(result, true);
+    }
+
+    @Test
+    public void testList() {
+        Map<String, String> labels = new HashMap<>();
+        labels.put("foo", "inbar");
+        labels.put("a", "b");
+        boolean result = SelectorUtils.isSelectorMatch("foo in (inbar), a= b", labels);
+        assertEquals(result, true);
+
+        labels.put("foo", "bar2");
+        labels.put("a", "b");
+        result = SelectorUtils.isSelectorMatch("a =b1,foo in (bar2)", labels);
+        assertEquals(result, false);
+    }
+
+    @Test
+    public void testNoOp() {
+        Map<String, String> labels = new HashMap<>();
+        labels.put("foo", "bar");
+        boolean result = SelectorUtils.isSelectorMatch("foo", labels);
+        assertEquals(result, true);
+
+        labels.clear();
+        labels.put("foo1", "bar");
+        result = SelectorUtils.isSelectorMatch("foo", labels);
+        assertEquals(result, false);
+
+        labels.clear();
+        labels.put("foo", "bar");
+        labels.put("bar", "foo");
+        result = SelectorUtils.isSelectorMatch("foo, bar", labels);
+        assertEquals(result, true);
+
+        labels.clear();
+        labels.put("foo", "bar");
+        labels.put("bar1", "foo");
+        result = SelectorUtils.isSelectorMatch("foo, bar", labels);
+        assertEquals(result, false);
+    }
+}

--- a/resources/content/db/changelog.xml
+++ b/resources/content/db/changelog.xml
@@ -66,5 +66,6 @@
     <include file="db/core-059.xml"/>
     <include file="db/core-060.xml"/>
     <include file="db/core-061.xml"/>
+    <include file="db/core-062.xml"/>
     
 </databaseChangeLog>

--- a/resources/content/db/core-062.xml
+++ b/resources/content/db/core-062.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+    <property name="mediumtext" value="TEXT" dbms="postgresql" />
+    <property name="mediumtext" value="MEDIUMTEXT" />
+    <changeSet author="alena (generated)" id="dump1">
+        <addColumn tableName="service_expose_map">
+            <column defaultValueNumeric="1" name="managed" type="BIT">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet author="alena (generated)" id="dump2">
+        <addColumn tableName="service">
+            <column name="selector_link" type="VARCHAR(4096)"/>
+        </addColumn>
+    </changeSet>
+    <changeSet author="alena (generated)" id="dump3">
+        <addColumn tableName="service">
+            <column name="selector_container" type="VARCHAR(4096)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/resources/content/schema/base/service.json
+++ b/resources/content/schema/base/service.json
@@ -28,7 +28,7 @@
         "launchConfig": {
             "type": "launchConfig",
             "create": true,
-            "required": true
+            "required": false
         },
         "upgrade": {
             "type": "serviceUpgrade",

--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -423,6 +423,8 @@
         "service.vip" : "cr",
         "service.createIndex" : "r",
         "service.metadata" : "cru",
+        "service.selectorLink" : "cr",
+        "service.selectorContainer" : "cr",
 
         "addRemoveServiceLinkInput" : "r",
         "addRemoveServiceLinkInput.serviceLink" : "cr",
@@ -474,10 +476,10 @@
         "serviceExposeMap.serviceId" : "r",
         "serviceExposeMap.ipAddress" : "r",
         "serviceExposeMap.hostname" : "r",
+        "serviceExposeMap.managed" : "r",
 
         "externalService" : "r",
         "externalService.externalIpAddresses" : "cru",
-        "externalService.launchConfig" : "",
         "externalService.scale" : "",
         "externalService.secondaryLaunchConfigs" : "",
         "externalService.hostname" : "cru",
@@ -486,7 +488,6 @@
         "externalService.createIndex" : "",
 
         "dnsService" : "r",
-        "dnsService.launchConfig" : "",
         "dnsService.scale" : "",
         "dnsService.secondaryLaunchConfigs" : "",
         "dnsService.vip" : "",

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -1523,7 +1523,9 @@ def test_svc_discovery_service(admin_user_client, user_client, project_client):
         'secondaryLaunchConfigs': 'r',
         'vip': 'r',
         'createIndex': 'r',
-        'metadata': 'r'
+        'metadata': 'r',
+        'selectorLink': 'r',
+        'selectorContainer': 'r'
     })
 
     auth_check(user_client.schema, 'service', 'r', {
@@ -1536,7 +1538,9 @@ def test_svc_discovery_service(admin_user_client, user_client, project_client):
         'secondaryLaunchConfigs': 'r',
         'vip': 'r',
         'createIndex': 'r',
-        'metadata': 'r'
+        'metadata': 'r',
+        'selectorLink': 'r',
+        'selectorContainer': 'r'
     })
 
     auth_check(project_client.schema, 'service', 'crud', {
@@ -1549,7 +1553,9 @@ def test_svc_discovery_service(admin_user_client, user_client, project_client):
         'secondaryLaunchConfigs': 'cr',
         'vip': 'cr',
         'createIndex': 'r',
-        'metadata': 'cru'
+        'metadata': 'cru',
+        'selectorLink': 'cr',
+        'selectorContainer': 'cr'
     })
 
 
@@ -1592,7 +1598,9 @@ def test_svc_discovery_lb_service(admin_user_client, user_client,
         'vip': 'r',
         'defaultCertificateId': 'r',
         'certificateIds': 'r',
-        'metadata': 'r'
+        'metadata': 'r',
+        'selectorLink': 'r',
+        'selectorContainer': 'r'
     })
 
     auth_check(user_client.schema, 'loadBalancerService', 'r', {
@@ -1606,7 +1614,9 @@ def test_svc_discovery_lb_service(admin_user_client, user_client,
         'vip': 'r',
         'defaultCertificateId': 'r',
         'certificateIds': 'r',
-        'metadata': 'r'
+        'metadata': 'r',
+        'selectorLink': 'r',
+        'selectorContainer': 'r'
     })
 
     auth_check(project_client.schema, 'loadBalancerService', 'crud', {
@@ -1620,7 +1630,9 @@ def test_svc_discovery_lb_service(admin_user_client, user_client,
         'vip': 'cr',
         'defaultCertificateId': 'cru',
         'certificateIds': 'cru',
-        'metadata': 'cru'
+        'metadata': 'cru',
+        'selectorLink': 'cr',
+        'selectorContainer': 'cr'
     })
 
 
@@ -1687,7 +1699,8 @@ def test_svc_discovery_expose_map(admin_user_client, user_client,
         'instanceId': 'r',
         'ipAddress': 'r',
         'data': 'r',
-        'accountId': 'r'
+        'accountId': 'r',
+        'managed': 'r'
     })
 
     auth_check(user_client.schema, 'serviceExposeMap', 'r', {
@@ -1695,7 +1708,8 @@ def test_svc_discovery_expose_map(admin_user_client, user_client,
         'serviceId': 'r',
         'instanceId': 'r',
         'ipAddress': 'r',
-        'accountId': 'r'
+        'accountId': 'r',
+        'managed': 'r'
     })
 
     auth_check(project_client.schema, 'serviceExposeMap', 'r', {
@@ -1703,7 +1717,8 @@ def test_svc_discovery_expose_map(admin_user_client, user_client,
         'serviceId': 'r',
         'instanceId': 'r',
         'ipAddress': 'r',
-        'accountId': 'r'
+        'accountId': 'r',
+        'managed': 'r'
     })
 
 
@@ -1718,7 +1733,10 @@ def test_svc_discovery_external_service(admin_user_client, user_client,
         'data': 'r',
         'upgrade': 'r',
         'healthCheck': 'r',
-        'metadata': 'r'
+        'metadata': 'r',
+        'selectorLink': 'r',
+        'selectorContainer': 'r',
+        'launchConfig': 'r'
     })
 
     auth_check(user_client.schema, 'externalService', 'r', {
@@ -1729,7 +1747,10 @@ def test_svc_discovery_external_service(admin_user_client, user_client,
         'accountId': 'r',
         'upgrade': 'r',
         'healthCheck': 'r',
-        'metadata': 'r'
+        'metadata': 'r',
+        'selectorLink': 'r',
+        'selectorContainer': 'r',
+        'launchConfig': 'r'
     })
 
     auth_check(project_client.schema, 'externalService', 'crud', {
@@ -1740,7 +1761,10 @@ def test_svc_discovery_external_service(admin_user_client, user_client,
         'accountId': 'r',
         'upgrade': 'r',
         'healthCheck': 'cr',
-        'metadata': 'cru'
+        'metadata': 'cru',
+        'selectorLink': 'cr',
+        'selectorContainer': 'cr',
+        'launchConfig': 'cr'
     })
 
 

--- a/tests/integration/cattletest/core/test_svc_selectors.py
+++ b/tests/integration/cattletest/core/test_svc_selectors.py
@@ -1,0 +1,331 @@
+from common_fixtures import *  # NOQA
+import yaml
+
+
+def _create_service(client, env, image_uuid, service_kind):
+    labels = {'foo': "bar"}
+    if service_kind == "service":
+        launch_config = {"imageUuid": image_uuid, "labels": labels}
+        service = client.create_service(name=random_str(),
+                                        environmentId=env.id,
+                                        launchConfig=launch_config)
+
+    elif service_kind == "loadBalancerService":
+        launch_config = {"labels": labels}
+        service = client.create_loadBalancerService(name=random_str(),
+                                                    environmentId=env.id,
+                                                    launchConfig=launch_config)
+
+    elif service_kind == "dnsService":
+        launch_config = {"labels": labels}
+        service = client.create_dnsService(name=random_str(),
+                                           environmentId=env.id,
+                                           launchConfig=launch_config)
+
+    elif service_kind == "externalService":
+        launch_config = {"labels": labels}
+        service = client.create_externalService(name=random_str(),
+                                                environmentId=env.id,
+                                                launchConfig=launch_config,
+                                                hostname="a.com")
+
+    return labels, service
+
+
+def _validate_service_link(client, context, service_kind):
+    env = client.create_environment(name=random_str())
+    env = client.wait_success(env)
+    assert env.state == "active"
+    image_uuid = context.image_uuid
+    # use case #1 - service having selector's label,
+    # is present when service with selector is created
+    labels, service = _create_service(client, env, image_uuid, service_kind)
+    service = client.wait_success(service)
+    assert service.launchConfig.labels == labels
+    launch_config = {"imageUuid": image_uuid}
+    service1 = client.create_service(name=random_str(),
+                                     environmentId=env.id,
+                                     launchConfig=launch_config,
+                                     selectorLink="foo=bar")
+    service1 = client.wait_success(service1)
+    assert service1.selectorLink == "foo=bar"
+    _validate_add_service_link(service1, service, client)
+    # use case #2 - service having selector's label,
+    # is added after service with selector creation
+    labels, service2 = _create_service(client, env, image_uuid, service_kind)
+    service2 = client.wait_success(service2)
+    assert service2.launchConfig.labels == labels
+    _validate_add_service_link(service1, service2, client)
+
+    compose_config = env.exportconfig()
+    assert compose_config is not None
+    document = yaml.load(compose_config.dockerComposeConfig)
+    assert len(document[service1.name]['labels']) == 1
+    labels = {"io.rancher.service.selector.link": "foo=bar"}
+    assert document[service1.name]['labels'] == labels
+
+
+def test_service_add_service_link_selector(client, context):
+    _validate_service_link(client, context, "loadBalancerService")
+    _validate_service_link(client, context, "service")
+    _validate_service_link(client, context, "dnsService")
+    _validate_service_link(client, context, "externalService")
+
+
+def test_service_add_instance_selector(client, context):
+    env = client.create_environment(name=random_str())
+    env = client.wait_success(env)
+    assert env.state == "active"
+
+    image_uuid = context.image_uuid
+
+    # use case #1 - instance having selector's label,
+    # is present when service with selector is created
+    labels = {'foo': "bar"}
+    container1 = client.create_container(imageUuid=image_uuid,
+                                         startOnCreate=True,
+                                         labels=labels)
+    container1 = client.wait_success(container1)
+    assert container1.state == "running"
+
+    launch_config = {"imageUuid": "rancher/none"}
+    service = client.create_service(name=random_str(),
+                                    environmentId=env.id,
+                                    launchConfig=launch_config,
+                                    selectorContainer="foo=bar")
+    service = client.wait_success(service)
+    assert service.selectorContainer == "foo=bar"
+
+    service = client.wait_success(service.activate())
+    assert service.state == "active"
+    compose_config = env.exportconfig()
+    assert compose_config is not None
+    document = yaml.load(compose_config.dockerComposeConfig)
+    assert len(document[service.name]['labels']) == 1
+    export_labels = {"io.rancher.service.selector.container": "foo=bar"}
+    assert document[service.name]['labels'] == export_labels
+
+    wait_for(
+        lambda: len(client.list_serviceExposeMap(serviceId=service.id)) == 1
+    )
+    expose_map = container1.serviceExposeMaps()[0]
+    assert expose_map.managed == 0
+
+    # use case #2 - instance having selector's label,
+    # is added after service with selector creation
+    container2 = client.create_container(imageUuid=image_uuid,
+                                         startOnCreate=True,
+                                         labels=labels)
+    container2 = client.wait_success(container2)
+    assert container2.state == "running"
+    wait_for(
+        lambda: len(client.list_serviceExposeMap(serviceId=service.id)) == 2
+    )
+    expose_map = container2.serviceExposeMaps()[0]
+    assert expose_map.managed == 0
+
+
+def test_service_mixed_selector_based_wo_image(client, context):
+    env = client.create_environment(name=random_str())
+    env = client.wait_success(env)
+    assert env.state == "active"
+    image_uuid = context.image_uuid
+
+    labels = {'foo': "barbar"}
+    container1 = client.create_container(imageUuid=image_uuid,
+                                         startOnCreate=True,
+                                         labels=labels)
+    container1 = client.wait_success(container1)
+    assert container1.state == "running"
+
+    launch_config = {"imageUuid": "rancher/none"}
+    service = client.create_service(name=random_str(),
+                                    environmentId=env.id,
+                                    launchConfig=launch_config,
+                                    selectorContainer="foo=barbar")
+    service = client.wait_success(service)
+    assert service.selectorContainer == "foo=barbar"
+
+    service = client.wait_success(service.activate())
+    assert service.state == "active"
+
+    wait_for(
+        lambda: len(client.list_serviceExposeMap(serviceId=service.id)) == 1
+    )
+
+    # add instance having selector label
+    labels = {'foo': "barbar"}
+    container2 = client.create_container(imageUuid=image_uuid,
+                                         startOnCreate=True,
+                                         labels=labels)
+    container2 = client.wait_success(container2)
+    assert container2.state == "running"
+    wait_for(
+        lambda: len(client.list_serviceExposeMap(serviceId=service.id)) == 2
+    )
+
+
+def test_service_mixed_selector_based_w_image(client, context):
+    env = client.create_environment(name=random_str())
+    env = client.wait_success(env)
+    assert env.state == "active"
+    image_uuid = context.image_uuid
+
+    labels = {'foo': "test"}
+    container1 = client.create_container(imageUuid=image_uuid,
+                                         startOnCreate=True,
+                                         labels=labels)
+    container1 = client.wait_success(container1)
+    assert container1.state == "running"
+
+    launch_config = {"imageUuid": image_uuid}
+    service = client.create_service(name=random_str(),
+                                    environmentId=env.id,
+                                    launchConfig=launch_config,
+                                    selectorContainer="foo=test")
+    service = client.wait_success(service)
+    assert service.selectorContainer == "foo=test"
+
+    service = client.wait_success(service.activate())
+    assert service.state == "active"
+
+    wait_for(
+        lambda: len(client.list_serviceExposeMap(serviceId=service.id,
+                                                 state='active')) == 2
+    )
+
+    # add instance having selector label
+    labels = {'foo': "test"}
+    container2 = client.create_container(imageUuid=image_uuid,
+                                         startOnCreate=True,
+                                         labels=labels)
+    container2 = client.wait_success(container2)
+    assert container2.state == "running"
+    wait_for(
+        lambda: len(client.list_serviceExposeMap(serviceId=service.id,
+                                                 state='active')) == 3
+    )
+
+    # scale up
+    service = client.update(service, scale=3)
+    service = client.wait_success(service)
+    wait_for(
+        lambda: len(client.list_serviceExposeMap(serviceId=service.id,
+                                                 state='active')) == 5
+    )
+
+    # scale down, validate container1 and container2 are still running
+    service = client.update(service, scale=1)
+    service = client.wait_success(service)
+    wait_for(
+        lambda: len(client.list_serviceExposeMap(serviceId=service.id,
+                                                 state='active')) == 3
+    )
+    container1 = client.reload(container1)
+    assert container1.state == "running"
+    container2 = client.reload(container2)
+    assert container2.state == "running"
+
+    # remove service, validate not managed instances are still running
+    service = client.wait_success(service.remove())
+    assert service.state == "removed"
+    wait_for(
+        lambda: len(client.list_serviceExposeMap(serviceId=service.id,
+                                                 state='active')) == 0
+    )
+    container1 = client.reload(container1)
+    assert container1.state == "running"
+    container2 = client.reload(container2)
+    assert container2.state == "running"
+
+
+def test_lb_service_add_instance_selector(client, context):
+    env = client.create_environment(name=random_str())
+    env = client.wait_success(env)
+    assert env.state == "active"
+
+    image_uuid = context.image_uuid
+
+    # use case #1 - instance having selector's label,
+    # is present when service with selector is created
+    labels = {'foo32': "bar"}
+    container1 = client.create_container(imageUuid=image_uuid,
+                                         startOnCreate=True,
+                                         labels=labels)
+    container1 = client.wait_success(container1)
+    assert container1.state == "running"
+
+    launch_config = {"imageUuid": "rancher/none"}
+    service = client.create_service(name=random_str(),
+                                    environmentId=env.id,
+                                    launchConfig=launch_config,
+                                    selectorContainer="foo32=bar")
+    service = client.wait_success(service)
+    assert service.selectorContainer == "foo32=bar"
+    service = client.wait_success(service.activate(), 120)
+    assert service.state == "active"
+
+    wait_for(
+        lambda: len(client.list_serviceExposeMap(serviceId=service.id)) == 1
+    )
+
+    # register service to lb service
+    launch_config = {"imageUuid": image_uuid,
+                     "ports": [567, '568:569'],
+                     "expose": [9999, '9998:9997']}
+    lb_service = client.create_loadBalancerService(name=random_str(),
+                                                   environmentId=env.id,
+                                                   launchConfig=launch_config)
+    lb_service = client.wait_success(lb_service)
+    assert lb_service.state == "inactive"
+    lb_service = client.wait_success(lb_service.activate(), 120)
+    assert lb_service.state == "active"
+    service_link = {"serviceId": service.id}
+    lb_service = lb_service.addservicelink(serviceLink=service_link)
+
+    # use case #2 - instance having selector's label,
+    # is added after service with selector creation
+    container2 = client.create_container(imageUuid=image_uuid,
+                                         startOnCreate=True,
+                                         labels=labels)
+    container2 = client.wait_success(container2)
+    assert container2.state == "running"
+    wait_for(
+        lambda: len(client.list_serviceExposeMap(serviceId=service.id)) == 2
+    )
+
+    # validate containers got registered to the LB
+    _wait_until_target_instance_map_created(client, container1)
+    _wait_until_target_instance_map_created(client, container2)
+
+
+def _validate_add_service_link(service,
+                               consumedService, client):
+    service_maps = client. \
+        list_serviceConsumeMap(serviceId=service.id,
+                               consumedServiceId=consumedService.id)
+
+    assert len(service_maps) == 1
+
+    service_map = service_maps[0]
+    wait_for_condition(
+        client, service_map, _resource_is_active,
+        lambda x: 'State is: ' + x.state)
+
+
+def _resource_is_active(resource):
+    return resource.state == 'active'
+
+
+def _wait_until_target_instance_map_created(client,
+                                            container, timeout=30):
+    start = time.time()
+    target_maps = client. \
+        list_loadBalancerTarget(instanceId=container.id)
+    while len(target_maps) == 0:
+        time.sleep(.5)
+        target_maps = super_client. \
+            list_loadBalancerTarget(instanceId=container.id)
+        if time.time() - start > timeout:
+            assert 'Timeout waiting for map creation'
+    return target_maps


### PR DESCRIPTION
2 selector kinds are supported for the service, here are the API object fields:

* selectorLink
* selectorContainer

First one defines which services get linked to it. Second selector defines the criteria that container has to satisfy in order to join the service.

Selector format: 

```
key in (value1, value2)
key notin (value1, value2)
key
key = value
key != value
and any combination of them can be specified in coma separated way:
key != value, key in (value1, value2), key = value
```
 
For selectorLink, validation is done against labels defined on the service; for selectorContainer  - labels defined on the container.


Service can be:

* a combination of managed - containers started based on service launchConfig/scale - and unmanaged - containers joined service based on selectors
* selector only service identified by presence of following param in launch config:

```
image: rancher/none
```

Containers joining the service based on selectors, are not managed by the service replication controller. It means:

* service.deactivate won't stop the container
* service.reconcile won't restart the container if it dies
* service.remove won't remove the unmanaged container; it will just get disassociated from the service, and will continue to run as standalone. 


Selectors get represented in docker-compose.yml as labels.

```
io.rancher.service.selector.container: foo=bar
io.rancher.service.selector.link: foo in (bar)
```


https://github.com/rancher/rancher/issues/2239