### PR TITLE
Fix deadlock issue where reply messages get queued

### DIFF
--- a/code/framework/async/src/main/resources/META-INF/cattle/system-services/spring-async-context.xml
+++ b/code/framework/async/src/main/resources/META-INF/cattle/system-services/spring-async-context.xml
@@ -15,7 +15,7 @@
     </task:scheduled-tasks>
 
     <bean id="RetryTimeoutService" class="io.cattle.platform.async.retry.impl.RetryTimeoutServiceImpl" >
-        <property name="executorService" ref="CoreExecutorService" />
+        <property name="executorService" ref="ReplyExecutorService" />
     </bean>
 
 </beans>

--- a/code/framework/eventing/src/main/java/io/cattle/platform/eventing/impl/AbstractEventService.java
+++ b/code/framework/eventing/src/main/java/io/cattle/platform/eventing/impl/AbstractEventService.java
@@ -4,6 +4,7 @@ import io.cattle.platform.archaius.util.ArchaiusUtil;
 import io.cattle.platform.async.retry.Retry;
 import io.cattle.platform.async.retry.RetryTimeoutService;
 import io.cattle.platform.async.utils.AsyncUtils;
+import io.cattle.platform.async.utils.TimeoutException;
 import io.cattle.platform.eventing.EventCallOptions;
 import io.cattle.platform.eventing.EventListener;
 import io.cattle.platform.eventing.EventService;
@@ -27,7 +28,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -339,6 +339,8 @@ public abstract class AbstractEventService implements EventService {
                     error(event);
                     if (t.getCause() instanceof TimeoutException) {
                         // Ignore don't treat as a bad listener
+                    } else if (t.getCause() instanceof EventExecutionException) {
+                        // Ignore event errors
                     } else {
                         listener.setFailed(true);
                     }

--- a/code/framework/eventing/src/main/java/io/cattle/platform/eventing/impl/AbstractThreadPoolingEventService.java
+++ b/code/framework/eventing/src/main/java/io/cattle/platform/eventing/impl/AbstractThreadPoolingEventService.java
@@ -146,6 +146,15 @@ public abstract class AbstractThreadPoolingEventService extends AbstractEventSer
             executor = executorServices.get(((PoolSpecificListener) listener).getPoolKey());
         }
 
+        String eventName = event.getName();
+        if (executor == null && eventName != null) {
+            if (eventName.startsWith(Event.REPLY_PREFIX)) {
+                executor = executorServices.get("reply");
+            } else if (eventName.endsWith(Event.REPLY_SUFFIX)) {
+                executor = executorServices.get("reply");
+            }
+        }
+
         if (executor == null) {
             executor = getDefaultExecutor();
         }

--- a/code/framework/eventing/src/main/java/io/cattle/platform/eventing/impl/ListenerPoolObjectFactory.java
+++ b/code/framework/eventing/src/main/java/io/cattle/platform/eventing/impl/ListenerPoolObjectFactory.java
@@ -1,9 +1,11 @@
 package io.cattle.platform.eventing.impl;
 
+import io.cattle.platform.async.utils.AsyncUtils;
 import io.cattle.platform.eventing.model.Event;
 
 import java.util.Random;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
@@ -27,10 +29,10 @@ public class ListenerPoolObjectFactory implements PooledObjectFactory<FutureEven
 
     @Override
     public PooledObject<FutureEventListener> makeObject() throws Exception {
-        String key = "reply." + Math.abs(random.nextLong());
+        String key = prefix + Math.abs(random.nextLong());
         FutureEventListener listener = new FutureEventListener(eventService, key);
         Future<?> future = eventService.subscribe(key, listener);
-        future.get();
+        AsyncUtils.get(future, 10, TimeUnit.SECONDS);
         return new DefaultPooledObject<FutureEventListener>(listener);
     }
 

--- a/code/iaas/system/src/main/resources/META-INF/cattle/system/spring-system-context.xml
+++ b/code/iaas/system/src/main/resources/META-INF/cattle/system/spring-system-context.xml
@@ -32,7 +32,15 @@
     <management:executor-service 
         id="CoreExecutorService"
         keep-alive="120"
-        pool-size="25"
+        pool-size="50"
+        />
+
+    <management:executor-service
+        id="ReplyExecutorService"
+        keep-alive="120"
+        pool-size="4-20"
+        queue-capacity="0"
+        rejection-policy="DISCARD"
         />
 
     <bean class="io.cattle.platform.util.concurrent.NamedExecutorService" >
@@ -43,6 +51,11 @@
     <bean class="io.cattle.platform.util.concurrent.NamedExecutorService" >
         <property name="name" value="process" />
         <property name="executorService" ref="ProcessExecutorService" />
+    </bean>
+
+    <bean class="io.cattle.platform.util.concurrent.NamedExecutorService" >
+        <property name="name" value="reply" />
+        <property name="executorService" ref="ReplyExecutorService" />
     </bean>
 
     <bean id="CoreListeningExecutorService" class="com.google.common.util.concurrent.MoreExecutors" factory-method="listeningDecorator" >


### PR DESCRIPTION
If you have a thread pool of 5 threads and all 5 send a request and
wait for the response then you have to free threads to process the
response