### PR TITLE
Keep-alive mode by default in haproxy config

### DIFF
--- a/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
+++ b/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
@@ -18,7 +18,6 @@ defaults
         option  dontlognull
         option  redispatch
         option forwardfor
-        option httpclose
         retries 3
         timeout connect 5000
         timeout client 50000

--- a/resources/content/config-content/healthcheck/content/etc/healthcheck/healthcheck.cfg.ftl
+++ b/resources/content/config-content/healthcheck/content/etc/healthcheck/healthcheck.cfg.ftl
@@ -17,7 +17,6 @@ defaults
     option  dontlognull
     option  redispatch
     option forwardfor
-    option httpclose
     retries 3
     contimeout 5000
     clitimeout 50000


### PR DESCRIPTION
As majority of the use cases would require it