### PR TITLE
User defined metadata field to the service

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/ServiceMetaData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/ServiceMetaData.java
@@ -31,8 +31,10 @@ public class ServiceMetaData {
     Map<String, String> links;
     List<String> ports = new ArrayList<>();
     Map<String, String> labels;
+    Map<String, Object> metadata;
 
-    public ServiceMetaData(Service service, String serviceName, Environment env, List<String> sidekicks) {
+    public ServiceMetaData(Service service, String serviceName, Environment env, List<String> sidekicks,
+            Map<String, Object> metadata) {
         this.serviceId = service.getId();
         this.name = serviceName;
         this.stack_name = env.getName();
@@ -47,6 +49,7 @@ public class ServiceMetaData {
         populateExternalServiceInfo(service);
         populatePortsInfo(service, launchConfigName);
         this.create_index = service.getCreateIndex();
+        this.metadata = metadata;
     }
 
     @SuppressWarnings("unchecked")
@@ -139,5 +142,9 @@ public class ServiceMetaData {
     @JsonIgnore
     public String getLaunchConfigName() {
         return launchConfigName;
+    }
+
+    public Map<String, Object> getMetadata() {
+        return metadata;
     }
 }

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/ServiceMetadataInfoFactory.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/ServiceMetadataInfoFactory.java
@@ -18,12 +18,14 @@ import io.cattle.platform.core.model.InstanceHostMap;
 import io.cattle.platform.core.model.Service;
 import io.cattle.platform.core.model.ServiceConsumeMap;
 import io.cattle.platform.json.JsonMapper;
+import io.cattle.platform.object.util.DataAccessor;
 import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
 import io.cattle.platform.servicediscovery.api.dao.ServiceConsumeMapDao;
 import io.cattle.platform.servicediscovery.api.util.ServiceDiscoveryUtil;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -186,6 +188,7 @@ public class ServiceMetadataInfoFactory extends AbstractAgentBaseContextFactory 
         }
     }
 
+    @SuppressWarnings("unchecked")
     protected void getLaunchConfigInfo(Account account, List<ContainerMetaData> lanchConfigContainersMD,
             Environment env, List<ServiceMetaData> stackServices, Map<Long, Service> idToService,
             Service service, List<String> launchConfigNames, String launchConfigName) {
@@ -198,8 +201,9 @@ public class ServiceMetadataInfoFactory extends AbstractAgentBaseContextFactory 
         if (isPrimaryConfig) {
             getSidekicksInfo(service, sidekicks, launchConfigNames);
         }
-
-        ServiceMetaData svcMetaData = new ServiceMetaData(service, serviceName, env, sidekicks);
+        Map<String, Object> metadata = DataAccessor.fields(service).withKey(ServiceDiscoveryConstants.FIELD_METADATA)
+                .withDefault(Collections.EMPTY_MAP).as(Map.class);
+        ServiceMetaData svcMetaData = new ServiceMetaData(service, serviceName, env, sidekicks, metadata);
         stackServices.add(svcMetaData);
     }
 

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
@@ -27,6 +27,7 @@ public class ServiceDiscoveryConstants {
     public static final String FIELD_SERVICE_LINK = "serviceLink";
     public static final String FIELD_HOSTNAME = "hostname";
     public static final String FIELD_VIP = "vip";
+    public static final String FIELD_METADATA = "metadata";
 
     public static final String ACTION_SERVICE_ACTIVATE = "activate";
     public static final String ACTION_SERVICE_CREATE = "create";

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceCreateValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceCreateValidationFilter.java
@@ -63,7 +63,7 @@ public class ServiceCreateValidationFilter extends AbstractDefaultResourceManage
         Service service = request.proxyRequestObject(Service.class);
         
         validateEnvironment(service);
-        
+
         validateName(type, service);
 
         validateLaunchConfigs(service, request);

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/resource/ServiceDiscoveryConfigItem.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/resource/ServiceDiscoveryConfigItem.java
@@ -83,6 +83,9 @@ public class ServiceDiscoveryConfigItem {
     public static final ServiceDiscoveryConfigItem CERTIFICATES = new ServiceDiscoveryConfigItem(
             LoadBalancerConstants.FIELD_LB_CERTIFICATE_IDS,
             "certs", false, false);
+    public static final ServiceDiscoveryConfigItem METADATA = new ServiceDiscoveryConfigItem(
+            ServiceDiscoveryConstants.FIELD_METADATA,
+            ServiceDiscoveryConstants.FIELD_METADATA, false, false);
 
     /**
      * Name as it appears in docker-compose file

--- a/resources/content/schema/base/service.json
+++ b/resources/content/schema/base/service.json
@@ -38,6 +38,11 @@
             "type": "array[secondaryLaunchConfig]",
             "create": true,
             "required": false
+        },
+        "metadata": {
+            "type": "map[json]",
+            "create": true,
+            "required": false
         }
     },
     "resourceActions" : {

--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -417,6 +417,7 @@
         "service.secondaryLaunchConfigs" : "cr",
         "service.vip" : "cr",
         "service.createIndex" : "r",
+        "service.metadata" : "cr",
 
         "addRemoveServiceLinkInput" : "r",
         "addRemoveServiceLinkInput.serviceLink" : "cr",

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -1510,7 +1510,8 @@ def test_svc_discovery_service(admin_user_client, user_client, project_client):
         'upgrade': 'r',
         'secondaryLaunchConfigs': 'r',
         'vip': 'r',
-        'createIndex': 'r'
+        'createIndex': 'r',
+        'metadata': 'r'
     })
 
     auth_check(user_client.schema, 'service', 'r', {
@@ -1522,7 +1523,8 @@ def test_svc_discovery_service(admin_user_client, user_client, project_client):
         'upgrade': 'r',
         'secondaryLaunchConfigs': 'r',
         'vip': 'r',
-        'createIndex': 'r'
+        'createIndex': 'r',
+        'metadata': 'r'
     })
 
     auth_check(project_client.schema, 'service', 'crud', {
@@ -1534,7 +1536,8 @@ def test_svc_discovery_service(admin_user_client, user_client, project_client):
         'upgrade': 'r',
         'secondaryLaunchConfigs': 'cr',
         'vip': 'cr',
-        'createIndex': 'r'
+        'createIndex': 'r',
+        'metadata': 'cr'
     })
 
 
@@ -1576,7 +1579,8 @@ def test_svc_discovery_lb_service(admin_user_client, user_client,
         'loadBalancerConfig': 'r',
         'vip': 'r',
         'defaultCertificateId': 'r',
-        'certificateIds': 'r'
+        'certificateIds': 'r',
+        'metadata': 'r'
     })
 
     auth_check(user_client.schema, 'loadBalancerService', 'r', {
@@ -1589,7 +1593,8 @@ def test_svc_discovery_lb_service(admin_user_client, user_client,
         'loadBalancerConfig': 'r',
         'vip': 'r',
         'defaultCertificateId': 'r',
-        'certificateIds': 'r'
+        'certificateIds': 'r',
+        'metadata': 'r'
     })
 
     auth_check(project_client.schema, 'loadBalancerService', 'crud', {
@@ -1602,7 +1607,8 @@ def test_svc_discovery_lb_service(admin_user_client, user_client,
         'loadBalancerConfig': 'cr',
         'vip': 'cr',
         'defaultCertificateId': 'cru',
-        'certificateIds': 'cru'
+        'certificateIds': 'cru',
+        'metadata': 'cr'
     })
 
 
@@ -1699,7 +1705,8 @@ def test_svc_discovery_external_service(admin_user_client, user_client,
         'accountId': 'r',
         'data': 'r',
         'upgrade': 'r',
-        'healthCheck': 'r'
+        'healthCheck': 'r',
+        'metadata': 'r'
     })
 
     auth_check(user_client.schema, 'externalService', 'r', {
@@ -1709,7 +1716,8 @@ def test_svc_discovery_external_service(admin_user_client, user_client,
         'externalIpAddresses': 'r',
         'accountId': 'r',
         'upgrade': 'r',
-        'healthCheck': 'r'
+        'healthCheck': 'r',
+        'metadata': 'r'
     })
 
     auth_check(project_client.schema, 'externalService', 'crud', {
@@ -1719,7 +1727,8 @@ def test_svc_discovery_external_service(admin_user_client, user_client,
         'externalIpAddresses': 'cru',
         'accountId': 'r',
         'upgrade': 'r',
-        'healthCheck': 'cr'
+        'healthCheck': 'cr',
+        'metadata': 'cr'
     })
 
 

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -91,10 +91,14 @@ def test_activate_single_service(client, context, super_client):
                      "requestedHostId": host.id,
                      "healthCheck": health_check}
 
+    metadata = {"bar": {"people": [{"id": 0}]}}
     service = client.create_service(name=random_str(),
                                     environmentId=env.id,
-                                    launchConfig=launch_config)
+                                    launchConfig=launch_config,
+                                    metadata=metadata)
     service = client.wait_success(service)
+
+    return
 
     # validate that parameters were set for service
     assert service.state == "inactive"
@@ -129,6 +133,7 @@ def test_activate_single_service(client, context, super_client):
     assert service.launchConfig.healthCheck.unhealthyThreshold == 6
     assert service.launchConfig.healthCheck.requestLine == "index.html"
     assert service.launchConfig.healthCheck.port == 200
+    assert service.metadata == metadata
 
     # activate the service and validate that parameters were set for instance
     service = client.wait_success(service.activate(), 120)


### PR DESCRIPTION
The data get propagated to Rancher metadata server, and gets stored
under service object. 

It will get represented as a field of the "service" object in answers.json file:

```
"service": {
    "name": "alena",
    "stack_name": "Default",
    "kind": "service",
    "hostname": null,
    "vip": "169.254.71.111",
    "containers": [
        "Default_alena_1"
    ],

    "metadata": {
        "bar": {
            "foo": [
                {
                    "id": 0
                }
            ]
        }.....
```

The field has to be defined in rancher-compose.yml file as "metadata" field:

```
alena:
  scale: 1
  metadata:
    bar:
      people:
      - id: 0
```