### PR TITLE
On any service/instance related operation, trigger updates for all vnets in the system

### DIFF
--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/HostCreateRemoveNicLookup.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/HostCreateRemoveNicLookup.java
@@ -1,16 +1,11 @@
 package io.cattle.platform.agent.instance.service.impl;
 
-import static io.cattle.platform.core.model.tables.InstanceHostMapTable.INSTANCE_HOST_MAP;
-import static io.cattle.platform.core.model.tables.InstanceTable.INSTANCE;
 import static io.cattle.platform.core.model.tables.NetworkTable.NETWORK;
-import static io.cattle.platform.core.model.tables.NicTable.NIC;
 import io.cattle.platform.agent.instance.service.InstanceNicLookup;
 import io.cattle.platform.core.constants.NetworkConstants;
 import io.cattle.platform.core.model.Host;
 import io.cattle.platform.core.model.Network;
 import io.cattle.platform.core.model.Nic;
-import io.cattle.platform.core.model.tables.records.NicRecord;
-import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
 import io.cattle.platform.object.ObjectManager;
 
 import java.util.List;
@@ -21,7 +16,7 @@ import javax.inject.Inject;
  * This class is used by metadata service to 
  * push the update to all network agents on host.add event
  */
-public class HostCreateRemoveNicLookup extends AbstractJooqDao implements InstanceNicLookup {
+public class HostCreateRemoveNicLookup extends NicPerVnetNicLookup implements InstanceNicLookup {
 
     @Inject
     ObjectManager objMgr;
@@ -39,20 +34,6 @@ public class HostCreateRemoveNicLookup extends AbstractJooqDao implements Instan
             return null;
         }
 
-        // need to get one instance per host
-        return create().
-                select(NIC.fields()).
-                from(NIC)
-                .join(INSTANCE)
-                .on(INSTANCE.ID.eq(NIC.INSTANCE_ID))
-                .join(INSTANCE_HOST_MAP)
-                .on(INSTANCE_HOST_MAP.INSTANCE_ID.eq(INSTANCE.ID))
-                .where(NIC.REMOVED.isNull())
-                .and(INSTANCE.REMOVED.isNull())
-                .and(INSTANCE_HOST_MAP.REMOVED.isNull())
-                .and(NIC.ACCOUNT_ID.eq(host.getAccountId()))
-                .and(NIC.NETWORK_ID.eq(managedNtwk.getId()))
-                .and(INSTANCE.SYSTEM_CONTAINER.isNull()).groupBy(INSTANCE_HOST_MAP.HOST_ID)
-                .fetchInto(NicRecord.class);
+        return super.getNicPerVnetForAccount(host.getAccountId());
     }
 }

--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/NicPerVnetNicLookup.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/NicPerVnetNicLookup.java
@@ -1,0 +1,29 @@
+package io.cattle.platform.agent.instance.service.impl;
+
+import static io.cattle.platform.core.model.tables.InstanceTable.INSTANCE;
+import static io.cattle.platform.core.model.tables.NicTable.NIC;
+import static io.cattle.platform.core.model.tables.VnetTable.VNET;
+import io.cattle.platform.core.model.Nic;
+import io.cattle.platform.core.model.tables.records.NicRecord;
+import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
+
+import java.util.List;
+
+public class NicPerVnetNicLookup extends AbstractJooqDao {
+
+    public List<? extends Nic> getNicPerVnetForAccount(long accountId) {
+        return create()
+                .select(NIC.fields())
+                .from(NIC)
+                .join(VNET)
+                .on(VNET.ID.eq(NIC.VNET_ID))
+                .join(INSTANCE)
+                .on(INSTANCE.ID.eq(NIC.INSTANCE_ID))
+                .where(NIC.ACCOUNT_ID.eq(accountId))
+                .and(NIC.REMOVED.isNull())
+                .and(INSTANCE.REMOVED.isNull())
+                .and(INSTANCE.SYSTEM_CONTAINER.isNull())
+                .groupBy(VNET.ID)
+                .fetchInto(NicRecord.class);
+    }
+}

--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/ServiceConsumeMapCreateNicLookup.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/ServiceConsumeMapCreateNicLookup.java
@@ -1,23 +1,16 @@
 package io.cattle.platform.agent.instance.service.impl;
 
