### PR TITLE
More stuff to metadata

### DIFF
--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/HostCreateRemoveNicLookup.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/HostCreateRemoveNicLookup.java
@@ -1,0 +1,58 @@
+package io.cattle.platform.agent.instance.service.impl;
+
+import static io.cattle.platform.core.model.tables.InstanceHostMapTable.INSTANCE_HOST_MAP;
+import static io.cattle.platform.core.model.tables.InstanceTable.INSTANCE;
+import static io.cattle.platform.core.model.tables.NetworkTable.NETWORK;
+import static io.cattle.platform.core.model.tables.NicTable.NIC;
+import io.cattle.platform.agent.instance.service.InstanceNicLookup;
+import io.cattle.platform.core.constants.NetworkConstants;
+import io.cattle.platform.core.model.Host;
+import io.cattle.platform.core.model.Network;
+import io.cattle.platform.core.model.Nic;
+import io.cattle.platform.core.model.tables.records.NicRecord;
+import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
+import io.cattle.platform.object.ObjectManager;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+/*
+ * This class is used by metadata service to 
+ * push the update to all network agents on host.add event
+ */
+public class HostCreateRemoveNicLookup extends AbstractJooqDao implements InstanceNicLookup {
+
+    @Inject
+    ObjectManager objMgr;
+
+    @Override
+    public List<? extends Nic> getNics(Object obj) {
+        if (!(obj instanceof Host)) {
+            return null;
+        }
+
+        Host host = (Host) obj;
+        Network managedNtwk = objMgr.findAny(Network.class, NETWORK.ACCOUNT_ID, host.getAccountId(),
+                NETWORK.REMOVED, null, NETWORK.KIND, NetworkConstants.KIND_HOSTONLY);
+        if (managedNtwk == null) {
+            return null;
+        }
+
+        // need to get one instance per host
+        return create().
+                select(NIC.fields()).
+                from(NIC)
+                .join(INSTANCE)
+                .on(INSTANCE.ID.eq(NIC.INSTANCE_ID))
+                .join(INSTANCE_HOST_MAP)
+                .on(INSTANCE_HOST_MAP.INSTANCE_ID.eq(INSTANCE.ID))
+                .where(NIC.REMOVED.isNull())
+                .and(INSTANCE.REMOVED.isNull())
+                .and(INSTANCE_HOST_MAP.REMOVED.isNull())
+                .and(NIC.ACCOUNT_ID.eq(host.getAccountId()))
+                .and(NIC.NETWORK_ID.eq(managedNtwk.getId()))
+                .and(INSTANCE.SYSTEM_CONTAINER.isNull()).groupBy(INSTANCE_HOST_MAP.HOST_ID)
+                .fetchInto(NicRecord.class);
+    }
+}

--- a/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/agent-instance-defaults.properties
+++ b/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/agent-instance-defaults.properties
@@ -6,7 +6,7 @@ agent.instance.start.items.increment=agent-instance-startup
 
 agent.instance.services.base.items=${agent.instance.start.items.apply},${agent.instance.start.items.increment}
 
-agent.instance.services.processes=nic.activate,nic.deactivate,instancelink.update,instancelink.activate,hostipaddressmap.activate,serviceexposemap.create,serviceconsumemap.create,serviceconsumemap.remove,service.activate,service.deactivate,service.update,healthcheckinstancehostmap.create,networkserviceproviderinstancemap.activate,networkserviceproviderinstancemap.remove,ipaddress.update
+agent.instance.services.processes=nic.activate,nic.deactivate,instancelink.update,instancelink.activate,hostipaddressmap.activate,serviceexposemap.create,serviceconsumemap.create,serviceconsumemap.remove,service.activate,service.deactivate,service.update,healthcheckinstancehostmap.create,networkserviceproviderinstancemap.activate,networkserviceproviderinstancemap.remove,ipaddress.update,host.create,host.remove
 
 ipaddress.update.agentInstanceProvider.ipsecTunnelService.increment=hosts,ipsec-hosts,ipsec,host-routes,host-iptables
 
@@ -65,6 +65,10 @@ networkserviceproviderinstancemap.activate.agentInstanceProvider.dnsService.appl
 networkserviceproviderinstancemap.activate.agentInstanceProvider.dnsService.increment=hosts
 networkserviceproviderinstancemap.remove.agentInstanceProvider.dnsService.apply=hosts
 networkserviceproviderinstancemap.remove.agentInstanceProvider.dnsService.increment=hosts
+host.create.agentInstanceProvider.dnsService.apply=hosts
+host.create.agentInstanceProvider.dnsService.increment=hosts
+host.remove.agentInstanceProvider.dnsService.apply=hosts
+host.remove.agentInstanceProvider.dnsService.increment=hosts
 
 nic.activate.agentInstanceProvider.healthCheckService.apply=healthcheck
 nic.activate.agentInstanceProvider.healthCheckService.increment=healthcheck

--- a/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/spring-agent-instance-context.xml
+++ b/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/spring-agent-instance-context.xml
@@ -29,6 +29,7 @@
     <bean class="io.cattle.platform.agent.instance.service.impl.ServiceConsumeMapCreateNicLookup" />
     <bean class="io.cattle.platform.agent.instance.service.impl.VIPProviderNicLookup" />
     <bean class="io.cattle.platform.agent.instance.service.impl.ServiceNicLookup" />
+    <bean class="io.cattle.platform.agent.instance.service.impl.HostCreateRemoveNicLookup" />
 
     <bean id="AgentInstanceTypes" class="io.cattle.platform.object.meta.TypeSet" >
         <property name="typeNames">

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/MetaDataInfoDao.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/MetaDataInfoDao.java
@@ -1,11 +1,15 @@
 package io.cattle.platform.configitem.context.dao;
 
 import io.cattle.platform.configitem.context.data.ContainerMetaData;
