### PR TITLE
InService upgrade bug fixes:

### DIFF
--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceUpgradeValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceUpgradeValidationFilter.java
@@ -125,12 +125,12 @@ public class ServiceUpgradeValidationFilter extends AbstractDefaultResourceManag
 
     protected void upgradeLaunchConfigFields(Service service, Map<String, Object> launchConfigToUpgrade,
             Map<String, Object> newLaunchConfig) {
-        for (String key : newLaunchConfig.keySet()) {
-            launchConfigToUpgrade.put(key, newLaunchConfig.get(key));
-        }
         Integer version = new Integer(Integer.valueOf(launchConfigToUpgrade.get(
                 ServiceDiscoveryConstants.FIELD_VERSION)
                 .toString()));
+        for (String key : newLaunchConfig.keySet()) {
+            launchConfigToUpgrade.put(key, newLaunchConfig.get(key));
+        }
         launchConfigToUpgrade.put(ServiceDiscoveryConstants.FIELD_VERSION, String.valueOf(version + 1));
     }
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentManager.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentManager.java
@@ -1,6 +1,7 @@
 package io.cattle.platform.servicediscovery.deployment;
 
 import io.cattle.platform.configitem.events.ConfigUpdate;
+import io.cattle.platform.core.addon.ServiceUpgrade;
 import io.cattle.platform.core.model.Service;
 import io.cattle.platform.eventing.annotation.AnnotatedEventListener;
 import io.cattle.platform.eventing.annotation.EventHandler;
@@ -21,5 +22,7 @@ public interface DeploymentManager extends AnnotatedEventListener {
     void reconcileServices(Collection<? extends Service> services);
 
     boolean isHealthy(Service service);
+
+    boolean doInServiceUpgrade(Service service, ServiceUpgrade upgrade);
 
 }

--- a/tests/integration/cattletest/core/test_healthcheck.py
+++ b/tests/integration/cattletest/core/test_healthcheck.py
@@ -149,6 +149,10 @@ def test_health_check_bad_external_timestamp(super_client, context, client):
 def test_health_check_bad_agent(super_client, context, client):
     # Create another host to get the agent from that host
     host2 = super_client.reload(register_simulated_host(context))
+    # register one more host to ensure
+    # there is at least one more host
+    #  to schedule healtcheck on
+    super_client.reload(register_simulated_host(context))
 
     env = client.create_environment(name='env-' + random_str())
     service = client.create_service(name='test', launchConfig={

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -2279,9 +2279,7 @@ def test_sidekick_destroy_instance_indirect_ref(client, context):
                                                   service,
                                                   env, "1", "secondary1")
 
-    instance_service_map1 = client. \
-        list_serviceExposeMap(serviceId=service.id, state="active")
-    assert len(instance_service_map1) == 3
+    _wait_until_active_map_count(service, 3, client, timeout=30)
 
     # destroy secondary1 instance and wait for the service to reconcile
     _instance_remove(instance13, client)
@@ -2291,9 +2289,7 @@ def test_sidekick_destroy_instance_indirect_ref(client, context):
     _validate_compose_instance_start(client, service, env, "1", "secondary")
     _validate_compose_instance_start(client, service, env, "1", "secondary1")
 
-    instance_service_map1 = client. \
-        list_serviceExposeMap(serviceId=service.id, state="active")
-    assert len(instance_service_map1) == 3
+    _wait_until_active_map_count(service, 3, client, timeout=30)
     # validate that the primary and secondary instances got recreated
     instance11 = client.reload(instance11)
     assert instance11.state == 'removed'


### PR DESCRIPTION
InService upgrade bug fixes:

    1) Fixed consecutive upgrade
    2) Fixed the bug in upgrade-using-batchsize logic
    3) Hold the lock while doing inService upgrade for the batch
    so service.reconcile triggered by instance removal, wouldn't interfere

Update: also added some integration test fixes to this PR (second commit)

https://github.com/rancher/rancher/issues/2293
https://github.com/rancher/rancher/issues/2296