-import static io.cattle.platform.core.model.tables.InstanceTable.INSTANCE;
-import static io.cattle.platform.core.model.tables.NicTable.NIC;
-import static io.cattle.platform.core.model.tables.ServiceExposeMapTable.SERVICE_EXPOSE_MAP;
-import static io.cattle.platform.core.model.tables.ServiceConsumeMapTable.*;
 import io.cattle.platform.agent.instance.service.InstanceNicLookup;
 import io.cattle.platform.core.dao.GenericMapDao;
 import io.cattle.platform.core.model.Nic;
-import io.cattle.platform.core.model.Service;
 import io.cattle.platform.core.model.ServiceConsumeMap;
-import io.cattle.platform.core.model.tables.records.NicRecord;
-import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
 import io.cattle.platform.object.ObjectManager;
 
 import java.util.List;
 
 import javax.inject.Inject;
 
-public class ServiceConsumeMapCreateNicLookup extends AbstractJooqDao implements InstanceNicLookup {
+public class ServiceConsumeMapCreateNicLookup extends NicPerVnetNicLookup implements InstanceNicLookup {
     @Inject
     ObjectManager objectManager;
 
@@ -31,40 +24,6 @@ public class ServiceConsumeMapCreateNicLookup extends AbstractJooqDao implements
         }
 
         ServiceConsumeMap consumeMap = (ServiceConsumeMap) obj;
-        Service service = objectManager.loadResource(Service.class, consumeMap.getServiceId());
-        
-        // hardcoding the value to mvn projects cross reference
-        if (service.getKind().equalsIgnoreCase("dnsService")) {
-            // get the nics of the instances of the services consuming the DNS service
-            return create().
-                    select(NIC.fields()).
-                    from(NIC)
-                    .join(INSTANCE)
-                    .on(INSTANCE.ID.eq(NIC.INSTANCE_ID))
-                    .join(SERVICE_EXPOSE_MAP)
-                    .on(SERVICE_EXPOSE_MAP.INSTANCE_ID.eq(INSTANCE.ID))
-                    .join(SERVICE_CONSUME_MAP)
-                    .on(SERVICE_CONSUME_MAP.SERVICE_ID.eq(SERVICE_EXPOSE_MAP.SERVICE_ID))
-                    .where(SERVICE_CONSUME_MAP.CONSUMED_SERVICE_ID.eq(service.getId())
-                            .and(NIC.REMOVED.isNull())
-                            .and(INSTANCE.REMOVED.isNull())
-                            .and(SERVICE_EXPOSE_MAP.REMOVED.isNull())
-                            .and(SERVICE_CONSUME_MAP.REMOVED.isNull()))
-                    .fetchInto(NicRecord.class);
-        } else {
-            // get nics of instances that are the part of the service
-            return create().
-                    select(NIC.fields()).
-                    from(NIC)
-                    .join(INSTANCE)
-                    .on(INSTANCE.ID.eq(NIC.INSTANCE_ID))
-                    .join(SERVICE_EXPOSE_MAP)
-                    .on(SERVICE_EXPOSE_MAP.INSTANCE_ID.eq(INSTANCE.ID))
-                    .where(SERVICE_EXPOSE_MAP.SERVICE_ID.eq(service.getId())
-                            .and(NIC.REMOVED.isNull())
-                            .and(INSTANCE.REMOVED.isNull())
-                            .and(SERVICE_EXPOSE_MAP.REMOVED.isNull()))
-                    .fetchInto(NicRecord.class);
-        }
+        return super.getNicPerVnetForAccount(consumeMap.getAccountId());
     }
 }

--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/ServiceExposeMapCreateNicLookup.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/ServiceExposeMapCreateNicLookup.java
@@ -1,17 +1,18 @@
 package io.cattle.platform.agent.instance.service.impl;
 
-import static io.cattle.platform.core.model.tables.NicTable.NIC;
 import io.cattle.platform.agent.instance.service.InstanceNicLookup;
 import io.cattle.platform.core.model.Nic;
 import io.cattle.platform.core.model.ServiceExposeMap;
-import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
 import io.cattle.platform.object.ObjectManager;
 
 import java.util.List;
 
 import javax.inject.Inject;
 
