### PR TITLE
More bugfixes

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
@@ -504,6 +504,13 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
                 LOAD_BALANCER.REMOVED, null);
         if (lb != null) {
             Map<String, Object> data = new HashMap<>();
+            if (certIds == null) {
+                certIds = DataAccessor.fields(service)
+                        .withKey(LoadBalancerConstants.FIELD_LB_CERTIFICATE_IDS).asList(jsonMapper, Long.class);
+            }
+            if (defaultCertId == null) {
+                defaultCertId = DataAccessor.fieldLong(service, LoadBalancerConstants.FIELD_LB_DEFAULT_CERTIFICATE_ID);
+            }
             data.put(LoadBalancerConstants.FIELD_LB_CERTIFICATE_IDS, certIds);
             data.put(LoadBalancerConstants.FIELD_LB_DEFAULT_CERTIFICATE_ID, defaultCertId);
             DataUtils.getWritableFields(lb).putAll(data);

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
@@ -407,8 +407,16 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
 
         LoadBalancer lb = objectManager.findOne(LoadBalancer.class, LOAD_BALANCER.SERVICE_ID,
                 lbSvc.getId(), LOAD_BALANCER.REMOVED, null);
+        if (lb == null) {
+            return;
+        }
+
         ServiceConsumeMap map = consumeMapDao.findNonRemovedMap(lbSvc.getId(), instanceToRegister.getServiceId(),
                 null);
+        if (map == null) {
+            return;
+        }
+
         LoadBalancerTargetInput target = new LoadBalancerTargetInput(instanceToRegister,
                 map, jsonMapper);
         lbService.addTargetToLoadBalancer(lb, target);

--- a/tests/integration/cattletest/core/test_cert.py
+++ b/tests/integration/cattletest/core/test_cert.py
@@ -30,18 +30,6 @@ def test_create_cert_basic(client):
     return cert1
 
 
-def test_create_cert_invalid_key(client):
-    cert = _read_cert("cert.pem")
-    key = _read_cert("key_invalid.pem")
-    with pytest.raises(ApiError) as e:
-        client. \
-            create_certificate(name=random_str(),
-                               cert=cert,
-                               key=key)
-    assert e.value.error.status == 422
-    assert e.value.error.code == 'InvalidFormat'
-
-
 def test_create_cert_invalid_cert(client):
     cert = _read_cert("cert_invalid.pem")
     key = _read_cert("key.pem")
@@ -67,20 +55,6 @@ def test_create_cert_chain(client):
     assert cert1.state == 'active'
     assert cert1.cert == cert
     return cert1
-
-
-def test_invalid_key_cert_in_cert_chain(client):
-    cert = _read_cert("cert.pem")
-    key = _read_cert("key.pem")
-    chain = _read_cert("enduser-example.com.chain")
-    with pytest.raises(ApiError) as e:
-        client. \
-            create_certificate(name=random_str(),
-                               cert=cert,
-                               key=key,
-                               certChain=chain)
-    assert e.value.error.status == 422
-    assert e.value.error.code == 'InvalidFormat'
 
 
 def _read_cert(name):

--- a/tests/integration/cattletest/core/test_svc_discovery_lb.py
+++ b/tests/integration/cattletest/core/test_svc_discovery_lb.py
@@ -1037,9 +1037,15 @@ def test_cert_in_use(client, context, image_uuid):
     assert lb.defaultCertificateId == cert1.id
     assert lb.certificateIds == [cert1.id, cert2.id]
 
-    # try to remove the cert
+    # try to remove the cert - delete action (used by UI)
     with pytest.raises(ApiError) as e:
         client.delete(cert1)
+    assert e.value.error.status == 405
+    assert e.value.error.code == 'InvalidAction'
+
+    # try to remove the cert - remove action
+    with pytest.raises(ApiError) as e:
+        cert1.remove()
     assert e.value.error.status == 405
     assert e.value.error.code == 'InvalidAction'
 

--- a/tests/integration/cattletest/core/test_svc_discovery_lb.py
+++ b/tests/integration/cattletest/core/test_svc_discovery_lb.py
@@ -944,6 +944,23 @@ def test_lb_service_update_certificate(client, context, image_uuid):
     assert rancher_compose[service.name]['default_cert'] == cert3.name
     assert rancher_compose[service.name]['certs'][0] == cert1.name
 
+    # don't pass certificate ids and validate that they are still set
+    service = client.update(service, name='newName')
+    client.wait_success(service, 120)
+
+    lb = client.reload(lb)
+    assert lb.defaultCertificateId == cert3.id
+    assert lb.certificateIds == [cert1.id]
+
+    # update with none certificates
+    service = client.update(service, certificateIds=None,
+                            defaultCertificateId=None)
+    client.wait_success(service, 120)
+
+    lb = client.reload(lb)
+    assert lb.defaultCertificateId is None
+    assert lb.certificateIds is None
+
 
 def test_lb_with_certs_service_update(new_context, image_uuid):
     client = new_context.client


### PR DESCRIPTION
1) Fixed error message noticed while running tests

2) Disabled certificate chain validation on the java side.

As some vendors issue certificates without including Root/intermediate certs in them as these are expected to be present in the CA store on the client side.

Tested it on haproxy 1.5.3; it doesn't validate the certificate chain and it doesn't complete missing certificate. So if user provides an incomplete chain, that what would be served by haproxy to the client and the validation will fail there.

@ibuildthecloud let me know if you are ok with that

https://github.com/rancher/rancher/issues/1943

3) If lbService.update is called w/o certificate ids, pass existing values set on the service to the lb->certificate map update. Sigh, can't wait to refactor the code and get rid of standalone LB support.

https://github.com/rancher/rancher/issues/1966

4) Validate both remove and delete operations when check if certificate to remove is in use (UI used delete):

https://github.com/rancher/rancher/issues/1965