### PR TITLE
Increased ResourceLockChange timeout

### DIFF
--- a/code/framework/engine/src/main/java/io/cattle/platform/engine/process/impl/DefaultProcessInstanceImpl.java
+++ b/code/framework/engine/src/main/java/io/cattle/platform/engine/process/impl/DefaultProcessInstanceImpl.java
@@ -2,7 +2,6 @@ package io.cattle.platform.engine.process.impl;
 
 import static io.cattle.platform.engine.process.ExitReason.*;
 import static io.cattle.platform.util.time.TimeUtils.*;
-
 import io.cattle.platform.async.utils.TimeoutException;
 import io.cattle.platform.deferred.util.DeferredUtils;
 import io.cattle.platform.engine.context.EngineContext;
@@ -54,6 +53,7 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.TreeSet;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -208,7 +208,8 @@ public class DefaultProcessInstanceImpl implements ProcessInstance {
                 } else if (e.getExitReason().isError()) {
                     log.error("Exiting with code [{}] : {}", e.getExitReason(), e.getMessage(), e.getCause());
                 } else {
-                    log.debug("Exiting with code [{}] : {}", e.getExitReason(), e.getMessage(), e.getCause());
+                    log.debug("Exiting with code [{}] : {}", e.getExitReason(), e.getMessage(),
+                            e.getCause() != null ? e.getCause().getMessage() : StringUtils.EMPTY);
                 }
 
                 throw e;

--- a/code/iaas/logic-common/src/main/java/io/cattle/platform/process/common/lock/ResourceChangeLock.java
+++ b/code/iaas/logic-common/src/main/java/io/cattle/platform/process/common/lock/ResourceChangeLock.java
@@ -11,7 +11,7 @@ public class ResourceChangeLock extends AbstractLockDefinition implements Blocki
 
     @Override
     public long getWait() {
-        return 1000;
+        return 3000;
     }
 
 }


### PR DESCRIPTION
Also removed logging exception cause for the exceptions logged in debug
mode - @ibuildthecloud need your opinion on this particular change. I've put this to omit logging stack traces for exceptions like io.cattle.platform.lock.exception.FailedToAcquireLockException

https://github.com/rancher/rancher/issues/1996