### PR TITLE
Trigger healtcheck update on healthcheckhostmap.create

### DIFF
--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/HealthcheckInstanceHostMapNicLookup.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/HealthcheckInstanceHostMapNicLookup.java
@@ -1,0 +1,35 @@
+package io.cattle.platform.agent.instance.service.impl;
+
+import static io.cattle.platform.core.model.tables.HealthcheckInstanceHostMapTable.HEALTHCHECK_INSTANCE_HOST_MAP;
+import static io.cattle.platform.core.model.tables.HealthcheckInstanceTable.HEALTHCHECK_INSTANCE;
+import static io.cattle.platform.core.model.tables.NicTable.NIC;
+import io.cattle.platform.agent.instance.service.InstanceNicLookup;
+import io.cattle.platform.core.model.HealthcheckInstanceHostMap;
+import io.cattle.platform.core.model.Nic;
+import io.cattle.platform.core.model.tables.records.NicRecord;
+import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
+
+import java.util.List;
+
+public class HealthcheckInstanceHostMapNicLookup extends AbstractJooqDao implements InstanceNicLookup {
+
+    @Override
+    public List<? extends Nic> getNics(Object obj) {
+        if (!(obj instanceof HealthcheckInstanceHostMap)) {
+            return null;
+        }
+        HealthcheckInstanceHostMap hostMap = (HealthcheckInstanceHostMap) obj;
+        return create()
+                .select(NIC.fields())
+                .from(NIC)
+                .join(HEALTHCHECK_INSTANCE)
+                .on(HEALTHCHECK_INSTANCE.INSTANCE_ID.eq(NIC.INSTANCE_ID))
+                .join(HEALTHCHECK_INSTANCE_HOST_MAP)
+                .on(HEALTHCHECK_INSTANCE_HOST_MAP.HEALTHCHECK_INSTANCE_ID.eq(HEALTHCHECK_INSTANCE.ID))
+                .where(HEALTHCHECK_INSTANCE_HOST_MAP.HOST_ID.eq(hostMap.getHostId())
+                        .and(NIC.REMOVED.isNull())
+                        .and(HEALTHCHECK_INSTANCE_HOST_MAP.REMOVED.isNull())
+                        .and(HEALTHCHECK_INSTANCE.REMOVED.isNull()))
+                .fetchInto(NicRecord.class);
+    }
+}

--- a/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/spring-agent-instance-context.xml
+++ b/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/spring-agent-instance-context.xml
@@ -30,6 +30,7 @@
     <bean class="io.cattle.platform.agent.instance.service.impl.VIPProviderNicLookup" />
     <bean class="io.cattle.platform.agent.instance.service.impl.ServiceNicLookup" />
     <bean class="io.cattle.platform.agent.instance.service.impl.HostCreateRemoveNicLookup" />
+    <bean class="io.cattle.platform.agent.instance.service.impl.HealthcheckInstanceHostMapNicLookup" />  
 
     <bean id="AgentInstanceTypes" class="io.cattle.platform.object.meta.TypeSet" >
         <property name="typeNames">

--- a/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/AgentReconnectPostHandler.java
+++ b/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/AgentReconnectPostHandler.java
@@ -42,7 +42,7 @@ public class AgentReconnectPostHandler extends AbstractObjectProcessLogic implem
         if (host == null) {
             return null;
         }
-        List<? extends Instance> instances = serviceDao.getInstancesWithHealtcheckRunningOnHost(host.getId());
+        List<? extends Instance> instances = serviceDao.getInstancesWithHealtcheckEnabled(host.getAccountId());
 
         reregisterInstancesForHealtchecks(instances);
 

--- a/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/HealthcheckInstanceHostMapRemovePostHandler.java
+++ b/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/HealthcheckInstanceHostMapRemovePostHandler.java
@@ -5,7 +5,7 @@ import io.cattle.platform.core.model.HealthcheckInstance;
 import io.cattle.platform.core.model.HealthcheckInstanceHostMap;
 import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.engine.handler.HandlerResult;
-import io.cattle.platform.engine.handler.ProcessPreListener;
+import io.cattle.platform.engine.handler.ProcessPostListener;
 import io.cattle.platform.engine.process.ProcessInstance;
 import io.cattle.platform.engine.process.ProcessState;
 import io.cattle.platform.process.common.handler.AbstractObjectProcessLogic;
@@ -16,7 +16,7 @@ import javax.inject.Named;
 
 @Named
 public class HealthcheckInstanceHostMapRemovePostHandler extends AbstractObjectProcessLogic implements
