### PR TITLE
Fixed DNS programming for the accounts created before Rancher beta

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/DnsInfoDaoImpl.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/DnsInfoDaoImpl.java
@@ -594,6 +594,9 @@ public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
     protected List<HostInstanceIpData> getHostContainerIpData(long accountId) {
         Network hostNtwk = objManager.findAny(Network.class, NETWORK.ACCOUNT_ID, accountId, NETWORK.REMOVED, null,
                 NETWORK.KIND, "dockerHost");
+        if (hostNtwk == null) {
+            return new ArrayList<HostInstanceIpData>();
+        }
         MultiRecordMapper<HostInstanceIpData> mapper = new MultiRecordMapper<HostInstanceIpData>() {
             @Override
             protected HostInstanceIpData map(List<Object> input) {


### PR DESCRIPTION
The account were missing networks, and the DNS code used to rely on the
fact that docker host network support is in

https://github.com/rancher/rancher/issues/2024