### PR TITLE
Don't process reported INIT health state

### DIFF
--- a/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/HostRemovePreHandler.java
+++ b/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/HostRemovePreHandler.java
@@ -63,7 +63,7 @@ public class HostRemovePreHandler extends AbstractObjectProcessLogic implements 
                 HealthcheckInstanceHostMap.class,
                 Host.class, host.getId());
         for (HealthcheckInstanceHostMap healthHostMap : healthHostMaps) {
-            objectProcessManager.executeStandardProcess(StandardProcess.REMOVE, healthHostMap, null);
+            objectProcessManager.scheduleStandardProcess(StandardProcess.REMOVE, healthHostMap, null);
         }
     }
 

--- a/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/ServiceEventCreate.java
+++ b/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/ServiceEventCreate.java
@@ -28,6 +28,10 @@ public class ServiceEventCreate extends AbstractObjectProcessHandler implements 
             return null;
         }
 
+        if ("INIT".equals(event.getReportedHealth())) {
+            return null;
+        }
+
         healthcheckService.updateHealthcheck(event.getHealthcheckUuid().split("_")[0], event.getExternalTimestamp(),
                 "UP".equals(event.getReportedHealth()));
 

--- a/tests/integration/cattletest/core/test_healthcheck.py
+++ b/tests/integration/cattletest/core/test_healthcheck.py
@@ -100,6 +100,39 @@ def test_health_check_create_service(super_client, context, client):
     ts = int(time.time())
     client = _get_agent_client(agent)
     se = client.create_service_event(externalTimestamp=ts,
+                                     reportedHealth='INIT',
+                                     healthcheckUuid=hcihm.uuid)
+    super_client.wait_success(se)
+    hcihm = super_client.wait_success(super_client.reload(hcihm))
+    assert hcihm.healthState == 'healthy'
+    check = lambda: super_client.reload(container).healthState == 'healthy'
+    wait_for(check, timeout=5)
+
+    ts = int(time.time())
+    client = _get_agent_client(agent)
+    se = client.create_service_event(externalTimestamp=ts,
+                                     reportedHealth='UP',
+                                     healthcheckUuid=hcihm.uuid)
+    super_client.wait_success(se)
+    hcihm = super_client.wait_success(super_client.reload(hcihm))
+    assert hcihm.healthState == 'healthy'
+    check = lambda: super_client.reload(container).healthState == 'healthy'
+    wait_for(check, timeout=5)
+
+    ts = int(time.time())
+    client = _get_agent_client(agent)
+    se = client.create_service_event(externalTimestamp=ts,
+                                     reportedHealth='INIT',
+                                     healthcheckUuid=hcihm.uuid)
+    super_client.wait_success(se)
+    hcihm = super_client.wait_success(super_client.reload(hcihm))
+    assert hcihm.healthState == 'healthy'
+    check = lambda: super_client.reload(container).healthState == 'healthy'
+    wait_for(check, timeout=5)
+
+    ts = int(time.time())
+    client = _get_agent_client(agent)
+    se = client.create_service_event(externalTimestamp=ts,
                                      reportedHealth='Something Bad',
                                      healthcheckUuid=hcihm.uuid)
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/2637

@ibuildthecloud it fixes the scenario when either network instance is restarted, or go healthcheck process is restarted within the running instance. Before in this scenario on fresh start INIT state was sent for all existing containers that were in "healthy" state in Cattle. And INIT was treated as unhealthy state further down if previous instance's state was not "initializing" 

With the fix, INIT reported health would be ignored. Next reported health would always be UP or DOWN (DOWN 1/2), and that state would get processed accordingly. 