### PR TITLE
Fix allocation bugs introduced by shared storage

### DIFF
--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/ImageVolumeStoragePoolKindConstraint.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/ImageVolumeStoragePoolKindConstraint.java
@@ -1,0 +1,39 @@
+package io.cattle.platform.allocator.constraint;
+
+import io.cattle.platform.allocator.service.AllocationAttempt;
+import io.cattle.platform.allocator.service.AllocationCandidate;
+import io.cattle.platform.core.model.StoragePool;
+import io.cattle.platform.core.model.Volume;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ImageVolumeStoragePoolKindConstraint extends HardConstraint implements Constraint {
+
+    private static final Set<String> VALID_POOL_KINDS = new HashSet<String>(Arrays.asList("sim", "docker"));
+
+    private Volume volume;
+
+    public ImageVolumeStoragePoolKindConstraint(Volume volume) {
+        super();
+        this.volume = volume;
+    }
+
+    @Override
+    public boolean matches(AllocationAttempt attempt, AllocationCandidate candidate) {
+        Set<Long> poolIds = candidate.getPools().get(volume.getId());
+        for (Long id : poolIds) {
+            StoragePool pool = candidate.loadResource(StoragePool.class, id);
+            if (!VALID_POOL_KINDS.contains(pool.getKind())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("storage pool for volume %s must be one of kind %s", volume.getId(), VALID_POOL_KINDS);
+    }
+}

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/VolumeValidStoragePoolConstraint.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/VolumeValidStoragePoolConstraint.java
@@ -11,10 +11,12 @@ public class VolumeValidStoragePoolConstraint extends HardConstraint implements 
 
     Volume volume;
     Set<Long> storagePools = new HashSet<Long>();
+    boolean exactMatch;
 
-    public VolumeValidStoragePoolConstraint(Volume volume) {
+    public VolumeValidStoragePoolConstraint(Volume volume, boolean exactMatch) {
         super();
         this.volume = volume;
+        this.exactMatch = exactMatch;
     }
 
     public Set<Long> getStoragePools() {
@@ -29,6 +31,10 @@ public class VolumeValidStoragePoolConstraint extends HardConstraint implements 
             return true;
         }
 
+        if (exactMatch) {
+            return storagePools.equals(poolIds);
+        }
+
         for (Long poolId : poolIds) {
             if (!storagePools.contains(poolId)) {
                 return false;
@@ -40,7 +46,8 @@ public class VolumeValidStoragePoolConstraint extends HardConstraint implements 
 
     @Override
     public String toString() {
-        return String.format("volume [%d] must be one of pool(s) %s", volume.getId(), storagePools);
+        String matchText = exactMatch ? "have exactly these pool(s): " : "must be one of pool(s)";
+        return String.format("volume [%d] %s %s", volume.getId(), matchText, storagePools);
     }
 
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/ImageConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/ImageConstants.java
@@ -1,6 +1,0 @@
-package io.cattle.platform.core.constants;
-
-public class ImageConstants {
-    public static String FORMAT_DOCKER = "docker:";
-    public static String FORMAT_SIM = "sim:";
-}

--- a/tests/integration/cattletest/core/test_external_events.py
+++ b/tests/integration/cattletest/core/test_external_events.py
@@ -1,134 +1,21 @@
 from common_fixtures import *  # NOQA
 from cattle import ApiError
 
-
-SP_CREATE = "storagepool.create"
-VOLUME_CREATE = "volume.create"
-VOLUME_DELETE = "volume.delete"
 SERVICE_KIND = 'testservicekind'
-
-
-@pytest.fixture(scope='module')
-def host(super_client, context):
-    return super_client.reload(context.host)
-
-
-def agent_cli(context):
-    return context.agent_client
 
 
 def from_context(context):
     return context.client, context.agent_client, context.host
 
 
-def test_external_volume_event(super_client, new_context):
-    client, agent_client, host = from_context(new_context)
-    sp_ex_id = random_str()
-    sp_name = 'name-%s' % sp_ex_id
-    external_id = random_str()
-
-    # Create a storage pool for the volume
-    create_sp_event(client, agent_client, super_client, new_context,
-                    sp_ex_id, sp_name, SP_CREATE, [host.uuid], None)
-    storage_pool = wait_for(lambda: sp_wait(client, sp_ex_id))
-
-    driver = 'convoy'
-    uri = '/foo/bar'
-    fmt = 'docker'
-    is_hp = False
-
-    create_volume_event(client, agent_client, super_client, new_context,
-                        sp_ex_id, VOLUME_CREATE, external_id,
-                        driver=driver, fmt=fmt, is_hp=is_hp, uri=uri)
-
-    volume = wait_for(lambda: volume_wait(client, external_id))
-    volume = wait_for(lambda: volume_in_sp(client, volume, storage_pool))
-    assert volume.state == 'inactive'
-    assert volume.externalId == external_id
-    assert volume.name == external_id
-    assert volume.driver == driver
-    assert volume.uri == uri
-    assert volume.isHostPath == is_hp
-    super_volume = super_client.by_id('volume', volume.id)
-    assert super_volume.deviceNumber == -1
-    assert super_volume.format == fmt
-
-    # Send event again to ensure two volumes are not created
-    create_volume_event(client, agent_client, super_client, new_context,
-                        sp_ex_id, VOLUME_CREATE, external_id,
-                        driver=driver, fmt=fmt, is_hp=is_hp, uri=uri)
-    volumes = client.list_volume(externalId=external_id)
-    assert len(volumes) == 1
-
-    # Delete volume event
-    create_volume_event(client, agent_client, super_client, new_context,
-                        sp_ex_id, VOLUME_DELETE, external_id,
-                        driver=driver, fmt=fmt, is_hp=is_hp, uri=uri)
-
-    volume = client.wait_success(volume)
-    assert volume.state == 'removed'
-
-
-def test_external_storage_pool_event(super_client, new_context):
-    client, agent_client, host = from_context(new_context)
-
-    external_id = random_str()
-    name = 'name-%s' % external_id
-    driver_name = 'rancher-bob'
-
-    # Create a new storage pool with a single host
-    uuids = [host.uuid]
-    create_sp_event(client, agent_client, super_client, new_context,
-                    external_id, name, SP_CREATE, uuids, driver_name)
-    storage_pool = wait_for(lambda: sp_wait(client, external_id))
-    assert storage_pool.state == 'active'
-    assert storage_pool.externalId == external_id
-    assert storage_pool.name == name
-    assert storage_pool.driverName == driver_name
-    hosts = wait_for(lambda: wait_host_count(storage_pool, 1))
-    assert len(hosts) == 1
-    assert hosts[0].uuid == host.uuid
-
-    # Send event again to ensure a second storage pool is not created
-    create_sp_event(client, agent_client, super_client, new_context,
-                    external_id, name, SP_CREATE, uuids, None)
-
-    # Add a second host
-    host2 = register_simulated_host(new_context)
-    uuids.append(host2.uuid)
-    create_sp_event(client, agent_client, super_client, new_context,
-                    external_id,
-                    name, SP_CREATE, uuids, None)
-    hosts = wait_for(lambda: wait_host_count(storage_pool, 2))
-    host_ids = [h.id for h in hosts]
-    assert host.id in host_ids
-    assert host2.id in host_ids
-
-    # Remove a host
-    uuids.pop(0)
-    create_sp_event(client, agent_client, super_client, new_context,
-                    external_id,
-                    name, SP_CREATE, uuids, None)
-    hosts = wait_for(lambda: wait_host_count(storage_pool, 1))
-    assert host2.id in hosts[0].id
-
-    # Send empty host list
-    uuids = []
-    create_sp_event(client, agent_client, super_client, new_context,
-                    external_id,
-                    name, SP_CREATE, uuids, None)
-    hosts = wait_for(lambda: wait_host_count(storage_pool, 0))
-    assert len(hosts) == 0
-
-
-def test_bad_agent(super_client, host):
+def test_bad_agent(super_client):
     # Even though super_client will have permissions to create the container
     # event, additional logic should assert that the creator is a valid agent.
     with pytest.raises(ApiError) as e:
         external_id = random_str()
         super_client.create_external_storage_pool_event(
             externalId=external_id,
-            eventType=SP_CREATE,
+            eventType="storagepool.create",
             hostUuids=[],
             storagePool={
                 'name': 'name-%s' % external_id,
@@ -293,94 +180,6 @@ def create_dns_event(client, agent_client, super_client,
     return event
 
 
-def create_volume_event(client, agent_client, super_client, context,
-                        sp_ex_id, event_type, external_id, driver=None,
-                        fmt=None, is_hp=False, uri=None):
-    vol_event = {
-        'externalId': external_id,
-        'eventType': event_type,
-        'storagePoolExternalId': sp_ex_id,
-        'volume': {
-            "externalId": external_id,
-            "name": external_id,
-            "driver": driver,
-            "uri": uri,
-            "format": fmt,
-            "isHostPath": is_hp,
-        }
-    }
-
-    event = agent_client.create_external_volume_event(vol_event)
-    assert event.externalId == external_id
-    assert event.eventType == event_type
-    event = wait_for(lambda: event_wait(client, event))
-    assert event.accountId == context.project.id
-    assert event.reportedAccountId == context.agent.id
-
-    return event
-
-
-def create_sp_event(client, agent_client, super_client, context, external_id,
-                    name, event_type, host_uuids, driver_name):
-    event = agent_client.create_external_storage_pool_event(
-        externalId=external_id,
-        eventType=event_type,
-        hostUuids=host_uuids,
-        storagePool={
-            'name': name,
-            'externalId': external_id,
-            'driverName': driver_name,
-        })
-
-    assert event.externalId == external_id
-    assert event.eventType == event_type
-    assert event.hostUuids == host_uuids
-
-    event = wait_for(lambda: event_wait(client, event))
-    assert event.accountId == context.project.id
-    assert event.reportedAccountId == context.agent.id
-
-    return event
-
-
-def sp_wait(client, external_id):
-    storage_pools = client.list_storage_pool(externalId=external_id)
-    if len(storage_pools) and storage_pools[0].state == 'active':
-        return storage_pools[0]
-
-
-def volume_wait(client, external_id):
-    volumes = client.list_volume(externalId=external_id)
-    if len(volumes) and volumes[0].state == 'inactive':
-        return volumes[0]
-
-
-def service_wait(client, external_id):
-    services = client.list_testservicekind(externalId=external_id)
-    if len(services) and services[0].state == 'active':
-        return services[0]
-
-
-def wait_host_count(storage_pool, count):
-    new_hosts = storage_pool.hosts()
-    if len(new_hosts) == count:
-        return new_hosts
-
-
-def volume_in_sp(client, volume, storage_pool):
-    volumes = storage_pool.volumes()
-    if len(volumes) > 0:
-        for v in volumes:
-            if v.id == volume.id:
-                return volume
-
-
-def event_wait(client, event):
-    created = client.by_id('externalEvent', event.id)
-    if created is not None and created.state == 'created':
-        return created
-
-
 def test_external_service_event_create(client, context,
                                        create_dynamic_service_type,
                                        super_client):
@@ -476,3 +275,15 @@ def create_dynamic_service_type(client, context):
                                     }})
     client.wait_success(service)
     client.reload_schema()
+
+
+def service_wait(client, external_id):
+    services = client.list_testservicekind(externalId=external_id)
+    if len(services) and services[0].state == 'active':
+        return services[0]
+
+
+def event_wait(client, event):
+    created = client.by_id('externalEvent', event.id)
+    if created is not None and created.state == 'created':
+        return created

--- a/tests/integration/cattletest/core/test_shared_volumes.py
+++ b/tests/integration/cattletest/core/test_shared_volumes.py
@@ -1,0 +1,246 @@
+from common_fixtures import *  # NOQA
+
+SP_CREATE = "storagepool.create"
+VOLUME_CREATE = "volume.create"
+VOLUME_DELETE = "volume.delete"
+
+
+def more_hosts(context):
+    host2 = register_simulated_host(context)
+    host3 = register_simulated_host(context)
+    return context.host, host2, host3
+
+
+def from_context(context):
+    return context.client, context.agent_client, context.host
+
+
+def add_storage_pool(context):
+    client, agent_client, host = from_context(context)
+    sp_name = 'convoy-%s' % random_str()
+    uuids = [host.uuid]
+    create_sp_event(client, agent_client, context,
+                    sp_name, sp_name, SP_CREATE, uuids, sp_name)
+    storage_pool = wait_for(lambda: sp_wait(client, sp_name))
+    assert storage_pool.state == 'active'
+    host = client.reload(host)
+    storage_pools = host.storagePools()
+    assert len(storage_pools) == 2
+    return storage_pool
+
+
+def test_multiple_sp_volume_schedule(new_context):
+    # Tests that when a host has more than one storage pool (one local, one
+    # shared), and a container is scheduled to it, the root volume can be
+    # properly scheduled.
+    client = new_context.client
+    add_storage_pool(new_context)
+
+    # The allocation bug that caused this issue is much more likely to occur
+    # when two containers are created back-to-back
+    c = client.create_container(imageUuid=new_context.image_uuid,
+                                networkMode=None)
+    c2 = client.create_container(imageUuid=new_context.image_uuid,
+                                 networkMode=None)
+
+    c = client.wait_success(c)
+    assert c is not None
+    vols = c.volumes()
+    assert len(vols) == 1
+    vol_pools = vols[0].storagePools()
+    assert len(vol_pools) == 1
+    assert vol_pools[0].kind == 'sim'
+
+    c2 = client.wait_success(c2)
+    assert c2 is not None
+    vols = c2.volumes()
+    assert len(vols) == 1
+    vol_pools = vols[0].storagePools()
+    assert len(vol_pools) == 1
+    assert vol_pools[0].kind == 'sim'
+
+
+def test_data_volume_mounts(new_context):
+    client, agent_client, host = from_context(new_context)
+    storage_pool = add_storage_pool(new_context)
+    sp_name = storage_pool.name
+    external_id = random_str()
+    uri = '/foo/bar'
+    create_volume_event(client, agent_client, new_context, sp_name,
+                        VOLUME_CREATE, external_id, driver=sp_name, uri=uri)
+    volume = wait_for(lambda: volume_wait(client, external_id))
+    volume = wait_for(lambda: volume_in_sp(client, volume, storage_pool))
+
+    data_volume_mounts = {'/somedir': volume.id}
+    c = client.create_container(imageUuid=new_context.image_uuid,
+                                volumeDriver='local',
+                                dataVolumeMounts=data_volume_mounts)
+    c = client.wait_success(c, timeout=240)
+    assert c.state == 'running'
+    assert c.dataVolumes[0] == '%s:/somedir' % external_id
+
+
+def test_external_volume_event(super_client, new_context):
+    client, agent_client, host = from_context(new_context)
+    storage_pool = add_storage_pool(new_context)
+    sp_name = storage_pool.name
+    external_id = random_str()
+    uri = '/foo/bar'
+
+    create_volume_event(client, agent_client, new_context, sp_name,
+                        VOLUME_CREATE, external_id, driver=sp_name, uri=uri)
+
+    volume = wait_for(lambda: volume_wait(client, external_id))
+    volume = wait_for(lambda: volume_in_sp(client, volume, storage_pool))
+    assert volume.state == 'inactive'
+    assert volume.externalId == external_id
+    assert volume.name == external_id
+    assert volume.driver == sp_name
+    assert volume.uri == uri
+    assert volume.isHostPath is False
+    super_volume = super_client.by_id('volume', volume.id)
+    assert super_volume.deviceNumber == -1
+    assert super_volume.format == 'docker'
+
+    # Send event again to ensure two volumes are not created
+    create_volume_event(client, agent_client, new_context, sp_name,
+                        VOLUME_CREATE, external_id, driver=sp_name, uri=uri)
+    volumes = client.list_volume(externalId=external_id)
+    assert len(volumes) == 1
+
+    # Delete volume event
+    create_volume_event(client, agent_client, new_context, sp_name,
+                        VOLUME_DELETE, external_id, driver=sp_name, uri=uri)
+
+    volume = client.wait_success(volume)
+    assert volume.state == 'removed'
+
+
+def test_external_storage_pool_event(new_context):
+    client, agent_client, host = from_context(new_context)
+    sp_name = 'convoy-%s' % random_str()
+
+    # Create a new storage pool with a single host
+    uuids = [host.uuid]
+    create_sp_event(client, agent_client, new_context,
+                    sp_name, sp_name, SP_CREATE, uuids, sp_name)
+    storage_pool = wait_for(lambda: sp_wait(client, sp_name))
+    assert storage_pool.state == 'active'
+    assert storage_pool.externalId == sp_name
+    assert storage_pool.name == sp_name
+    assert storage_pool.driverName == sp_name
+    hosts = wait_for(lambda: wait_host_count(storage_pool, 1))
+    assert len(hosts) == 1
+    assert hosts[0].uuid == host.uuid
+
+    # Send event again to ensure a second storage pool is not created
+    create_sp_event(client, agent_client, new_context,
+                    sp_name, sp_name, SP_CREATE, uuids, sp_name)
+
+    # Add a second host
+    host2 = register_simulated_host(new_context)
+    uuids.append(host2.uuid)
+    create_sp_event(client, agent_client, new_context,
+                    sp_name,
+                    sp_name, SP_CREATE, uuids, sp_name)
+    hosts = wait_for(lambda: wait_host_count(storage_pool, 2))
+    host_ids = [h.id for h in hosts]
+    assert host.id in host_ids
+    assert host2.id in host_ids
+
+    # Remove a host
+    uuids.pop(0)
+    create_sp_event(client, agent_client, new_context,
+                    sp_name,
+                    sp_name, SP_CREATE, uuids, sp_name)
+    hosts = wait_for(lambda: wait_host_count(storage_pool, 1))
+    assert host2.id in hosts[0].id
+
+    # Send empty host list
+    uuids = []
+    create_sp_event(client, agent_client, new_context,
+                    sp_name,
+                    sp_name, SP_CREATE, uuids, sp_name)
+    hosts = wait_for(lambda: wait_host_count(storage_pool, 0))
+    assert len(hosts) == 0
+
+
+def create_volume_event(client, agent_client, context, sp_ex_id, event_type,
+                        external_id, driver=None, uri=None):
+    vol_event = {
+        'externalId': external_id,
+        'eventType': event_type,
+        'storagePoolExternalId': sp_ex_id,
+        'volume': {
+            'externalId': external_id,
+            'name': external_id,
+            'driver': driver,
+            'uri': uri,
+            'format': 'docker',
+            'isHostPath': False,
+        }
+    }
+
+    event = agent_client.create_external_volume_event(vol_event)
+    assert event.externalId == external_id
+    assert event.eventType == event_type
+    event = wait_for(lambda: event_wait(client, event))
+    assert event.accountId == context.project.id
+    assert event.reportedAccountId == context.agent.id
+
+    return event
+
+
+def create_sp_event(client, agent_client, context, external_id, name,
+                    event_type, host_uuids, driver_name):
+    event = agent_client.create_external_storage_pool_event(
+        externalId=external_id,
+        eventType=event_type,
+        hostUuids=host_uuids,
+        storagePool={
+            'name': name,
+            'externalId': external_id,
+            'driverName': driver_name,
+        })
+
+    assert event.externalId == external_id
+    assert event.eventType == event_type
+    assert event.hostUuids == host_uuids
+
+    event = wait_for(lambda: event_wait(client, event))
+    assert event.accountId == context.project.id
+    assert event.reportedAccountId == context.agent.id
+
+    return event
+
+
+def sp_wait(client, external_id):
+    storage_pools = client.list_storage_pool(externalId=external_id)
+    if len(storage_pools) and storage_pools[0].state == 'active':
+        return storage_pools[0]
+
+
+def volume_wait(client, external_id):
+    volumes = client.list_volume(externalId=external_id)
+    if len(volumes) and volumes[0].state == 'inactive':
+        return volumes[0]
+
+
+def wait_host_count(storage_pool, count):
+    new_hosts = storage_pool.hosts()
+    if len(new_hosts) == count:
+        return new_hosts
+
+
+def volume_in_sp(client, volume, storage_pool):
+    volumes = storage_pool.volumes()
+    if len(volumes) > 0:
+        for v in volumes:
+            if v.id == volume.id:
+                return volume
+
+
+def event_wait(client, event):
+    created = client.by_id('externalEvent', event.id)
+    if created is not None and created.state == 'created':
+        return created


### PR DESCRIPTION
Bugs fixed (not recorded by QA because the feature isn't exposed yet):
- When specifying dataVolumeMounts, allocator cannot incrementally add a StoragePoolVolumeMap for each dataVolumeMount.
- When more than one storage pools is associated with a host, a race condition can cause the allocator to fail because the allocator would pick different storage pools on different runs
- When more than one storage pools is associated with a host, the placement of volumes to a storage pool was non-deterministic. They could land on any pool associated to the host.