### PR TITLE
Slow query optimization

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/HostInstanceIpData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/HostInstanceIpData.java
@@ -1,26 +1,26 @@
 package io.cattle.platform.configitem.context.dao.impl;
 
-import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.InstanceHostMap;
 import io.cattle.platform.core.model.IpAddress;
 
 public class HostInstanceIpData {
-    Instance instance;
+    InstanceHostMap instanceHostMap;
     IpAddress ipAddress;
-
-    public Instance getInstance() {
-        return instance;
-    }
 
     public IpAddress getIpAddress() {
         return ipAddress;
     }
 
-    public void setInstance(Instance instance) {
-        this.instance = instance;
-    }
-
     public void setIpAddress(IpAddress ipAddress) {
         this.ipAddress = ipAddress;
+    }
+
+    public InstanceHostMap getInstanceHostMap() {
+        return instanceHostMap;
+    }
+
+    public void setInstanceHostMap(InstanceHostMap instanceHostMap) {
+        this.instanceHostMap = instanceHostMap;
     }
 
 }


### PR DESCRIPTION
Optimized the query retrieving instances on host network by:

1) retrieving host network of the account and referencing it in the query by id, instead of verifying network.kind info in the query.
2) Added "removed=null" filter for every table participating in join
3) Excluded instance table from the join as we can get instanceId from instancehostmap table itself.

When you run mysql explain on a new sql statement, join type=All is no longer on the picture - fixed by 1). Also "rows" number is reduced - fixed by 2)