+import io.cattle.platform.configitem.context.data.HostMetaData;
+import io.cattle.platform.core.model.Instance;
 
 import java.util.List;
 
 public interface MetaDataInfoDao {
 
     List<ContainerMetaData> getContainersData(long accountId);
+
+    List<? extends HostMetaData> getInstanceHostMetaData(long accountId, Instance instance);
 
 }

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/ContainerMetaData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/ContainerMetaData.java
@@ -28,6 +28,8 @@ public class ContainerMetaData {
     String stack_name;
     Map<String, String> labels = new HashMap<>();
     Long create_index;
+    String host_uuid;
+    String hostname;
 
     public ContainerMetaData() {
     }
@@ -76,6 +78,8 @@ public class ContainerMetaData {
                 .withKey(InstanceConstants.FIELD_PORTS).withDefault(Collections.EMPTY_LIST)
                 .as(List.class);
         if (hostMetaData != null) {
+            this.host_uuid = hostMetaData.getUuid();
+            this.hostname = hostMetaData.getName();
             String hostIp = hostMetaData.agent_ip;
             if (hostIp == null) {
                 ports.addAll(portsObj);
@@ -120,5 +124,13 @@ public class ContainerMetaData {
 
     public Long getCreate_index() {
         return create_index;
+    }
+
+    public String getHost_uuid() {
+        return host_uuid;
+    }
+
+    public String getHostname() {
+        return hostname;
     }
 }

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/HostMetaData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/HostMetaData.java
@@ -9,6 +9,7 @@ public class HostMetaData {
     String name;
     Map<String, String> labels;
     Long hostId;
+    String uuid;
 
     public String getAgent_ip() {
         return agent_ip;
@@ -22,16 +23,25 @@ public class HostMetaData {
         return labels;
     }
 
-    public HostMetaData(String agent_ip, String name, Map<String, String> labels, long hostId) {
+    public HostMetaData() {
+
+    }
+
+    public HostMetaData(String agent_ip, String name, Map<String, String> labels, long hostId, String uuid) {
         super();
         this.agent_ip = agent_ip;
         this.name = name;
         this.labels = labels;
         this.hostId = hostId;
+        this.uuid = uuid;
     }
 
     @JsonIgnore
     public Long getHostId() {
         return hostId;
+    }
+
+    public String getUuid() {
+        return uuid;
     }
 }

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/ServiceMetadataInfoFactory.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/ServiceMetadataInfoFactory.java
@@ -4,6 +4,7 @@ import static io.cattle.platform.core.model.tables.EnvironmentTable.ENVIRONMENT;
 import static io.cattle.platform.core.model.tables.ServiceTable.SERVICE;
 import io.cattle.platform.configitem.context.dao.MetaDataInfoDao;
 import io.cattle.platform.configitem.context.data.ContainerMetaData;
+import io.cattle.platform.configitem.context.data.HostMetaData;
 import io.cattle.platform.configitem.context.data.SelfMetaData;
 import io.cattle.platform.configitem.context.data.ServiceMetaData;
 import io.cattle.platform.configitem.context.data.StackMetaData;
@@ -106,7 +107,13 @@ public class ServiceMetadataInfoFactory extends AbstractAgentBaseContextFactory 
             context.getData().put("containers", jsonMapper.writeValueAsString(containersMetaData));
             context.getData().put("services", jsonMapper.writeValueAsString(servicesMD));
             context.getData().put("stacks", jsonMapper.writeValueAsString(stacksMD));
-
+            List<? extends HostMetaData> hosts = metaDataInfoDao.getInstanceHostMetaData(instance.getAccountId(), null);
+            List<? extends HostMetaData> selfHost = metaDataInfoDao.getInstanceHostMetaData(instance.getAccountId(),
+                    instance);
+            context.getData().put("hosts", jsonMapper.writeValueAsString(hosts));
+            if (!selfHost.isEmpty()) {
+                context.getData().put("host", jsonMapper.writeValueAsString(selfHost.get(0)));
+            }
         } catch (IOException e) {
             log.error("Failed to marshal service metadata", e);
         }

--- a/resources/content/config-content/hosts/content-home/etc/cattle/metadata/answers.json.ftl
+++ b/resources/content/config-content/hosts/content-home/etc/cattle/metadata/answers.json.ftl
@@ -10,7 +10,16 @@
  	</#if>
  	<#if containers??>
  	"containers":
- 		${containers}
+ 		${containers},
+ 	</#if>
+ 	<#if host??>
+ 	"self":{
+ 		"host":${host}
+ 	},
+ 	</#if>
+ 	<#if hosts??>
+ 	"hosts":
+ 		${hosts}
  	</#if>
   }
   


### PR DESCRIPTION
1) Added /self/host and /hosts sections to defaults
2) Added "host_name" field to the container object (similarly we do  for service_name and stack_name)

```
  "create_index": 1,
   "service_name": "alena",
    "stack_name": "Default"
    "host_name": "myhost",
    "ips": [
        "10.42.34.58"
    ],.....
```

@ibuildthecloud @vincent99 - regarding the second change - not sure if we should expect host name to be unique within the account, and whether if we should instead introduce "uuid"/"host_uuid" to host/container objects respectively like @cjellick suggested earlier. 

@cloudnautique 

https://github.com/rancher/rancher/issues/2189


UPDATE: 2) won't be added as a part of this PR; we can add it on per request later (if use case comes up)

One more item is added as a part of the PR - "host_uuid" field to host object