### PR TITLE
LB service.activate - wait for hostMap and instance creation

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/LoadBalancerDaoImpl.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/LoadBalancerDaoImpl.java
@@ -74,7 +74,7 @@ public class LoadBalancerDaoImpl extends AbstractJooqDao implements LoadBalancer
                         .and(LOAD_BALANCER.ID.eq(lbId))
                         .and(
                         LOAD_BALANCER.STATE.in(CommonStatesConstants.ACTIVATING,
-                                CommonStatesConstants.ACTIVE)))
+                                        CommonStatesConstants.ACTIVE, CommonStatesConstants.UPDATING_ACTIVE)))
                 .fetchInto(LoadBalancerRecord.class);
         if (lbs.isEmpty()) {
             return null;


### PR DESCRIPTION
Used to skip the last part. Should be similar to regular service where
instance.state=running is a requirement for service to be in active
state.

Also fixed the LB update process - added one more state to the
list of UP lb states. It has caused the issue when service.update was called with certificateids and a new scale. CertificateIds update triggered LB to go into updating-activate state, that in turn resulted for the new LB instance to never start as underlying LB updateconfig code used to look for LBs only in activate/activating state.

https://github.com/rancher/rancher/issues/2011

The bug always happened when service got updated with the new scale + new set of certificates