### PR TITLE
Services inside stacks are discoverable to each other by default

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/DnsInfoDao.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/DnsInfoDao.java
@@ -8,11 +8,11 @@ import java.util.List;
 public interface DnsInfoDao {
     List<DnsEntryData> getInstanceLinksHostDnsData(Instance instance);
 
-    List<DnsEntryData> getServiceHostDnsData(Instance instance, boolean isVIPProvider);
+    List<DnsEntryData> getServiceDnsData(Instance instance, boolean isVIPProvider, boolean links);
 
-    List<DnsEntryData> getSelfServiceLinks(Instance instance, boolean isVIPProvider);
+    List<DnsEntryData> getSelfServiceData(Instance instance, boolean isVIPProvider);
 
-    List<DnsEntryData> getExternalServiceDnsData(Instance instance);
+    List<DnsEntryData> getExternalServiceDnsData(Instance instance, boolean links);
 
-    List<DnsEntryData> getDnsServiceLinks(Instance instance, boolean isVIPProvider);
+    List<DnsEntryData> getDnsServiceLinksData(Instance instance, boolean isVIPProvider, boolean links);
 }

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/DnsEntryData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/DnsEntryData.java
@@ -3,12 +3,16 @@ package io.cattle.platform.configitem.context.data;
 import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.IpAddress;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.collect.Lists;
+
 public class DnsEntryData {
     IpAddress sourceIpAddress;
+    Map<String, Map<String, String>> resolveServicesAndContainers = new HashMap<>();
     Map<String, List<String>> resolve = new HashMap<>();
     Map<String, String> resolveCname = new HashMap<>();
     Instance instance;
@@ -26,12 +30,23 @@ public class DnsEntryData {
     }
 
 
-    public Map<String, List<String>> getResolve() {
-        return resolve;
+    public Map<String, Map<String, String>> getResolveServicesAndContainers() {
+        return resolveServicesAndContainers;
     }
 
-    public void setResolve(Map<String, List<String>> resolve) {
-        this.resolve = resolve;
+    public void setResolveServicesAndContainers(Map<String, Map<String, String>> resolve) {
+        this.resolveServicesAndContainers = resolve;
+        for (String serviceName : resolve.keySet()) {
+            this.resolve.put(serviceName, Lists.newArrayList(resolve.get(serviceName).keySet()));
+            for (String ipAddress : resolve.get(serviceName).keySet()) {
+                String instanceName = resolve.get(serviceName).get(ipAddress);
+                if (instanceName != null) {
+                    List<String> ips = new ArrayList<>();
+                    ips.add(ipAddress);
+                    this.resolve.put(instanceName, ips);
+                }
+            }
+        }
     }
 
     public Instance getInstance() {
@@ -56,5 +71,13 @@ public class DnsEntryData {
 
     public void setClientServiceId(Long clientServiceId) {
         this.clientServiceId = clientServiceId;
+    }
+
+    public Map<String, List<String>> getResolve() {
+        return resolve;
+    }
+
+    public void setResolve(Map<String, List<String>> resolve) {
+        this.resolve = resolve;
     }
 }

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/DnsResolveEntryData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/DnsResolveEntryData.java
@@ -5,6 +5,7 @@ public class DnsResolveEntryData {
     String dnsName;
     String ipAddress;
     Long serviceId;
+    String targetInstanceName;
 
     public Long getServiceId() {
         return serviceId;
@@ -28,5 +29,13 @@ public class DnsResolveEntryData {
 
     public void setIpAddress(String ipAddress) {
         this.ipAddress = ipAddress;
+    }
+
+    public String getTargetInstanceName() {
+        return targetInstanceName;
+    }
+
+    public void setTargetInstanceName(String targetInstanceName) {
+        this.targetInstanceName = targetInstanceName;
     }
 }


### PR DESCRIPTION
* service is discoverable to every other service within the same stack by default. Service links would only be useful if user wants to override DNS name
* every container is discoverable by its name to every other container in the same stack
*  to make service discoverable to outside of the stack, links should still be used.
* for service to register to the LB, links still be used.
https://github.com/rancher/rancher/issues/2628