-public class ServiceExposeMapCreateNicLookup extends AbstractJooqDao implements InstanceNicLookup {
+/*
+ * Triggers selector containers use case. When container joins service, serviceExposeMap gets created
+ */
+public class ServiceExposeMapCreateNicLookup extends NicPerVnetNicLookup implements InstanceNicLookup {
 
     @Inject
     ObjectManager objectManager;
@@ -23,7 +24,7 @@ public class ServiceExposeMapCreateNicLookup extends AbstractJooqDao implements 
         }
 
         ServiceExposeMap map = (ServiceExposeMap) obj;
-        return create().selectFrom(NIC).where(NIC.INSTANCE_ID.eq(map.getInstanceId())).fetch();
+        return super.getNicPerVnetForAccount(map.getAccountId());
     }
 
 }

--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/ServiceNicLookup.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/ServiceNicLookup.java
@@ -1,23 +1,19 @@
 package io.cattle.platform.agent.instance.service.impl;
 
-import static io.cattle.platform.core.model.tables.InstanceTable.INSTANCE;
-import static io.cattle.platform.core.model.tables.NicTable.NIC;
-import static io.cattle.platform.core.model.tables.ServiceConsumeMapTable.SERVICE_CONSUME_MAP;
-import static io.cattle.platform.core.model.tables.ServiceExposeMapTable.SERVICE_EXPOSE_MAP;
 import io.cattle.platform.agent.instance.service.InstanceNicLookup;
 import io.cattle.platform.core.dao.GenericMapDao;
 import io.cattle.platform.core.model.Nic;
 import io.cattle.platform.core.model.Service;
-import io.cattle.platform.core.model.tables.records.NicRecord;
-import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
 import io.cattle.platform.object.ObjectManager;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;
 
-public class ServiceNicLookup extends AbstractJooqDao implements InstanceNicLookup {
+/*
+ * Triggers update on service link creation (service consume map creation)
+ */
+public class ServiceNicLookup extends NicPerVnetNicLookup implements InstanceNicLookup {
     @Inject
     ObjectManager objectManager;
 
@@ -29,49 +25,7 @@ public class ServiceNicLookup extends AbstractJooqDao implements InstanceNicLook
         if (!(obj instanceof Service)) {
             return null;
         }
-
         Service service = (Service) obj;
-        List<Nic> nics = new ArrayList<>();
-        populateConsumedByInstancesNics(service, nics);
-        populateServiceInstancesNics(service, nics);
-
-        return nics;
-    }
-
-    protected void populateServiceInstancesNics(Service service, List<Nic> nics) {
-        // get service's instances nics
-        List<? extends Nic> serviceInstancesNics = create().
-                select(NIC.fields()).
-                from(NIC)
-                .join(INSTANCE)
-                .on(INSTANCE.ID.eq(NIC.INSTANCE_ID))
-                .join(SERVICE_EXPOSE_MAP)
-                .on(SERVICE_EXPOSE_MAP.INSTANCE_ID.eq(INSTANCE.ID))
-                .where(SERVICE_EXPOSE_MAP.SERVICE_ID.eq(service.getId())
-                        .and(NIC.REMOVED.isNull())
-                        .and(INSTANCE.REMOVED.isNull())
-                        .and(SERVICE_EXPOSE_MAP.REMOVED.isNull()))
-                .fetchInto(NicRecord.class);
-        nics.addAll(serviceInstancesNics);
-    }
-
-    protected void populateConsumedByInstancesNics(Service service, List<Nic> nics) {
-        // get the nics of the instances of the services consuming the current service
-        List<? extends Nic> consumedByNics = create().
-                select(NIC.fields()).
-                from(NIC)
-                .join(INSTANCE)
-                .on(INSTANCE.ID.eq(NIC.INSTANCE_ID))
-                .join(SERVICE_EXPOSE_MAP)
-                .on(SERVICE_EXPOSE_MAP.INSTANCE_ID.eq(INSTANCE.ID))
-                .join(SERVICE_CONSUME_MAP)
-                .on(SERVICE_CONSUME_MAP.SERVICE_ID.eq(SERVICE_EXPOSE_MAP.SERVICE_ID))
-                .where(SERVICE_CONSUME_MAP.CONSUMED_SERVICE_ID.eq(service.getId())
-                        .and(NIC.REMOVED.isNull())
-                        .and(INSTANCE.REMOVED.isNull())
-                        .and(SERVICE_EXPOSE_MAP.REMOVED.isNull())
-                        .and(SERVICE_CONSUME_MAP.REMOVED.isNull()))
-                .fetchInto(NicRecord.class);
-        nics.addAll(consumedByNics);
+        return super.getNicPerVnetForAccount(service.getAccountId());
     }
 }

