### PR TITLE
Lookup named volumes on instance.create

### DIFF
--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceVolumeLookupPreCreate.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceVolumeLookupPreCreate.java
@@ -1,0 +1,111 @@
+package io.cattle.platform.process.instance;
+
+import io.cattle.platform.core.constants.InstanceConstants;
+import io.cattle.platform.core.dao.StoragePoolDao;
+import io.cattle.platform.core.dao.VolumeDao;
+import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.StoragePool;
+import io.cattle.platform.core.model.Volume;
+import io.cattle.platform.engine.handler.HandlerResult;
+import io.cattle.platform.engine.handler.ProcessPreListener;
+import io.cattle.platform.engine.process.ProcessInstance;
+import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.object.ObjectManager;
+import io.cattle.platform.object.process.ObjectProcessManager;
+import io.cattle.platform.object.util.DataAccessor;
+import io.cattle.platform.process.common.handler.AbstractObjectProcessLogic;
+import io.cattle.platform.util.exception.ExecutionException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Named
+public class InstanceVolumeLookupPreCreate extends AbstractObjectProcessLogic implements ProcessPreListener {
+
+    private static final Logger log = LoggerFactory.getLogger(InstanceVolumeLookupPreCreate.class);
+    private static final String LOCAL = "local";
+
+    @Inject
+    ObjectManager objectManager;
+    @Inject
+    ObjectProcessManager processManager;
+    @Inject
+    StoragePoolDao storagePoolDao;
+    @Inject
+    VolumeDao volumeDao;
+
+    @Override
+    public String[] getProcessNames() {
+        return new String[] { "instance.create" };
+    }
+
+    /**
+     * Looks for shared volumes in the dataVolumes field and converts them to dataVolumeMounts.
+     * If volumeDriver is set:
+     *  if set to local, do nothing
+     *  if set to anything else, restrict volume lookup to a matching storage pool
+     *  if blank, do not restrict volume lookup to a particular storage pool.
+     * If volume is found, remove from dataVolumes list and put it in dataVolumeMounts. 
+     * If volume is not found, just leave it in dataVolumes.
+     */
+    @Override
+    public HandlerResult handle(ProcessState state, ProcessInstance process) {
+        Instance instance = (Instance)state.getResource();
+        if (!InstanceConstants.KIND_CONTAINER.equals(instance.getKind())) {
+            return null;
+        }
+
+        String vd = DataAccessor.fieldString(instance, InstanceConstants.FIELD_VOLUME_DRIVER);
+        if (LOCAL.equals(vd)) {
+            return null;
+        }
+
+        Long storagePoolId = null;
+        long accountId = instance.getAccountId();
+        if (StringUtils.isNotEmpty(vd)) {
+            StoragePool sp = storagePoolDao.findStoragePoolByDriverName(accountId, vd);
+            if (sp != null) {
+                storagePoolId = sp.getId();
+            }
+        }
+
+        Map<Object, Object> data = new HashMap<>();
+        List<String> dataVolumes = DataAccessor.fieldStringList(instance, InstanceConstants.FIELD_DATA_VOLUMES);
+        Map<String, Object> dataVolumeMounts = DataAccessor.fieldMap(instance, InstanceConstants.FIELD_DATA_VOLUME_MOUNTS);
+        List<String> newDataVolumes = new ArrayList<String>();
+        data.put(InstanceConstants.FIELD_DATA_VOLUMES, newDataVolumes);
+        data.put(InstanceConstants.FIELD_DATA_VOLUME_MOUNTS, dataVolumeMounts);
+        for (String v : dataVolumes) {
+            if (!v.startsWith("/")) {
+                String[] parts = v.split(":", 2);
+                if (parts.length > 1) {
+                    try {
+                        Volume vol = volumeDao.findSharedVolume(accountId, storagePoolId, parts[0]);
+                        if (vol != null) {
+                            dataVolumeMounts.put(parts[1], vol.getId());
+                            continue;
+                        }
+                    } catch (IllegalStateException e) {
+                        log.error(e.getMessage());
+                        objectProcessManager.scheduleProcessInstance(InstanceConstants.PROCESS_REMOVE, instance, null);
+                        ExecutionException ex = new ExecutionException(String.format("Could not process named volume %s. "
+                                + "More than one volume with that name exists.", parts[0]));
+                        ex.setResources(state.getResource());
+                        throw ex;
+                    }
+                }
+            }
+            newDataVolumes.add(v);
+        }
+        return new HandlerResult(data);
+    }
+}

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
@@ -42,6 +42,7 @@ public class InstanceConstants {
     public static final String FIELD_DEPLOYMENT_UNIT_UUID = "deploymentUnitUuid";
     public static final String FIELD_DATA_VOLUME_MOUNTS = "dataVolumeMounts";
     public static final String FIELD_DATA_VOLUMES = "dataVolumes"; 
+    public static final String FIELD_VOLUME_DRIVER = "volumeDriver";
 
     public static final String PROCESS_DATA_NO_OP = "containerNoOpEvent";
 

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/VolumeDao.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/VolumeDao.java
@@ -10,4 +10,9 @@ public interface VolumeDao {
     
     void createVolumeInStoragePool(Map<String, Object> volumeData, StoragePool storagePool);
 
+    /**
+     * Does what the name says, but if storagePoolId is null, will look across all non-local storage pools
+     * if storagePoolId is not null, will restrict the lookup to that storage pool.
+     */
+    Volume findSharedVolume(long accountId, Long storagePoolId, String volumeName);
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/VolumeDaoImpl.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/VolumeDaoImpl.java
@@ -1,5 +1,6 @@
 package io.cattle.platform.core.dao.impl;
 
+import static io.cattle.platform.core.model.tables.StoragePoolTable.*;
 import static io.cattle.platform.core.model.tables.VolumeStoragePoolMapTable.*;
 import static io.cattle.platform.core.model.tables.VolumeTable.*;
 import io.cattle.platform.core.constants.CommonStatesConstants;
@@ -13,14 +14,20 @@ import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
 import io.cattle.platform.object.ObjectManager;
 import io.cattle.platform.object.process.ObjectProcessManager;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Inject;
 
 import org.jooq.Record;
 
 public class VolumeDaoImpl extends AbstractJooqDao implements VolumeDao {
+
+    private static final Set<String> LOCAL_POOL_KINDS = new HashSet<String>(Arrays.asList(new String[]{"docker", "sim"}));
 
     @Inject
     GenericResourceDao resourceDao;
@@ -52,5 +59,48 @@ public class VolumeDaoImpl extends AbstractJooqDao implements VolumeDao {
         vspm.put("volumeId", volume.getId());
         vspm.put("storagePoolId", storagePool.getId());
         resourceDao.createAndSchedule(VolumeStoragePoolMap.class, vspm);
+    }
+
+    @Override
+    public Volume findSharedVolume(long accountId, Long storagePoolId, String volumeName) {
+        List<VolumeRecord> volumes = null;
+        if (storagePoolId == null) {
+            volumes = create()
+            .select(VOLUME.fields())
+            .from(VOLUME)
+            .join(VOLUME_STORAGE_POOL_MAP)
+                .on(VOLUME_STORAGE_POOL_MAP.VOLUME_ID.eq(VOLUME.ID))
+            .join(STORAGE_POOL)
+                .on(VOLUME_STORAGE_POOL_MAP.STORAGE_POOL_ID.eq(STORAGE_POOL.ID)
+                .and(STORAGE_POOL.KIND.notIn(LOCAL_POOL_KINDS)))
+                .and(STORAGE_POOL.REMOVED.isNull())
+            .where(VOLUME.NAME.eq(volumeName)
+                .and((VOLUME.REMOVED.isNull().or(VOLUME.STATE.eq(CommonStatesConstants.REMOVING)))))
+                .and(VOLUME.ACCOUNT_ID.eq(accountId))
+            .fetchInto(VolumeRecord.class);
+        } else {
+            volumes = create()
+            .select(VOLUME.fields())
+            .from(VOLUME)
+            .join(VOLUME_STORAGE_POOL_MAP)
+                .on(VOLUME_STORAGE_POOL_MAP.VOLUME_ID.eq(VOLUME.ID)
+                .and(VOLUME_STORAGE_POOL_MAP.STORAGE_POOL_ID.eq(storagePoolId)))
+            .join(STORAGE_POOL)
+                .on(VOLUME_STORAGE_POOL_MAP.STORAGE_POOL_ID.eq(STORAGE_POOL.ID))
+                .and(STORAGE_POOL.REMOVED.isNull())
+            .where(VOLUME.NAME.eq(volumeName)
+                .and((VOLUME.REMOVED.isNull().or(VOLUME.STATE.eq(CommonStatesConstants.REMOVING)))))
+                .and(VOLUME.ACCOUNT_ID.eq(accountId))
+            .fetchInto(VolumeRecord.class);
+        }
+
+        if (volumes.size() <= 0) {
+            return null;
+        } else if (volumes.size() == 1) {
+            return volumes.get(0);
+        } else {
+            throw new IllegalStateException(String.format("Found %s volumes matching: account id %s, storage pool id %s, volume name %s.",
+                    volumes.size(), accountId, storagePoolId, volumeName));
+        }
     }
 }

--- a/code/implementation/docker/common/src/main/java/io/cattle/platform/docker/constants/DockerInstanceConstants.java
+++ b/code/implementation/docker/common/src/main/java/io/cattle/platform/docker/constants/DockerInstanceConstants.java
@@ -36,7 +36,6 @@ public class DockerInstanceConstants {
     public static final String FIELD_PID_MODE = "pidMode";
     public static final String FIELD_EXTRA_HOSTS = "extraHosts";
     public static final String FIELD_READ_ONLY = "readOnly";
-    public static final String FIELD_VOLUME_DRIVER = "volumeDriver";
 
     public static final String EVENT_FIELD_VOLUMES_FROM = "dataVolumesFromContainers";
 


### PR DESCRIPTION
Adds logic to support properly scheduling containers that are using
shared volumes. If a named volume is specified in dataVolumes like
this: `vol1:/container/path`, then during instance.create, look to see
if that volume exists in a non-local storage pool and if it does, use
that volume by adding an entry to dataVolumeMounts.