### PR TITLE
ldap: check "name" field before using "dn" for display name.

### DIFF
--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/LdapConstants.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/LdapConstants.java
@@ -95,6 +95,7 @@ public class LdapConstants {
         * */
     public static final DynamicStringProperty USER_NAME_FIELD = ArchaiusUtil.getString(USER_NAME_FIELD_SETTING);
     public static final DynamicStringProperty GROUP_NAME_FIELD = ArchaiusUtil.getString(GROUP_NAME_FIELD_SETTING);
+    public static final String DEFAULT_NAME_FIELD = "name";
     public static final String MEMBER_OF = "memberOf";
     public static final String OBJECT_CLASS = "objectClass";
     public static final DynamicStringProperty GROUP_OBJECT_CLASS = ArchaiusUtil.getString(GROUP_OBJECT_CLASS_SETTING);

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/LdapIdentitySearchProvider.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/LdapIdentitySearchProvider.java
@@ -368,27 +368,27 @@ public class LdapIdentitySearchProvider extends LdapConfigurable implements Iden
             if (!hasPermission(search)){
                 throw new ClientVisibleException(ResponseCodes.UNAUTHORIZED);
             }
+            Attribute nameField;
             String externalIdType;
-            String accountName;
             String externalId = (String) search.get(LdapConstants.DN).get();
+            String accountName = externalId;
             String login;
             if (isType(search, LdapConstants.USER_OBJECT_CLASS.get())){
                 externalIdType = LdapConstants.USER_SCOPE;
-                if (search.get(LdapConstants.USER_NAME_FIELD.get()) != null) {
-                    accountName = (String) search.get(LdapConstants.USER_NAME_FIELD.get()).get();
-                } else {
-                    accountName = externalId;
-                }
-
+                nameField = search.get(LdapConstants.USER_NAME_FIELD.get());
             } else if (isType(search, LdapConstants.GROUP_OBJECT_CLASS.get())) {
                 externalIdType = LdapConstants.GROUP_SCOPE;
-                if (search.get(LdapConstants.GROUP_NAME_FIELD.get()) != null) {
-                    accountName = (String) search.get(LdapConstants.GROUP_NAME_FIELD.get()).get();
-                } else {
-                    accountName = externalId;
-                }
+                nameField = search.get(LdapConstants.GROUP_NAME_FIELD.get());
             } else {
                 return null;
+            }
+            if (nameField != null) {
+                accountName = (String) nameField.get();
+            } else if (search.get(LdapConstants.DEFAULT_NAME_FIELD) != null) {
+                accountName = (String) search.get(LdapConstants.DEFAULT_NAME_FIELD).get();
+            }
+            if (StringUtils.isEmpty(accountName)) {
+                accountName = externalId;
             }
             login = (String) search.get(LdapConstants.USER_LOGIN_FIELD.get()).get();
             return new Identity(externalIdType, externalId, accountName, null, null, login);


### PR DESCRIPTION
In case the requested name field is missing, look first at the `name` field, before resolving to using the `dn` field, which is very verbose..

This is an untested implementation for my comment in #936 
