### PR TITLE
externalDns flag (boolean, default=true) to service

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/ServiceMetaData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/ServiceMetaData.java
@@ -33,6 +33,7 @@ public class ServiceMetaData {
     Map<String, String> labels;
     Map<String, Object> metadata;
     Integer scale;
+    Boolean external_dns = true;
 
     public ServiceMetaData(Service service, String serviceName, Environment env, List<String> sidekicks,
             Map<String, Object> metadata) {
@@ -52,6 +53,8 @@ public class ServiceMetaData {
         this.create_index = service.getCreateIndex();
         this.metadata = metadata;
         this.scale = DataAccessor.fieldInteger(service, ServiceDiscoveryConstants.FIELD_SCALE);
+        this.external_dns = DataAccessor.fields(service)
+                .withKey(ServiceDiscoveryConstants.FIELD_EXTERNAL_DNS).as(Boolean.class);
     }
 
     @SuppressWarnings("unchecked")
@@ -152,5 +155,9 @@ public class ServiceMetaData {
 
     public Integer getScale() {
         return scale;
+    }
+
+    public Boolean getExternal_dns() {
+        return external_dns;
     }
 }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
@@ -33,6 +33,7 @@ public class ServiceDiscoveryConstants {
     public static final String FIELD_SELECTOR_LINK = "selectorLink";
     public static final String FIELD_IN_SERVICE_STRATEGY = "inServiceStrategy";
     public static final String FIELD_TO_SERVICE_STRATEGY = "toServiceStrategy";
+    public static final String FIELD_EXTERNAL_DNS = "externalDns";
 
     public static final String ACTION_SERVICE_ACTIVATE = "activate";
     public static final String ACTION_SERVICE_CREATE = "create";

--- a/resources/content/schema/base/service.json
+++ b/resources/content/schema/base/service.json
@@ -56,6 +56,11 @@
         "previousSecondaryLaunchConfigs": {
             "type": "array[secondaryLaunchConfig]",
             "required": false
+        },
+        "externalDns": {
+            "type": "boolean",
+            "required": false,
+            "default": true
         }
     },
     "resourceActions" : {

--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -452,6 +452,7 @@
         "service.selectorContainer" : "cr",
         "service.previousLaunchConfig" : "r",
         "service.previousSecondaryLaunchConfigs" : "r",
+        "service.externalDns" : "cr",
 
         "addRemoveServiceLinkInput" : "r",
         "addRemoveServiceLinkInput.serviceLink" : "cr",
@@ -515,6 +516,7 @@
         "externalService.healthCheck" : "cr",
         "externalService.createIndex" : "",
         "externalService.selectorContainer" : "",
+        "externalService.externalDns" : "",
 
         "dnsService" : "r",
         "dnsService.scale" : "",
@@ -522,6 +524,7 @@
         "dnsService.vip" : "",
         "dnsService.createIndex" : "",
         "dnsService.selectorContainer" : "",
+        "dnsService.externalDns" : "",
 
         "serviceEvent" : "r",
         "serviceEvent.instanceId" : "r",

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -1556,6 +1556,7 @@ def test_svc_discovery_service(admin_user_client, user_client, project_client):
         'selectorContainer': 'r',
         'previousLaunchConfig': 'r',
         'previousSecondaryLaunchConfigs': 'r',
+        'externalDns': 'r'
     })
 
     auth_check(user_client.schema, 'service', 'r', {
@@ -1573,6 +1574,7 @@ def test_svc_discovery_service(admin_user_client, user_client, project_client):
         'selectorContainer': 'r',
         'previousLaunchConfig': 'r',
         'previousSecondaryLaunchConfigs': 'r',
+        'externalDns': 'r'
     })
 
     auth_check(project_client.schema, 'service', 'crud', {
@@ -1590,6 +1592,7 @@ def test_svc_discovery_service(admin_user_client, user_client, project_client):
         'selectorContainer': 'cr',
         'previousLaunchConfig': 'r',
         'previousSecondaryLaunchConfigs': 'r',
+        'externalDns': 'cr'
     })
 
 
@@ -1645,6 +1648,7 @@ def test_svc_discovery_lb_service(admin_user_client, user_client,
         'selectorLink': 'r',
         'previousLaunchConfig': 'r',
         'previousSecondaryLaunchConfigs': 'r',
+        'externalDns': 'r'
     })
 
     auth_check(user_client.schema, 'loadBalancerService', 'r', {
@@ -1662,6 +1666,7 @@ def test_svc_discovery_lb_service(admin_user_client, user_client,
         'selectorLink': 'r',
         'previousLaunchConfig': 'r',
         'previousSecondaryLaunchConfigs': 'r',
+        'externalDns': 'r'
     })
 
     auth_check(project_client.schema, 'loadBalancerService', 'crud', {
@@ -1679,6 +1684,7 @@ def test_svc_discovery_lb_service(admin_user_client, user_client,
         'selectorLink': 'cr',
         'previousLaunchConfig': 'r',
         'previousSecondaryLaunchConfigs': 'r',
+        'externalDns': 'cr'
     })
 
 

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -95,7 +95,8 @@ def test_activate_single_service(client, context, super_client):
     service = client.create_service(name=random_str(),
                                     environmentId=env.id,
                                     launchConfig=launch_config,
-                                    metadata=metadata)
+                                    metadata=metadata,
+                                    externalDns=False)
     service = client.wait_success(service)
 
     # validate that parameters were set for service
@@ -133,6 +134,7 @@ def test_activate_single_service(client, context, super_client):
     assert service.launchConfig.healthCheck.port == 200
     assert service.metadata == metadata
     assert service.launchConfig.version == '0'
+    assert service.externalDns is False
 
     # activate the service and validate that parameters were set for instance
     service = client.wait_success(service.activate(), 120)


### PR DESCRIPTION
If set, and external dns provider is registered to cattle, service will
get registered to public DNS

Introduced this flag so user has a choice to "turn off" dns for certain
services.

@ibuildthecloud 