### PR TITLE
Export LB ssl params

### DIFF
--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/resource/ServiceDiscoveryConfigItem.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/resource/ServiceDiscoveryConfigItem.java
@@ -1,6 +1,7 @@
 package io.cattle.platform.servicediscovery.api.resource;
 
 import io.cattle.platform.core.constants.InstanceConstants;
+import io.cattle.platform.core.constants.LoadBalancerConstants;
 import io.cattle.platform.core.model.Service;
 import io.cattle.platform.docker.constants.DockerInstanceConstants;
 import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
@@ -74,6 +75,14 @@ public class ServiceDiscoveryConfigItem {
     public static final ServiceDiscoveryConfigItem EXTERNAL_IPS = new ServiceDiscoveryConfigItem(
             ServiceDiscoveryConstants.FIELD_EXTERNALIPS,
             "external_ips", false, false);
+
+    public static final ServiceDiscoveryConfigItem DEFAULT_CERTIFICATE = new ServiceDiscoveryConfigItem(
+            LoadBalancerConstants.FIELD_LB_DEFAULT_CERTIFICATE_ID,
+            "default_cert", false, false);
+
+    public static final ServiceDiscoveryConfigItem CERTIFICATES = new ServiceDiscoveryConfigItem(
+            LoadBalancerConstants.FIELD_LB_CERTIFICATE_IDS,
+            "certs", false, false);
 
     /**
      * Name as it appears in docker-compose file

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/service/impl/RancherCertificatesToComposeFormatter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/service/impl/RancherCertificatesToComposeFormatter.java
@@ -1,0 +1,41 @@
+package io.cattle.platform.servicediscovery.api.service.impl;
+
+import io.cattle.platform.core.model.Certificate;
+import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
+import io.cattle.platform.object.ObjectManager;
+import io.cattle.platform.servicediscovery.api.resource.ServiceDiscoveryConfigItem;
+import io.cattle.platform.servicediscovery.api.service.RancherConfigToComposeFormatter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+public class RancherCertificatesToComposeFormatter extends AbstractJooqDao
+        implements RancherConfigToComposeFormatter {
+
+    @Inject
+    ObjectManager objManager;
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object format(ServiceDiscoveryConfigItem item, Object valueToTransform) {
+        if (item.getDockerName().equalsIgnoreCase(ServiceDiscoveryConfigItem.CERTIFICATES.getDockerName())) {
+            List<Integer> certificateIds = (List<Integer>) valueToTransform;
+            List<String> certificateNames = new ArrayList<>();
+            for (Integer certificateId : certificateIds) {
+                certificateNames.add(getCertName(certificateId));
+            }
+            return certificateNames;
+        } else if (item.getDockerName().equals(ServiceDiscoveryConfigItem.DEFAULT_CERTIFICATE.getDockerName())) {
+            Integer defaultCertId = (Integer) valueToTransform;
+            return getCertName(defaultCertId);
+        } else {
+            return null;
+        }
+    }
+    
+    private String getCertName(Integer certId) {
+        return objManager.loadResource(Certificate.class, certId.longValue()).getName();
+    }
+}

--- a/code/iaas/service-discovery/api/src/main/resources/META-INF/cattle/api-server/spring-service-discovery-api-context.xml
+++ b/code/iaas/service-discovery/api/src/main/resources/META-INF/cattle/api-server/spring-service-discovery-api-context.xml
@@ -34,6 +34,7 @@
        <bean class="io.cattle.platform.servicediscovery.api.service.impl.RancherImageToComposeFormatter" />
        <bean class="io.cattle.platform.servicediscovery.api.service.impl.RancherRestartToComposeFormatter" />
        <bean class="io.cattle.platform.servicediscovery.api.service.impl.RancherGenericMapToComposeFormatter" />
+       <bean class="io.cattle.platform.servicediscovery.api.service.impl.RancherCertificatesToComposeFormatter" />
        
        <bean class="io.cattle.platform.allocator.service.AllocatorServiceImpl" />
         

--- a/resources/content/schema/base/certificate.json
+++ b/resources/content/schema/base/certificate.json
@@ -59,6 +59,9 @@
             "type": "string",
             "required": true,
             "nullable": false
+        },
+         "name":{
+            "required": true
         }
     }
 }

--- a/tests/integration/cattletest/core/test_svc_discovery_lb.py
+++ b/tests/integration/cattletest/core/test_svc_discovery_lb.py
@@ -935,6 +935,15 @@ def test_lb_service_update_certificate(client, context, image_uuid):
     assert lb.defaultCertificateId == cert3.id
     assert lb.certificateIds == [cert1.id]
 
+    compose_config = env.exportconfig()
+    assert compose_config is not None
+    docker_compose = yaml.load(compose_config.dockerComposeConfig)
+    rancher_compose = yaml.load(compose_config.rancherComposeConfig)
+
+    assert docker_compose[service.name]['labels'] == labels
+    assert rancher_compose[service.name]['default_cert'] == cert3.name
+    assert rancher_compose[service.name]['certs'][0] == cert1.name
+
 
 def test_lb_with_certs_service_update(new_context, image_uuid):
     client = new_context.client


### PR DESCRIPTION
1) defaultCertificateId/certificates fields get exported to rancher-compose.yml parameters: default_cert and certs respectively 

2) ssl ports are represented as the label in the docker-compose.yml. Example: 

io.rancher.loadbalancer.ssl.ports=443,465

https://github.com/rancher/rancher/issues/1909

@ibuildthecloud @vincent99 ^^