### PR TITLE
Added option http-server-close for websockets.

### DIFF
--- a/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
+++ b/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
@@ -19,6 +19,7 @@ defaults
 	option	tcplog
         option  dontlognull
         option  redispatch
+        option http-server-close
         option forwardfor
         retries 3
         timeout connect 5000


### PR DESCRIPTION
Without adding "option http-server-close", HAProxy seems to not work with websockets.

Unfortunately, this setting does ignore the keepalive setting of
containers that the load balancer is linked to.

For more information, see http://blog.silverbucket.net/post/31927044856/3-ways-to-configure-haproxy-for-websockets and http://blog.haproxy.com/2012/11/07/websockets-load-balancing-with-haproxy/