### PR TITLE
Fix for setting truncated  io.rancher.container.hostname_override when instance.name > 64 chars

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DefaultDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DefaultDeploymentUnitInstance.java
@@ -88,10 +88,21 @@ public class DefaultDeploymentUnitInstance extends AbstractInstanceUnit {
             String overrideHostName = ((Map<String, String>) labels)
                     .get(ServiceDiscoveryConstants.LABEL_OVERRIDE_HOSTNAME);
             if (StringUtils.equalsIgnoreCase(overrideHostName, "container_name")) {
-                launchConfigData.put(InstanceConstants.FIELD_HOSTNAME, this.instanceName);
+                String overrideName = getOverrideHostName(this.instanceName);
+                launchConfigData.put(InstanceConstants.FIELD_HOSTNAME, overrideName);
             }
         }
         return launchConfigData;
+    }
+
+    private String getOverrideHostName(String instanceName) {
+        String overrideName = instanceName;
+        if (instanceName != null && instanceName.length() > 64) {
+            String serviceNumber = instanceName.substring(instanceName.lastIndexOf("_"));
+            int truncateIndex = 64 - serviceNumber.length();
+            overrideName = instanceName.substring(0, truncateIndex) + serviceNumber;
+        }
+        return overrideName;
     }
 
     @Override

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -11,6 +11,14 @@ def _create_stack(client):
     return env
 
 
+def _create_stack_long_name(client):
+    lname = "MyLongerStackNameCausingIssue"
+    env = client.create_environment(name=lname)
+    env = client.wait_success(env)
+    assert env.state == "active"
+    return env
+
+
 def create_env_and_svc(client, context):
     env = _create_stack(client)
 
@@ -2318,6 +2326,59 @@ def test_validate_hostname_override(client, context):
 
     # validate the host was overriden with instancename
     assert instance2.hostname == instance2.name
+
+
+def test_validate_long_hostname_override(client, context):
+    # create environment and services
+    env = _create_stack_long_name(client)
+    image_uuid = context.image_uuid
+    launch_config1 = {
+        "imageUuid": image_uuid,
+        "labels": {
+            'io.rancher.container.hostname_override': 'container_name'
+        }
+    }
+    first_service_name = "MyServiceNameLongerThanDNSPrefixLengthAllowed"
+    service1 = client.create_service(name=first_service_name,
+                                     environmentId=env.id,
+                                     launchConfig=launch_config1)
+    service1 = client.wait_success(service1)
+    assert service1.state == "inactive"
+
+    service1 = client.wait_success(service1.activate())
+    assert service1.state == "active"
+    instance1 = _validate_compose_instance_start(client, service1, env, "1")
+
+    # validate the host was overriden with truncated
+    # instancename - length should be 64
+    trunc_name = "MyLongerStackNameCausingIssue_" \
+                 "MyServiceNameLongerThanDNSPrefix_1"
+    assert instance1.hostname == trunc_name
+
+    # use case 2 - validate that even passed hostname
+    # gets overriden by the truncated instancename
+    launch_config2 = {
+        "imageUuid": image_uuid,
+        "labels": {
+            'io.rancher.container.hostname_override': 'container_name',
+            "hostname": "test"
+        }
+    }
+    second_service_name = "SecondServiceNameLongerThanDNSPrefixLengthAllowed"
+    service2 = client.create_service(name=second_service_name,
+                                     environmentId=env.id,
+                                     launchConfig=launch_config2)
+    service2 = client.wait_success(service2)
+    assert service2.state == "inactive"
+
+    service2 = client.wait_success(service2.activate())
+    assert service2.state == "active"
+    instance2 = _validate_compose_instance_start(client, service2, env, "1")
+
+    # validate the host was overriden with instancename
+    trunc_name2 = "MyLongerStackNameCausingIssue_" \
+                  "SecondServiceNameLongerThanDNSPr_1"
+    assert instance2.hostname == trunc_name2
 
 
 def test_vip_service(client, context):


### PR DESCRIPTION
When instance.name > 64, cant set hostname on the backend due to DNS segment length limit.

So truncate the instance.name value to be max 64 chars and use it to override the hostname.

An instance_name is of the format  [stack name]_[service name]_[instance number]. The fix is to retain the [instance_number] and truncate the part [stack name]_[service name] so that the full name is within 64 char limit.

https://github.com/rancher/rancher/issues/1934