### PR TITLE
Expose container.deploymentUnitUuid to API

### DIFF
--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -90,6 +90,7 @@
         "container.workingDir" : "cr",
         "container.expose" : "cr",
         "container.createIndex" : "r",
+        "container.deploymentUnitUuid" : "r",
 
         "containerExec" : "r",
         "containerExec.attachStdin" : "cr",

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -697,7 +697,8 @@ def test_container_auth(admin_user_client, user_client, project_client):
         'extraHosts': 'r',
         'readOnly': 'r',
         'expose': 'r',
-        'createIndex': 'r'
+        'createIndex': 'r',
+        'deploymentUnitUuid': 'r'
     })
 
     auth_check(user_client.schema, 'container', 'r', {
@@ -756,7 +757,8 @@ def test_container_auth(admin_user_client, user_client, project_client):
         'volumeDriver': 'r',
         'readOnly': 'r',
         'expose': 'r',
-        'createIndex': 'r'
+        'createIndex': 'r',
+        'deploymentUnitUuid': 'r'
     })
 
     auth_check(project_client.schema, 'container', 'crud', {
@@ -815,7 +817,8 @@ def test_container_auth(admin_user_client, user_client, project_client):
         'volumeDriver': 'cr',
         'readOnly': 'cr',
         'expose': 'cr',
-        'createIndex': 'r'
+        'createIndex': 'r',
+        'deploymentUnitUuid': 'r'
     })
 
     auth_check(project_client.schema, 'dockerBuild', 'cr', {

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -174,8 +174,7 @@ def test_activate_single_service(client, context, super_client):
     assert container.cpuSet == "2"
     assert container.requestedHostId == host.id
     assert container.healthState == 'initializing'
-
-    assert super_client.reload(container).deploymentUnitUuid is not None
+    assert container.deploymentUnitUuid is not None
 
 
 def test_activate_services(client, context):


### PR DESCRIPTION
@vincent99 in case UI needs to group containers per deployment unit basis, this param might be helpful

@ibuildthecloud 