### PR TITLE
Register instance to lb on exposemap.create

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceDiscoveryLoadBalancerTargetAddPostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceDiscoveryLoadBalancerTargetAddPostListener.java
@@ -122,15 +122,13 @@ public class ServiceDiscoveryLoadBalancerTargetAddPostListener extends AbstractO
     protected void getLBServiceForExposeMap(ProcessState state,
             List<Pair<ServiceExposeMap, Service>> exposeMapToLBService) {
         ServiceExposeMap map = (ServiceExposeMap) state.getResource();
-        if (map.getIpAddress() != null) {
-            // find all services consuming the current one
-            List<? extends ServiceConsumeMap> consumingServicesMaps = consumeMapDao
-                    .findConsumingServices(map.getServiceId());
-            for (ServiceConsumeMap consumingServiceMap : consumingServicesMaps) {
-                Service lbService = objectManager.loadResource(Service.class, consumingServiceMap.getServiceId());
-                if (lbService.getKind().equalsIgnoreCase(KIND.LOADBALANCERSERVICE.name())) {
-                    exposeMapToLBService.add(Pair.of(map, lbService));
-                }
+        // find all services consuming the current one
+        List<? extends ServiceConsumeMap> consumingServicesMaps = consumeMapDao
+                .findConsumingServices(map.getServiceId());
+        for (ServiceConsumeMap consumingServiceMap : consumingServicesMaps) {
+            Service lbService = objectManager.loadResource(Service.class, consumingServiceMap.getServiceId());
+            if (lbService.getKind().equalsIgnoreCase(KIND.LOADBALANCERSERVICE.name())) {
+                exposeMapToLBService.add(Pair.of(map, lbService));
             }
         }
     }


### PR DESCRIPTION
used to be enabled only on the instance.start event for service instance. For regular, non selector based containers, exposeMap exists at this point, so lb target gets created. For selector based container, instance.start schedules serviceExposeMap.creation, so the map might not exist when this code is called.