### PR TITLE
Prevent NPE in ContainerEventCreate

### DIFF
--- a/code/iaas/ha/src/main/java/io/cattle/platform/ha/monitor/impl/ReportedInstance.java
+++ b/code/iaas/ha/src/main/java/io/cattle/platform/ha/monitor/impl/ReportedInstance.java
@@ -8,6 +8,8 @@ import io.cattle.platform.util.type.CollectionUtils;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
 class ReportedInstance {
 
     String uuid;
@@ -97,5 +99,9 @@ class ReportedInstance {
 
     public void setInstance(KnownInstance instance) {
         this.instance = instance;
+    }
+
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
     }
 }

--- a/code/iaas/ha/src/main/java/io/cattle/platform/ha/monitor/model/KnownInstance.java
+++ b/code/iaas/ha/src/main/java/io/cattle/platform/ha/monitor/model/KnownInstance.java
@@ -1,6 +1,7 @@
 package io.cattle.platform.ha.monitor.model;
 
 import java.util.Date;
+import java.util.Map;
 
 public class KnownInstance {
     String uuid;
@@ -9,6 +10,7 @@ public class KnownInstance {
     String systemContainer;
     String instanceTriggeredStop;
     Date removed;
+    Map<String, Object>data;
     
     public String getUuid() {
         return uuid;
@@ -46,5 +48,10 @@ public class KnownInstance {
     public void setRemoved(Date removed) {
         this.removed = removed;
     }
-    
+    public Map<String, Object> getData() {
+        return data;
+    }
+    public void setData(Map<String, Object> data) {
+        this.data = data;
+    }
 }

--- a/code/implementation/simulator/agent-connection/src/main/java/io/cattle/platform/agent/connection/simulator/AgentConnectionSimulator.java
+++ b/code/implementation/simulator/agent-connection/src/main/java/io/cattle/platform/agent/connection/simulator/AgentConnectionSimulator.java
@@ -18,7 +18,7 @@ public class AgentConnectionSimulator implements AgentConnection {
     Agent agent;
     boolean open = true;
     List<AgentSimulatorEventProcessor> processors;
-    Map<String, String[]> instances = new HashMap<String, String[]>();
+    Map<String, Object[]> instances = new HashMap<String, Object[]>();
 
     public AgentConnectionSimulator(Agent agent, List<AgentSimulatorEventProcessor> processors) {
         super();
@@ -66,7 +66,7 @@ public class AgentConnectionSimulator implements AgentConnection {
         return agent;
     }
 
-    public Map<String, String[]> getInstances() {
+    public Map<String, Object[]> getInstances() {
         return instances;
     }
 

--- a/code/implementation/simulator/agent-connection/src/main/java/io/cattle/platform/agent/connection/simulator/impl/SimulatorPingProcessor.java
+++ b/code/implementation/simulator/agent-connection/src/main/java/io/cattle/platform/agent/connection/simulator/impl/SimulatorPingProcessor.java
@@ -50,9 +50,17 @@ public class SimulatorPingProcessor implements AgentSimulatorEventProcessor {
     protected void addInstances(AgentConnectionSimulator simulator, Ping pong, Agent agent) {
         List<Map<String, Object>> resources = pong.getData().getResources();
 
-        for (Map.Entry<String, String[]> kv : simulator.getInstances().entrySet()) {
-            Map<String, Object> instanceMap = CollectionUtils.asMap(ObjectMetaDataManager.TYPE_FIELD, InstanceConstants.TYPE, ObjectMetaDataManager.UUID_FIELD,
-                    kv.getKey(), ObjectMetaDataManager.STATE_FIELD, kv.getValue()[0], "dockerId", kv.getValue()[1]);
+        for (Map.Entry<String, Object[]> kv : simulator.getInstances().entrySet()) {
+            // This matches the data structure returned by the ping logic in the real ping agent.
+            Map<String, Object> instanceMap = CollectionUtils.asMap(
+                    ObjectMetaDataManager.TYPE_FIELD, InstanceConstants.TYPE,
+                    ObjectMetaDataManager.UUID_FIELD, kv.getKey(),
+                    ObjectMetaDataManager.STATE_FIELD, kv.getValue()[0],
+                    "systemContainer", null,
+                    "dockerId", kv.getValue()[1],
+                    "image", kv.getValue()[2],
+                    "labels", new String[0],
+                    "created", kv.getValue()[3]);
             resources.add(instanceMap);
         }
 


### PR DESCRIPTION
In simulated tests, we werent maintaing enough data in the simulated hosts. Specifically, image, but this PR maintains all the same info that a real host maintains.