-        ProcessPreListener, Priority {
+        ProcessPostListener, Priority {
 
     @Inject
     HealthcheckService hcSvc;

--- a/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/HostRemovePreHandler.java
+++ b/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/HostRemovePreHandler.java
@@ -2,14 +2,12 @@ package io.cattle.iaas.healthcheck.process;
 
 import static io.cattle.platform.core.model.tables.HostTable.HOST;
 import io.cattle.iaas.healthcheck.service.HealthcheckService;
-import io.cattle.iaas.healthcheck.service.HealthcheckService.HealthcheckInstanceType;
 import io.cattle.platform.core.constants.AgentConstants;
 import io.cattle.platform.core.constants.HostConstants;
 import io.cattle.platform.core.dao.GenericMapDao;
 import io.cattle.platform.core.model.Agent;
 import io.cattle.platform.core.model.HealthcheckInstanceHostMap;
 import io.cattle.platform.core.model.Host;
-import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.engine.handler.HandlerResult;
 import io.cattle.platform.engine.handler.ProcessPreListener;
 import io.cattle.platform.engine.process.ProcessInstance;
@@ -54,19 +52,10 @@ public class HostRemovePreHandler extends AbstractObjectProcessLogic implements 
         if (host == null) {
             return null;
         }
-        List<? extends Instance> instances = serviceDao.getInstancesWithHealtcheckScheduledOnHost(host.getId());
 
         removeHealthCheckHostMaps(host);
 
-        reregisterInstancesForHealtchecks(instances);
-
         return null;
-    }
-
-    protected void reregisterInstancesForHealtchecks(List<? extends Instance> instances) {
-        for (Instance instance : instances) {
-            healthcheckService.registerForHealtcheck(HealthcheckInstanceType.INSTANCE, instance.getId());
-        }
     }
 
     protected void removeHealthCheckHostMaps(Host host) {

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/dao/ServiceDao.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/dao/ServiceDao.java
@@ -15,5 +15,5 @@ public interface ServiceDao {
 
     List<? extends Instance> getInstancesWithHealtcheckScheduledOnHost(long hostId);
 
-    List<? extends Instance> getInstancesWithHealtcheckRunningOnHost(long hostId);
+    List<? extends Instance> getInstancesWithHealtcheckEnabled(long accountId);
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/dao/impl/ServiceDaoImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/dao/impl/ServiceDaoImpl.java
@@ -49,18 +49,15 @@ public class ServiceDaoImpl extends AbstractJooqDao implements ServiceDao {
     }
 
     @Override
-    public List<? extends Instance> getInstancesWithHealtcheckRunningOnHost(long hostId) {
+    public List<? extends Instance> getInstancesWithHealtcheckEnabled(long accountId) {
         return create().select(INSTANCE.fields())
                 .from(INSTANCE)
                 .join(HEALTHCHECK_INSTANCE)
                 .on(HEALTHCHECK_INSTANCE.INSTANCE_ID.eq(INSTANCE.ID))
-                .join(INSTANCE_HOST_MAP)
-                .on(INSTANCE_HOST_MAP.INSTANCE_ID.eq(INSTANCE.ID))
-                .where(INSTANCE_HOST_MAP.HOST_ID.eq(hostId))
-                .and(INSTANCE_HOST_MAP.REMOVED.isNull())
                 .and(HEALTHCHECK_INSTANCE.REMOVED.isNull())
                 .and(INSTANCE.REMOVED.isNull())
-                .and(INSTANCE.STATE.in(InstanceConstants.STATE_STARTING, InstanceConstants.STATE_RUNNING))
+                .and(INSTANCE.STATE.in(InstanceConstants.STATE_STARTING, InstanceConstants.STATE_RUNNING)
+                        .and(INSTANCE.ACCOUNT_ID.eq(accountId)))
                 .fetchInto(InstanceRecord.class);
     }
 }

--- a/tests/integration/cattletest/core/test_healthcheck.py
+++ b/tests/integration/cattletest/core/test_healthcheck.py
@@ -208,7 +208,8 @@ def test_health_check_host_remove(super_client, context, client):
     expose_map = find_one(service.serviceExposeMaps)
     container = super_client.reload(expose_map.instance())
     hci = find_one(container.healthcheckInstances)
-    assert len(hci.healthcheckInstanceHostMaps()) == 3
+    initial_len = len(hci.healthcheckInstanceHostMaps())
+    assert initial_len == 3
 
     hcihm = hci.healthcheckInstanceHostMaps()[0]
     hosts = super_client.list_host(uuid=hcihm.host().uuid)
@@ -222,12 +223,14 @@ def test_health_check_host_remove(super_client, context, client):
 
     # verify that new hostmap was created for the instance
     hci = find_one(container.healthcheckInstances)
-    assert len(hci.healthcheckInstanceHostMaps()) == 3
+    final_len = len(hci.healthcheckInstanceHostMaps())
+    assert final_len >= initial_len
 
     hcim = None
     for h in hci.healthcheckInstanceHostMaps():
         if h.hostId == host.id:
-            hcihm = h
-            break
+            if hcihm.state == 'active':
+                hcihm = h
+                break
 
     assert hcim is None


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/2641

@ibuildthecloud:

* added that missing NicLookup for healtcheckhostmap.create.

* removed obsolete code registering instance for healtcheck in HostRemovePreHandler. Instance is being registered automatically as a part of HealthcheckInstanceHostMapRemovePostHandler

* when agent reconnects back to cattle, schedule for healtchecks all instances of host's account (in case healtcheck is missing for some of them, so it can be set on this host). That would fix the scenario when there are only 2 hosts in the system, and host2 is going down while host1 is coming up taking over all host2's healtchecks https://github.com/rancher/rancher/issues/2642
