### PR TITLE
Fixed regression bug in selectors code

### DIFF
--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/util/ServiceDiscoveryUtil.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/util/ServiceDiscoveryUtil.java
@@ -238,9 +238,9 @@ public class ServiceDiscoveryUtil {
 
     public static boolean isNoopService(Service service, AllocatorService allocatorService) {
         Object imageUUID = ServiceDiscoveryUtil.getServiceDataAsMap(service,
-                ServiceDiscoveryConstants.PRIMARY_LAUNCH_CONFIG_NAME,
-                allocatorService).get(InstanceConstants.FIELD_IMAGE_UUID);
-        return imageUUID == null || imageUUID.toString().equalsIgnoreCase(ServiceDiscoveryConstants.IMAGE_NONE);
+                ServiceDiscoveryConstants.PRIMARY_LAUNCH_CONFIG_NAME, allocatorService).get(
+                InstanceConstants.FIELD_IMAGE_UUID);
+        return service.getSelectorContainer() != null
+                && (imageUUID == null || imageUUID.toString().equalsIgnoreCase(ServiceDiscoveryConstants.IMAGE_NONE));
     }
-
 }


### PR DESCRIPTION
Making LB instances fail to deploy as no image is being set in launch config for those. Integration test didn't caught it as for LB instance we are always adding simulator image.

https://github.com/rancher/rancher/issues/2284

TBD - in the future as a part of LB refactoring, we should probably update launch config with the network-instance image information.