### PR TITLE
Fix issue in which not all port ports get exposed

### DIFF
--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/process/AbstractApplyItems.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/process/AbstractApplyItems.java
@@ -30,12 +30,12 @@ public abstract class AbstractApplyItems extends AbstractObjectProcessLogic impl
     ConfigItemStatusManager statusManager;
     boolean assignBase = true;
 
-    protected void assignItems(NetworkServiceProvider provider, Agent agent, Object owner, ProcessState state, ProcessInstance processInstance) {
+    protected void assignItems(NetworkServiceProvider provider, Agent agent, ProcessState state, ProcessInstance processInstance) {
         if (agent == null) {
             return;
         }
 
-        String contextId = getContext(processInstance, owner);
+        String contextId = getContext(processInstance, state.getResource());
 
         ConfigUpdateRequest request = ConfigUpdateRequestUtils.getRequest(jsonMapper, state, contextId);
         if (request == null) {
@@ -73,7 +73,7 @@ public abstract class AbstractApplyItems extends AbstractObjectProcessLogic impl
                 continue;
             }
 
-            String context = getContext(processInstance, otherAgent);
+            String context = getContext(processInstance, state.getResource());
             ConfigUpdateRequest otherRequest = ConfigUpdateRequestUtils.getRequest(jsonMapper, state, context);
             if (otherRequest == null) {
                 otherRequest = ConfigUpdateRequest.forResource(Agent.class, otherAgent.getId());

--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/process/AbstractHostApplyItems.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/process/AbstractHostApplyItems.java
@@ -37,7 +37,7 @@ public abstract class AbstractHostApplyItems extends AbstractApplyItems implemen
             }
 
             for (NetworkServiceProvider provider : entry.getValue()) {
-                assignItems(provider, agent, host, state, process);
+                assignItems(provider, agent, state, process);
             }
         }
 

--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/process/AgentInstanceApplyItems.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/process/AgentInstanceApplyItems.java
@@ -51,7 +51,7 @@ public class AgentInstanceApplyItems extends AbstractApplyItems implements Proce
             for (Map.Entry<NetworkServiceProvider, Instance> entry : agentInstances.entrySet()) {
                 Agent agent = objectManager.loadResource(Agent.class, entry.getValue().getAgentId());
 
-                assignItems(entry.getKey(), agent, nic, state, process);
+                assignItems(entry.getKey(), agent, state, process);
             }
         }
 


### PR DESCRIPTION
When multiple ports were activated only the first port would increment
the requested version which would cause a race condition in that the
configuration pull by the agent would be often incomplete.

https://github.com/rancher/rancher/issues/1898