### PR TITLE
Service discovery bug fixes

### DIFF
--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
@@ -68,6 +68,7 @@ public class ServiceDiscoveryConstants {
     public static final String LABEL_SERVICE_GLOBAL = "io.rancher.scheduler.global";
     public static final String LABEL_SERVICE_REQUESTED_HOST_ID = "io.rancher.service.requested.host.id";
     public static final String LABEL_SERVICE_LAUNCH_CONFIG = "io.rancher.service.launch.config";
+    public static final String LABEL_SERVICE_CONTAINER_CREATE_ONLY = "io.rancher.container.start_once";
 
     public static final String PRIMARY_LAUNCH_CONFIG_NAME = "io.rancher.service.primary.launch.config";
     public static final String LABEL_SIDEKICK = "io.rancher.sidekicks";

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/ServiceDeploymentPlanner.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/ServiceDeploymentPlanner.java
@@ -5,6 +5,7 @@ import io.cattle.platform.servicediscovery.deployment.impl.DeploymentManagerImpl
 import io.cattle.platform.servicediscovery.deployment.impl.DeploymentUnit;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -73,23 +74,38 @@ public abstract class ServiceDeploymentPlanner {
         this.healthyUnits.addAll(units);
     }
 
-    public List<DeploymentUnit> getBadUnits() {
-        return badUnits;
-    }
-
-    public List<DeploymentUnit> getUnhealthyUnits() {
-        return unhealthyUnits;
-    }
-
     public List<Service> getServices() {
         return services;
     }
 
-    public List<DeploymentUnit> getIncompleteUnits() {
-        return incompleteUnits;
-    }
-
     public List<DeploymentUnit> getHealthyUnits() {
         return healthyUnits;
+    }
+
+    public void cleanupUnhealthyUnits() {
+        Iterator<DeploymentUnit> it = this.unhealthyUnits.iterator();
+        while (it.hasNext()) {
+            DeploymentUnit next = it.next();
+            next.remove();
+            it.remove();
+        }
+    }
+
+    public void cleanupBadUnits() {
+        Iterator<DeploymentUnit> it = this.badUnits.iterator();
+        while (it.hasNext()) {
+            DeploymentUnit next = it.next();
+            next.remove();
+            it.remove();
+        }
+    }
+
+    public void cleanupIncompleteUnits() {
+        Iterator<DeploymentUnit> it = this.incompleteUnits.iterator();
+        while (it.hasNext()) {
+            DeploymentUnit next = it.next();
+            next.cleanupUnit();
+            it.remove();
+        }
     }
 }


### PR DESCRIPTION
1) Error out when there is still a need to reconcile after the reconcile
is finished.

to avoid service.reconcile going into an infinite loop

https://github.com/rancher/rancher/issues/1933

2) RestartPolicy=No in service container context- respect the flag for containers only in HA cases - when
service.update is caused by service.reconcile triggers.

https://github.com/rancher/rancher/issues/1935

3) Define create-only service containers using label "io.rancher.container.start_once" (with value=true) instead of utilizing the restartPolicy param. Makes the bug below no longer relevant: 

https://github.com/rancher/rancher/issues/1752

