### PR TITLE
Bug fixes

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
@@ -1,18 +1,13 @@
 package io.cattle.platform.servicediscovery.deployment;
 
 import io.cattle.platform.core.constants.CommonStatesConstants;
-import io.cattle.platform.core.constants.InstanceConstants;
 import io.cattle.platform.core.model.Service;
 import io.cattle.platform.core.model.ServiceExposeMap;
 import io.cattle.platform.object.process.StandardProcess;
 import io.cattle.platform.object.resource.ResourcePredicate;
-import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
-import io.cattle.platform.servicediscovery.api.util.ServiceDiscoveryUtil;
 import io.cattle.platform.servicediscovery.deployment.impl.DeploymentManagerImpl.DeploymentServiceContext;
 
 import java.util.Map;
-
-import org.apache.commons.lang.StringUtils;
 
 /**
  * TODO: Since the majority of the system references DeploymentUnitInstance and not InstanceUnit
@@ -26,7 +21,6 @@ public abstract class DeploymentUnitInstance {
     protected ServiceExposeMap exposeMap;
     protected String launchConfigName;
     protected Service service;
-    protected boolean startOnce = false;
 
     public abstract boolean isError();
 
@@ -48,22 +42,12 @@ public abstract class DeploymentUnitInstance {
 
     public abstract void stop();
 
-    @SuppressWarnings("unchecked")
     protected DeploymentUnitInstance(DeploymentServiceContext context, String uuid, Service service,
             String launchConfigName) {
         this.context = context;
         this.uuid = uuid;
         this.launchConfigName = launchConfigName;
         this.service = service;
-        Object labels = ServiceDiscoveryUtil.getLaunchConfigObject(service, launchConfigName,
-                InstanceConstants.FIELD_LABELS);
-        if (labels != null) {
-            String createOnlyLabel = ((Map<String, String>) labels)
-                    .get(ServiceDiscoveryConstants.LABEL_SERVICE_CONTAINER_CREATE_ONLY);
-            if (StringUtils.equalsIgnoreCase(createOnlyLabel, "true")) {
-                startOnce = true;
-            }
-        }
     }
 
     public DeploymentUnitInstance createAndStart(Map<String, Object> deployParams) {
@@ -95,9 +79,6 @@ public abstract class DeploymentUnitInstance {
     protected abstract DeploymentUnitInstance waitForStartImpl();
 
     public boolean isStarted() {
-        if (startOnce && !this.createNew()) {
-            return true;
-        }
         return isStartedImpl();
     }
 

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -507,7 +507,9 @@ def test_link_volumes(client, context):
     launch_config = {"imageUuid": image_uuid,
                      "dataVolumesFromLaunchConfigs": ['secondary']}
 
-    secondary_lc = {"imageUuid": image_uuid, "name": "secondary"}
+    labels = {"io.rancher.container.start_once": "true"}
+    secondary_lc = {"imageUuid": image_uuid,
+                    "name": "secondary", "labels": labels}
 
     service = client.create_service(name=random_str(),
                                     environmentId=env.id,
@@ -521,6 +523,10 @@ def test_link_volumes(client, context):
 
     assert len(container1.dataVolumesFrom) == 1
     assert set(container1.dataVolumesFrom) == set([container2.id])
+
+    container2 = client.wait_success(container2.stop())
+    client.wait_success(service)
+    assert container2.state == 'stopped'
 
 
 def test_volumes_service_links_scale_one(client, context):


### PR DESCRIPTION
1) Integration test fixes: Fixed healtcheck test to work with idempotent checks on (by passing more parameters to the call instead of assuming that the account would always own one service instance)

2) start_once flag: wait for instance to reach one of the Running/Stopped/Stopping states

instead of returning soon after create is done

https://github.com/rancher/rancher/issues/2036

3) 1MB limit on service.metadata field:

https://github.com/rancher/rancher/issues/2256