### PR TITLE
Don't wait for lb config update

### DIFF
--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerUpdateConfig.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerUpdateConfig.java
@@ -140,12 +140,6 @@ public class LoadBalancerUpdateConfig extends AbstractObjectProcessLogic impleme
             request = before(request, agent);
             ConfigUpdateRequestUtils.setRequest(request, state, getContext(agent));
         }
-
-        for (Agent agent : agents) {
-            ConfigUpdateRequest request = ConfigUpdateRequestUtils.getRequest(jsonMapper, state, getContext(agent));
-            after(request);
-            ConfigUpdateRequestUtils.setRequest(request, state, getContext(agent));
-        }
     }
 
     @Override
@@ -164,14 +158,6 @@ public class LoadBalancerUpdateConfig extends AbstractObjectProcessLogic impleme
         statusManager.updateConfig(request);
 
         return request;
-    }
-
-    protected void after(ConfigUpdateRequest request) {
-        if (request == null) {
-            return;
-        }
-
-        statusManager.waitFor(request);
     }
 
     public String getContext(Agent agent) {


### PR DESCRIPTION
during the instance start. Instance start shouldn't be delayed because it takes time to program itself to the (n) lb services in the system or/and if lb service itself goes through activating/updating state. 

So with this fix, target instance.start will just schedule haproxy config item update. This fix is already in "Killed standalone LB" PR, so just porting it to master as health check use cases can be affected by the pre-fix behavior.  

https://github.com/rancher/rancher/issues/2697