### PR TITLE
Revert "Merge only affinity labels for sidekicks"

### DIFF
--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/util/ServiceDiscoveryUtil.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/util/ServiceDiscoveryUtil.java
@@ -72,7 +72,7 @@ public class ServiceDiscoveryUtil {
     }
 
     @SuppressWarnings("unchecked")
-    public static Map<String, String> getServiceLabelsUnion(Service service, AllocatorService allocatorService) {
+    public static Map<String, String> getServiceLabels(Service service, AllocatorService allocatorService) {
         List<String> launchConfigNames = getServiceLaunchConfigNames(service);
         Map<String, String> labelsStr = new HashMap<>();
         for (String launchConfigName : launchConfigNames) {
@@ -87,43 +87,17 @@ public class ServiceDiscoveryUtil {
         return labelsStr;
     }
 
-    @SuppressWarnings("unchecked")
     public static Map<String, Object> getLaunchConfigDataWLabelsUnion(Service service, String launchConfigName, AllocatorService allocatorService) {
         Map<String, Object> launchConfigData = new HashMap<>();
 
         // 1) get launch config data from the list of primary/secondary
         launchConfigData.putAll(getLaunchConfigDataAsMap(service, launchConfigName));
 
-        // 2) Get labels with merged affinity labels
-        Object labelsObj = launchConfigData.get(ServiceDiscoveryConfigItem.LABELS.getCattleName());
-        if (labelsObj != null) {
-            Map<String, String> labels = (Map<String, String>) labelsObj;
-            labels.putAll(getServiceAffnityLabels(service, allocatorService));
-        }
+        // 2. remove labels, and request the union
+        launchConfigData.remove(InstanceConstants.FIELD_LABELS);
+        launchConfigData.put(InstanceConstants.FIELD_LABELS, getServiceLabels(service, allocatorService));
 
         return launchConfigData;
-    }
-
-    @SuppressWarnings("unchecked")
-    protected static Map<String, String> getServiceAffnityLabels(Service service, AllocatorService allocatorService) {
-        List<String> launchConfigNames = getServiceLaunchConfigNames(service);
-        Map<String, String> allAffinityLabels = new HashMap<>();
-        for (String launchConfigName : launchConfigNames) {
-            Map<String, Object> data = getLaunchConfigDataAsMap(service, launchConfigName);
-            Object labels = data.get(ServiceDiscoveryConfigItem.LABELS.getCattleName());
-            if (labels != null) {
-                Map<String, String> launchConfigAffinityLabels = new HashMap<>();
-                for (String key : ((Map<String, String>) labels).keySet()) {
-                    if (key.startsWith("io.rancher.scheduler.affinity")) {
-                        launchConfigAffinityLabels.put(key, ((Map<String, String>) labels).get(key));
-                    }
-                }
-                allocatorService.mergeLabels(launchConfigAffinityLabels,
-                        allAffinityLabels);
-            }
-        }
-
-        return allAffinityLabels;
     }
 
     @SuppressWarnings("unchecked")

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/GlobalServiceDeploymentPlanner.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/GlobalServiceDeploymentPlanner.java
@@ -22,7 +22,7 @@ public class GlobalServiceDeploymentPlanner extends ServiceDeploymentPlanner {
         for (Service service : services) {
             List<Long> hostIdsToDeployService =
                     context.allocatorService.getHostsSatisfyingHostAffinity(service.getAccountId(),
-                            ServiceDiscoveryUtil.getServiceLabelsUnion(service, context.allocatorService));
+                            ServiceDiscoveryUtil.getServiceLabels(service, context.allocatorService));
             hostIds.addAll(hostIdsToDeployService);
         }
         for (DeploymentUnit unit : units) {

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/ServiceDeploymentPlannerFactoryImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/ServiceDeploymentPlannerFactoryImpl.java
@@ -21,7 +21,7 @@ public class ServiceDeploymentPlannerFactoryImpl implements ServiceDeploymentPla
         }
 
         Service service = services.get(0);
-        Map<String, String> serviceLabels = ServiceDiscoveryUtil.getServiceLabelsUnion(service, context.allocatorService);
+        Map<String, String> serviceLabels = ServiceDiscoveryUtil.getServiceLabels(service, context.allocatorService);
         String globalService = serviceLabels.get(ServiceDiscoveryConstants.LABEL_SERVICE_GLOBAL);
 
         if (service.getKind().equalsIgnoreCase(ServiceDiscoveryConstants.KIND.EXTERNALSERVICE.name())

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/GlobalHostActivateServiceLookup.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/GlobalHostActivateServiceLookup.java
@@ -50,7 +50,7 @@ public class GlobalHostActivateServiceLookup implements ServiceLookup {
         List<? extends Service> services = expMapDao.getActiveServices(host.getAccountId());
         List<Service> activeGlobalServices = new ArrayList<Service>();
         for (Service service : services) {
-            Map<String, String> serviceLabels = ServiceDiscoveryUtil.getServiceLabelsUnion(service, allocatorSvc);
+            Map<String, String> serviceLabels = ServiceDiscoveryUtil.getServiceLabels(service, allocatorSvc);
             if (serviceLabels.containsKey(ServiceDiscoveryConstants.LABEL_SERVICE_GLOBAL) &&
                     allocatorSvc.hostChangesAffectsHostAffinityRules(host.getId(), serviceLabels)) {
                 activeGlobalServices.add(service);

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -2614,37 +2614,6 @@ def test_stop_network_from_container(client, context, super_client):
     init_start_count = super_client.reload(s11_container).startCount
 
 
-def test_sidekick_labels_merge(client, context):
-    env = _create_stack(client)
-
-    image_uuid = context.image_uuid
-    labels = {'foo': "bar"}
-    launch_config = {"imageUuid": image_uuid, "labels": labels}
-
-    secondary_labels = {'bar': "foo"}
-    secondary_lc = {"imageUuid": image_uuid,
-                    "name": "secondary", "labels": secondary_labels}
-
-    service = client.create_service(name=random_str(),
-                                    environmentId=env.id,
-                                    launchConfig=launch_config,
-                                    secondaryLaunchConfigs=[secondary_lc])
-    service = client.wait_success(service)
-    service = client.wait_success(service.activate(), 120)
-    primary = _validate_compose_instance_start(client, service, env, "1")
-    secondary = _validate_compose_instance_start(client, service,
-                                                 env, "1", "secondary")
-
-    assert all(item in primary.labels for item in labels) is True
-    assert all(item in secondary.labels for item in secondary_labels) is True
-    assert all(item in primary.labels for item in secondary_labels) is False
-    assert all(item in secondary.labels for item in labels) is False
-
-
-def _start_count_is_greater_than(resource, count):
-    return resource.startCount > count
-
-
 def _get_instance_for_service(super_client, serviceId):
     instances = []
     instance_service_maps = super_client. \


### PR DESCRIPTION
This reverts commit cf2d2a5fa61b45e3b865022585e90230110a208a.

Conflicts:
	tests/integration/cattletest/core/test_svc_discovery.py

https://github.com/rancher/rancher/issues/2127