### PR TITLE
Removed the space for non-default certs on haproxy

### DIFF
--- a/resources/content/config-content/haproxy/content/etc/haproxy/certs/certs.pem.ftl
+++ b/resources/content/config-content/haproxy/content/etc/haproxy/certs/certs.pem.ftl
@@ -2,6 +2,6 @@
 <#list certs as cert >
 ${cert.key}
 ${cert.cert}
-<#if cert.certChain??> ${cert.certChain}</#if>
+<#if cert.certChain??>${cert.certChain}</#if>
 </#list>
 </#if>


### PR DESCRIPTION
One missing fix for: https://github.com/rancher/rancher/issues/2502

Applied the original fix to only default cert, forgot the rest