### PR TITLE
Fix switch to a lesser role

### DIFF
--- a/code/framework/api/src/main/java/io/cattle/platform/api/auth/Policy.java
+++ b/code/framework/api/src/main/java/io/cattle/platform/api/auth/Policy.java
@@ -13,6 +13,7 @@ public interface Policy {
     public static final String PLAIN_ID = "plain.id";
     public static final String PLAIN_ID_OPTION = "plain.id.option";
     public static final String ROLE_OPTION = "role.option";
+    public static final String ASSIGNED_ROLE = "assigned.role";
     public static final long NO_ACCOUNT = -1L;
 
     boolean isOption(String optionName);

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/impl/DefaultAuthorizationProvider.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/impl/DefaultAuthorizationProvider.java
@@ -98,6 +98,7 @@ public class DefaultAuthorizationProvider implements AuthorizationProvider, Init
         String kind = getRole(policy, request);
         if (kind != null) {
             options = new PolicyOptionsWrapper(optionsFactory.getOptions(kind));
+            options.setOption(Policy.ASSIGNED_ROLE, kind);
             policy = new AccountPolicy(account, authenticatedAsAccount, identities, options);
         }
 
@@ -110,6 +111,10 @@ public class DefaultAuthorizationProvider implements AuthorizationProvider, Init
     }
 
     protected String getRole(Policy policy, ApiRequest request) {
+        String assignedRole = policy.getOption(Policy.ASSIGNED_ROLE);
+        if (assignedRole != null) {
+            return assignedRole;
+        }
         if (policy.isOption(Policy.ROLE_OPTION)) {
             Object role = request.getOptions().get("_role");
             if (role != null && schemaFactories.containsKey(role)) {

--- a/tests/integration/cattletest/core/test_api.py
+++ b/tests/integration/cattletest/core/test_api.py
@@ -302,6 +302,10 @@ def test_role_option(admin_user_client, client, random_str, context):
     creds = client.list_credential(name=random_str, _role='superadmin')
     assert len(creds) == 0
 
+    schemas = [x for x in admin_user_client.list_schema(_role='project')
+               if x.id == 'externalHandler']
+    assert len(schemas) == 0
+
 
 def test_query_length(admin_user_client):
     big = 'a' * 8192


### PR DESCRIPTION
Previously you could only switch to another role that also allowed
role switching.  For example between admin and superadmin.  Now you
can switch from admin to project.