### PR TITLE
If api.host is unset the value of startup-env is wrong

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/ConfigUrlInfoFactory.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/ConfigUrlInfoFactory.java
@@ -24,6 +24,7 @@ public class ConfigUrlInfoFactory extends AbstractAgentBaseContextFactory implem
 
     @Override
     protected void populateContext(Agent agent, Instance instance, ConfigItem item, ArchiveContext context) {
+        context.getData().put("customApiHost", ServerContext.isCustomApiHost());
         context.getData().put("configUrl", ServerContext.getHostApiBaseUrl(BaseProtocol.HTTP));
     }
 

--- a/resources/content/config-content/agent-instance-startup/content-home/etc/cattle/startup-env.ftl
+++ b/resources/content/config-content/agent-instance-startup/content-home/etc/cattle/startup-env.ftl
@@ -1,1 +1,3 @@
+<#if customApiHost >
 export CATTLE_CONFIG_URL="${configUrl}"
+</#if>


### PR DESCRIPTION
For an initial setup where api.host is unset the value of
${CATTLE_HOME}/etc/cattle/startup-env will be set to a possibly wrong IP
address from the Rancher server