### PR TITLE
Service discovery fixes

### DIFF
--- a/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/InstanceHealthcheckRegister.java
+++ b/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/InstanceHealthcheckRegister.java
@@ -45,11 +45,13 @@ public class InstanceHealthcheckRegister extends AbstractObjectProcessLogic impl
                 InstanceConstants.FIELD_HEALTH_CHECK, jsonMapper, InstanceHealthCheck.class);
 
         // set healthcheck
+        Long startCount = instance.getStartCount() == null ? 0 : instance.getStartCount() + 1;
         if (healthCheck != null) {
-            Long startCount = instance.getStartCount() == null ? 0 : instance.getStartCount() + 1;
             objectManager.setFields(instance, INSTANCE.START_COUNT, startCount, INSTANCE.HEALTH_STATE,
                     HealthcheckConstants.HEALTH_STATE_INITIALIZING);
             healtcheckService.registerForHealtcheck(HealthcheckInstanceType.INSTANCE, instance.getId());
+        } else {
+            objectManager.setFields(instance, INSTANCE.START_COUNT, startCount);
         }
         return null;
     }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
@@ -39,6 +39,7 @@ public class InstanceConstants {
     public static final String FIELD_EXPOSE = "expose";
     public static final String FIELD_HOSTNAME = "hostname";
     public static final String FIELD_CREATE_INDEX = "createIndex";
+    public static final String FIELD_DEPLOYMENT_UNIT_UUID = "deploymentUnitUuid";
 
     public static final String PROCESS_DATA_NO_OP = "containerNoOpEvent";
 

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/Instance.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/Instance.java
@@ -366,6 +366,17 @@ public interface Instance extends java.io.Serializable {
 	@javax.persistence.Column(name = "create_index", precision = 19)
 	public java.lang.Long getCreateIndex();
 
+	/**
+	 * Setter for <code>cattle.instance.deployment_unit_uuid</code>.
+	 */
+	public void setDeploymentUnitUuid(java.lang.String value);
+
+	/**
+	 * Getter for <code>cattle.instance.deployment_unit_uuid</code>.
+	 */
+	@javax.persistence.Column(name = "deployment_unit_uuid", length = 128)
+	public java.lang.String getDeploymentUnitUuid();
+
 	// -------------------------------------------------------------------------
 	// FROM and INTO
 	// -------------------------------------------------------------------------

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/InstanceTable.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/InstanceTable.java
@@ -11,7 +11,7 @@ package io.cattle.platform.core.model.tables;
 @java.lang.SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class InstanceTable extends org.jooq.impl.TableImpl<io.cattle.platform.core.model.tables.records.InstanceRecord> {
 
-	private static final long serialVersionUID = 1555254989;
+	private static final long serialVersionUID = 1433297026;
 
 	/**
 	 * The singleton instance of <code>cattle.instance</code>
@@ -185,6 +185,11 @@ public class InstanceTable extends org.jooq.impl.TableImpl<io.cattle.platform.co
 	 * The column <code>cattle.instance.create_index</code>.
 	 */
 	public final org.jooq.TableField<io.cattle.platform.core.model.tables.records.InstanceRecord, java.lang.Long> CREATE_INDEX = createField("create_index", org.jooq.impl.SQLDataType.BIGINT, this, "");
+
+	/**
+	 * The column <code>cattle.instance.deployment_unit_uuid</code>.
+	 */
+	public final org.jooq.TableField<io.cattle.platform.core.model.tables.records.InstanceRecord, java.lang.String> DEPLOYMENT_UNIT_UUID = createField("deployment_unit_uuid", org.jooq.impl.SQLDataType.VARCHAR.length(128), this, "");
 
 	/**
 	 * Create a <code>cattle.instance</code> table reference

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/records/InstanceRecord.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/records/InstanceRecord.java
@@ -13,7 +13,7 @@ package io.cattle.platform.core.model.tables.records;
 @javax.persistence.Table(name = "instance", schema = "cattle")
 public class InstanceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.platform.core.model.tables.records.InstanceRecord> implements io.cattle.platform.db.jooq.utils.TableRecordJaxb, io.cattle.platform.core.model.Instance {
 
-	private static final long serialVersionUID = 1229743951;
+	private static final long serialVersionUID = -79467212;
 
 	/**
 	 * Setter for <code>cattle.instance.id</code>.
@@ -560,6 +560,23 @@ public class InstanceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.
 		return (java.lang.Long) getValue(31);
 	}
 
+	/**
+	 * Setter for <code>cattle.instance.deployment_unit_uuid</code>.
+	 */
+	@Override
+	public void setDeploymentUnitUuid(java.lang.String value) {
+		setValue(32, value);
+	}
+
+	/**
+	 * Getter for <code>cattle.instance.deployment_unit_uuid</code>.
+	 */
+	@javax.persistence.Column(name = "deployment_unit_uuid", length = 128)
+	@Override
+	public java.lang.String getDeploymentUnitUuid() {
+		return (java.lang.String) getValue(32);
+	}
+
 	// -------------------------------------------------------------------------
 	// Primary key information
 	// -------------------------------------------------------------------------
@@ -613,6 +630,7 @@ public class InstanceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.
 		setHealthState(from.getHealthState());
 		setStartCount(from.getStartCount());
 		setCreateIndex(from.getCreateIndex());
+		setDeploymentUnitUuid(from.getDeploymentUnitUuid());
 	}
 
 	/**
@@ -638,7 +656,7 @@ public class InstanceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.
 	/**
 	 * Create a detached, initialised InstanceRecord
 	 */
-	public InstanceRecord(java.lang.Long id, java.lang.String name, java.lang.Long accountId, java.lang.String kind, java.lang.String uuid, java.lang.String description, java.lang.String state, java.util.Date created, java.util.Date removed, java.util.Date removeTime, java.util.Map<String,Object> data, java.lang.String allocationState, java.lang.Long compute, java.lang.Long memoryMb, java.lang.Long imageId, java.lang.Long offeringId, java.lang.String hostname, java.lang.Long zoneId, java.lang.String instanceTriggeredStop, java.lang.Long agentId, java.lang.String domain, java.util.Date firstRunning, java.lang.String token, java.lang.String userdata, java.lang.String systemContainer, java.lang.Long registryCredentialId, java.lang.String externalId, java.lang.Boolean nativeContainer, java.lang.Long networkContainerId, java.lang.String healthState, java.lang.Long startCount, java.lang.Long createIndex) {
+	public InstanceRecord(java.lang.Long id, java.lang.String name, java.lang.Long accountId, java.lang.String kind, java.lang.String uuid, java.lang.String description, java.lang.String state, java.util.Date created, java.util.Date removed, java.util.Date removeTime, java.util.Map<String,Object> data, java.lang.String allocationState, java.lang.Long compute, java.lang.Long memoryMb, java.lang.Long imageId, java.lang.Long offeringId, java.lang.String hostname, java.lang.Long zoneId, java.lang.String instanceTriggeredStop, java.lang.Long agentId, java.lang.String domain, java.util.Date firstRunning, java.lang.String token, java.lang.String userdata, java.lang.String systemContainer, java.lang.Long registryCredentialId, java.lang.String externalId, java.lang.Boolean nativeContainer, java.lang.Long networkContainerId, java.lang.String healthState, java.lang.Long startCount, java.lang.Long createIndex, java.lang.String deploymentUnitUuid) {
 		super(io.cattle.platform.core.model.tables.InstanceTable.INSTANCE);
 
 		setValue(0, id);
@@ -673,5 +691,6 @@ public class InstanceRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.
 		setValue(29, healthState);
 		setValue(30, startCount);
 		setValue(31, createIndex);
+		setValue(32, deploymentUnitUuid);
 	}
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentManagerImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentManagerImpl.java
@@ -192,7 +192,7 @@ public class DeploymentManagerImpl implements DeploymentManager {
          * For instances having networkFrom deps, if A used network of B, and B is restarted, A has to be restarted as
          * well.
          */
-        cleanupPartiallyStoppedUnits(planner);
+        // cleanupPartiallyStoppedUnits(planner);
 
         /*
          * Activate all the units
@@ -233,14 +233,6 @@ public class DeploymentManagerImpl implements DeploymentManager {
 
         for (DeploymentUnit unit : units) {
             unit.waitForStart();
-        }
-    }
-
-    protected void cleanupPartiallyStoppedUnits(ServiceDeploymentPlanner planner) {
-        List<DeploymentUnit> units = planner.getHealthyUnits();
-
-        for (DeploymentUnit unit : units) {
-            unit.cleanupPartiallyStoppedUnit();
         }
     }
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnit.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnit.java
@@ -162,16 +162,6 @@ public class DeploymentUnit {
         }
     }
 
-    public void cleanupPartiallyStoppedUnit() {
-        /*
-         * Delete all the units having missing dependencies
-         */
-        for (Long serviceId : svc.keySet()) {
-            DeploymentUnitService duService = svc.get(serviceId);
-            duService.stopInstancesWithStoppedDependencies();
-        }
-    }
-
     public void stop() {
         /*
          * stops all instances. This should be non-blocking (don't wait)
@@ -342,6 +332,7 @@ public class DeploymentUnit {
         if (networkContainerId != null) {
             deployParams.put(DockerInstanceConstants.FIELD_NETWORK_CONTAINER_ID, networkContainerId);
         }
+        deployParams.put(InstanceConstants.FIELD_DEPLOYMENT_UNIT_UUID, this.uuid);
         return deployParams;
     }
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnitService.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentUnitService.java
@@ -85,30 +85,6 @@ public class DeploymentUnitService {
         }
     }
 
-    public void stopInstancesWithStoppedDependencies() {
-        for (String launchConfigName : launchConfigNames) {
-            DeploymentUnitInstance instance = launchConfigToInstance.get(launchConfigName);
-            if (instance != null && !instance.isStarted()) {
-                stopInstancesWithStoppedDeps(launchConfigName);
-            }
-        }
-    }
-
-    protected void stopInstancesWithStoppedDeps(String launchConfigName) {
-        List<String> usedInLaunchConfigs = sidekickUsedByMap.get(launchConfigName);
-        if (usedInLaunchConfigs == null) {
-            return;
-        }
-        for (String usedInLaunchConfig : usedInLaunchConfigs) {
-            DeploymentUnitInstance usedByInstance = launchConfigToInstance.get(usedInLaunchConfig);
-            if (usedByInstance == null) {
-                continue;
-            }
-            usedByInstance.stop();
-            stopInstancesWithStoppedDeps(usedInLaunchConfig);
-        }
-    }
-
     protected void cleanupInstanceWithMissingDep(String launchConfigName) {
         List<String> usedInLaunchConfigs = sidekickUsedByMap.get(launchConfigName);
         if (usedInLaunchConfigs == null) {

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/GlobalServiceDeploymentPlanner.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/GlobalServiceDeploymentPlanner.java
@@ -22,7 +22,7 @@ public class GlobalServiceDeploymentPlanner extends ServiceDeploymentPlanner {
         for (Service service : services) {
             List<Long> hostIdsToDeployService =
                     context.allocatorService.getHostsSatisfyingHostAffinity(service.getAccountId(),
-                            ServiceDiscoveryUtil.getServiceLabels(service, context.allocatorService));
+                            ServiceDiscoveryUtil.getServiceLabelsUnion(service, context.allocatorService));
             hostIds.addAll(hostIdsToDeployService);
         }
         for (DeploymentUnit unit : units) {

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/ServiceDeploymentPlannerFactoryImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/ServiceDeploymentPlannerFactoryImpl.java
@@ -21,7 +21,7 @@ public class ServiceDeploymentPlannerFactoryImpl implements ServiceDeploymentPla
         }
 
         Service service = services.get(0);
-        Map<String, String> serviceLabels = ServiceDiscoveryUtil.getServiceLabels(service, context.allocatorService);
+        Map<String, String> serviceLabels = ServiceDiscoveryUtil.getServiceLabelsUnion(service, context.allocatorService);
         String globalService = serviceLabels.get(ServiceDiscoveryConstants.LABEL_SERVICE_GLOBAL);
 
         if (service.getKind().equalsIgnoreCase(ServiceDiscoveryConstants.KIND.EXTERNALSERVICE.name())

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/NetworkFromInstanceStop.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/NetworkFromInstanceStop.java
@@ -1,0 +1,53 @@
+package io.cattle.platform.servicediscovery.process;
+
+import static io.cattle.platform.core.model.tables.InstanceTable.INSTANCE;
+import io.cattle.platform.core.constants.InstanceConstants;
+import io.cattle.platform.core.dao.NetworkDao;
+import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.engine.handler.HandlerResult;
+import io.cattle.platform.engine.process.ProcessInstance;
+import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.json.JsonMapper;
+import io.cattle.platform.process.common.handler.AbstractObjectProcessHandler;
+import io.cattle.platform.servicediscovery.service.ServiceDiscoveryService;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+public class NetworkFromInstanceStop extends AbstractObjectProcessHandler {
+
+    @Inject
+    ServiceDiscoveryService sdService;
+    @Inject
+    JsonMapper jsonMapper;
+
+    @Inject
+    NetworkDao ntwkDao;
+
+    @Override
+    public String[] getProcessNames() {
+        return new String[] { InstanceConstants.PROCESS_STOP, InstanceConstants.PROCESS_RESTART };
+    }
+
+    @Override
+    public HandlerResult handle(ProcessState state, ProcessInstance process) {
+        Instance instance = (Instance) state.getResource();
+        if (instance.getDeploymentUnitUuid() == null) {
+            return null;
+        }
+        
+        List<Instance> dependants = objectManager.find(Instance.class, INSTANCE.REMOVED, null,
+                INSTANCE.DEPLOYMENT_UNIT_UUID, instance.getDeploymentUnitUuid(), INSTANCE.NETWORK_CONTAINER_ID,
+                instance.getId());
+        if (dependants.isEmpty()) {
+            return null;
+        }
+        
+        for (Instance dependant : dependants) {
+            objectProcessManager.scheduleProcessInstance(InstanceConstants.PROCESS_STOP, dependant, null);
+        }
+
+        return null;
+    }
+}

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/GlobalHostActivateServiceLookup.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/GlobalHostActivateServiceLookup.java
@@ -50,7 +50,7 @@ public class GlobalHostActivateServiceLookup implements ServiceLookup {
         List<? extends Service> services = expMapDao.getActiveServices(host.getAccountId());
         List<Service> activeGlobalServices = new ArrayList<Service>();
         for (Service service : services) {
-            Map<String, String> serviceLabels = ServiceDiscoveryUtil.getServiceLabels(service, allocatorSvc);
+            Map<String, String> serviceLabels = ServiceDiscoveryUtil.getServiceLabelsUnion(service, allocatorSvc);
             if (serviceLabels.containsKey(ServiceDiscoveryConstants.LABEL_SERVICE_GLOBAL) &&
                     allocatorSvc.hostChangesAffectsHostAffinityRules(host.getId(), serviceLabels)) {
                 activeGlobalServices.add(service);

--- a/code/iaas/service-discovery/server/src/main/resources/META-INF/cattle/system-services/spring-service-discovery-server-context.xml
+++ b/code/iaas/service-discovery/server/src/main/resources/META-INF/cattle/system-services/spring-service-discovery-server-context.xml
@@ -18,6 +18,7 @@
     <bean class="io.cattle.platform.servicediscovery.process.ServiceCreate" />
     <bean class="io.cattle.platform.servicediscovery.process.ServiceUpgrade" />
     <bean class="io.cattle.platform.servicediscovery.process.ServiceCancelupgrade" />
+    <bean class="io.cattle.platform.servicediscovery.process.NetworkFromInstanceStop" />
 
     <bean class="io.cattle.platform.servicediscovery.process.EnvironmentRemove" />
 

--- a/resources/content/db/changelog.xml
+++ b/resources/content/db/changelog.xml
@@ -65,5 +65,6 @@
     <include file="db/core-058.xml"/>
     <include file="db/core-059.xml"/>
     <include file="db/core-060.xml"/>
+    <include file="db/core-061.xml"/>
     
 </databaseChangeLog>

--- a/resources/content/db/core-061.xml
+++ b/resources/content/db/core-061.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+    <property name="mediumtext" value="TEXT" dbms="postgresql" />
+    <property name="mediumtext" value="MEDIUMTEXT" />
+    <changeSet author="alena (generated)" id="dump1">
+        <addColumn tableName="instance">
+            <column name="deployment_unit_uuid" type="VARCHAR(128)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
1) Update start_count for all instances
Used to update for only ones having healthcheck enabled.

Supposed to resolve following TF: 

http://ci.rancher.io/github.com/rancher/cattle/master/e8055d3df7c6b99956fabd92770caa9aeadc46d9

2) Merge only affinity labels for sidekicks @cjellick ^^

3) Fixed TF happening once in a while on Drone:

http://ci.rancher.io/github.com/rancher/cattle/pull_status/95298420d9a2f94172eda522c748bcd116152a0b

Wait for service instance map count to match certain value instead of expecting it to be this value once the service is activated. Service.activate does wait only for instances to be running, but not for service instance maps to be active (in 99% of the cases this map would be active though, and TF happened due to 1% chance)

4) Refactored restart process for containers having networkFrom deps. If A used network of B, on B stop/restart A should be restarted as well. Before it used to be handled in deployment manager logic. With this fix, its moved to container.stop/restart process handler. On B stop/restart A gets stopped, and its start logic will be delegated to service.reconcile code.

@ibuildthecloud 