### PR TITLE
Replace single $ with $$ in exported yml files

### DIFF
--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/service/impl/ServiceDiscoveryApiServiceImpl.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/service/impl/ServiceDiscoveryApiServiceImpl.java
@@ -109,7 +109,8 @@ public class ServiceDiscoveryApiServiceImpl implements ServiceDiscoveryApiServic
         options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
         options.setLineBreak(LineBreak.WIN);
         Yaml yaml = new Yaml(options);
-        return yaml.dump(dockerComposeData);
+        String yamlStr = yaml.dump(dockerComposeData);
+        return yamlStr.replaceAll("[$]", "\\$\\$");
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/2351

@ibuildthecloud just to confirm: we have to replace in both docker-compose.yml and rancher-compose.yml? 

Also is there a chance that we override user defined value where $ is expected to be single? Like in "command" field for example