### PR TITLE
Bug fixes

### DIFF
--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/service/impl/ServiceDiscoveryApiServiceImpl.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/service/impl/ServiceDiscoveryApiServiceImpl.java
@@ -136,6 +136,7 @@ public class ServiceDiscoveryApiServiceImpl implements ServiceDiscoveryApiServic
                     addExtraComposeParameters(service, launchConfigName, composeServiceData);
                     populateSidekickLabels(service, composeServiceData, isPrimaryConfig);
                     populateLoadBalancerServiceLabels(service, launchConfigName, composeServiceData);
+                    formatScale(service, composeServiceData);
                 }
 
                 if (!composeServiceData.isEmpty()) {
@@ -146,6 +147,17 @@ public class ServiceDiscoveryApiServiceImpl implements ServiceDiscoveryApiServic
         return data;
     }
     
+    @SuppressWarnings("unchecked")
+    protected void formatScale(Service service, Map<String, Object> composeServiceData) {
+        if (composeServiceData.get(InstanceConstants.FIELD_LABELS) != null) {
+            Map<String, String> labels = ((HashMap<String, String>) composeServiceData.get(InstanceConstants.FIELD_LABELS));
+            if (labels.containsKey(ServiceDiscoveryConstants.LABEL_SERVICE_GLOBAL)
+                    && labels.get(ServiceDiscoveryConstants.LABEL_SERVICE_GLOBAL).equals(Boolean.TRUE)) {
+                composeServiceData.remove(ServiceDiscoveryConstants.FIELD_SCALE);
+            }
+        }
+    }
+
     @SuppressWarnings("unchecked")
     protected void populateLoadBalancerServiceLabels(Service service,
             String launchConfigName, Map<String, Object> composeServiceData) {

--- a/resources/content/schema/base/certificate.json
+++ b/resources/content/schema/base/certificate.json
@@ -61,7 +61,8 @@
             "nullable": false
         },
          "name":{
-            "required": true
+            "required": true,
+            "unique": true
         }
     }
 }


### PR DESCRIPTION
1) Don't export "scale" if global deployment flag is present

https://github.com/rancher/rancher/issues/1842

2) Made certificate name unique within the account scope as rancher-compose accesses certificates by their names, and we have to guard against having duplicates:

https://github.com/rancher/rancher/issues/2042