--- a/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/agent-instance-defaults.properties
+++ b/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/agent-instance-defaults.properties
@@ -6,7 +6,7 @@ agent.instance.start.items.increment=agent-instance-startup
 
 agent.instance.services.base.items=${agent.instance.start.items.apply},${agent.instance.start.items.increment}
 
-agent.instance.services.processes=nic.activate,nic.deactivate,instancelink.update,instancelink.activate,hostipaddressmap.activate,serviceexposemap.create,serviceconsumemap.create,serviceconsumemap.remove,service.activate,service.deactivate,service.update,healthcheckinstancehostmap.create,networkserviceproviderinstancemap.activate,networkserviceproviderinstancemap.remove,ipaddress.update,host.create,host.remove
+agent.instance.services.processes=nic.activate,nic.deactivate,instancelink.update,instancelink.activate,hostipaddressmap.activate,serviceexposemap.create,serviceconsumemap.create,serviceconsumemap.update,serviceconsumemap.remove,service.activate,service.deactivate,service.update,service.remove,healthcheckinstancehostmap.create,networkserviceproviderinstancemap.activate,networkserviceproviderinstancemap.remove,ipaddress.update,host.create,host.remove
 
 ipaddress.update.agentInstanceProvider.ipsecTunnelService.increment=hosts,ipsec-hosts,ipsec
 
@@ -45,12 +45,14 @@ host.ipassociation.deactivate.agentInstanceProvider.hostNatGatewayService.increm
 
 serviceconsumemap.create.agentInstanceProvider.dnsService.increment=hosts
 serviceconsumemap.remove.agentInstanceProvider.dnsService.increment=hosts
+serviceconsumemap.update.agentInstanceProvider.dnsService.increment=hosts
 serviceexposemap.create.agentInstanceProvider.dnsService.increment=hosts
 serviceexposemap.remove.agentInstanceProvider.dnsService.increment=hosts
 instancelink.update.agentInstanceProvider.dnsService.increment=hosts
 service.activate.agentInstanceProvider.dnsService.increment=hosts
 service.deactivate.agentInstanceProvider.dnsService.increment=hosts
 service.update.agentInstanceProvider.dnsService.increment=hosts
+service.remove.agentInstanceProvider.dnsService.increment=hosts
 networkserviceproviderinstancemap.activate.agentInstanceProvider.dnsService.increment=hosts
 networkserviceproviderinstancemap.remove.agentInstanceProvider.dnsService.increment=hosts
 host.create.agentInstanceProvider.dnsService.increment=hosts

--- a/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/spring-agent-instance-context.xml
+++ b/code/iaas/agent-instance/src/main/resources/META-INF/cattle/system-services/spring-agent-instance-context.xml
@@ -30,7 +30,8 @@
     <bean class="io.cattle.platform.agent.instance.service.impl.VIPProviderNicLookup" />
     <bean class="io.cattle.platform.agent.instance.service.impl.ServiceNicLookup" />
     <bean class="io.cattle.platform.agent.instance.service.impl.HostCreateRemoveNicLookup" />
-    <bean class="io.cattle.platform.agent.instance.service.impl.HealthcheckInstanceHostMapNicLookup" />  
+    <bean class="io.cattle.platform.agent.instance.service.impl.HealthcheckInstanceHostMapNicLookup" />
+    <bean class="io.cattle.platform.agent.instance.service.impl.NicPerVnetNicLookup" />
 
     <bean id="AgentInstanceTypes" class="io.cattle.platform.object.meta.TypeSet" >
         <property name="typeNames">


### PR DESCRIPTION
As all changes should be propagated for dns/metadata to all the hosts on any instance change.

@ibuildthecloud this PR makes the decision whether to update configs on certain hosts, less flaky. Its also required by https://github.com/rancher/cattle/pull/1039 as there DNS updates should be triggered all instances in the stack on any instance-in-the-stack change.

I do not update ALL the nics of all instances on all hosts, but rather pick one NIC per VNET, and that triggers agent update. 