### PR TITLE
Fix sed to make it idempotent

### DIFF
--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -24,7 +24,7 @@ install_build_tools
 
 if [ "${CATTLE_DB_CATTLE_DATABASE}" == "mysql" ]; then
     sed -i "0,/3306/! {0,/3306/ s/3306/${CATTLE_DB_CATTLE_MYSQL_PORT}/}" /etc/mysql/my.cnf
-    sed -i 's/^#\(max_connections.*\)/\1/;s/100/1000/' /etc/mysql/my.cnf
+    sed -i 's/^#\(max_connections.*\)/\1/;s/100$/1000/' /etc/mysql/my.cnf
     service mysql start
 
     set +e


### PR DESCRIPTION
This is to make the fix consistent with Rancher server. Prevents unending 0 additions to max_connections when running the bootstrap script in the same container.