### PR TITLE
Make core thread pool never reject tasks

### DIFF
--- a/code/iaas/system/src/main/resources/META-INF/cattle/system/spring-system-context.xml
+++ b/code/iaas/system/src/main/resources/META-INF/cattle/system/spring-system-context.xml
@@ -32,8 +32,7 @@
     <management:executor-service 
         id="CoreExecutorService"
         keep-alive="120"
-        pool-size="0-100"
-        queue-capacity="0"
+        pool-size="25"
         />
 
     <bean class="io.cattle.platform.util.concurrent.NamedExecutorService" >


### PR DESCRIPTION
The core thread pool should not reject tasks because of the
RetryTimeoutService