### PR TITLE
Standalone LB bug fixes...

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/MetaDataInfoDaoImpl.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/MetaDataInfoDaoImpl.java
@@ -11,6 +11,7 @@ import static io.cattle.platform.core.model.tables.ServiceExposeMapTable.SERVICE
 import io.cattle.platform.configitem.context.dao.MetaDataInfoDao;
 import io.cattle.platform.configitem.context.data.ContainerMetaData;
 import io.cattle.platform.configitem.context.data.HostMetaData;
+import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
 import io.cattle.platform.core.constants.IpAddressConstants;
 import io.cattle.platform.core.model.Host;
@@ -91,6 +92,9 @@ public class MetaDataInfoDaoImpl extends AbstractJooqDao implements MetaDataInfo
                 .and(instance.ACCOUNT_ID.eq(accountId))
                 .and(instanceIpAddress.ROLE.eq(IpAddressConstants.ROLE_PRIMARY))
                 .and(instance.REMOVED.isNull())
+                .and(instance.STATE.notIn(CommonStatesConstants.REMOVING, CommonStatesConstants.REMOVED))
+                .and(exposeMap.REMOVED.isNull())
+                .and(exposeMap.STATE.notIn(CommonStatesConstants.REMOVING, CommonStatesConstants.REMOVED))
                 .fetch().map(mapper);
     }
 
@@ -129,6 +133,7 @@ public class MetaDataInfoDaoImpl extends AbstractJooqDao implements MetaDataInfo
                 .leftOuterJoin(INSTANCE_HOST_MAP)
                 .on(host.ID.eq(INSTANCE_HOST_MAP.HOST_ID))
                 .where(host.REMOVED.isNull())
+                .and(host.STATE.notIn(CommonStatesConstants.REMOVING, CommonStatesConstants.REMOVED))
                 .and(condition)
                 .and(hostIpAddress.REMOVED.isNull())
                 .and(host.ACCOUNT_ID.eq(accountId)).groupBy(host.ID)

--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerUpdateConfig.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerUpdateConfig.java
@@ -152,7 +152,7 @@ public class LoadBalancerUpdateConfig extends AbstractObjectProcessLogic impleme
         if (request == null) {
             request = ConfigUpdateRequest.forResource(Agent.class, agent.getId());
             for (String item : ITEMS.get()) {
-                request.addItem(item).withIncrement(true).setCheckInSyncOnly(true);
+                request.addItem(item).withApply(true).withIncrement(true).setCheckInSyncOnly(true);
             }
         }
 

--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerUpdateConfig.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/process/LoadBalancerUpdateConfig.java
@@ -7,6 +7,7 @@ import io.cattle.platform.configitem.request.util.ConfigUpdateRequestUtils;
 import io.cattle.platform.configitem.version.ConfigItemStatusManager;
 import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
+import io.cattle.platform.core.constants.LoadBalancerConstants;
 import io.cattle.platform.core.constants.PortConstants;
 import io.cattle.platform.core.dao.GenericResourceDao;
 import io.cattle.platform.core.dao.IpAddressDao;
@@ -151,7 +152,7 @@ public class LoadBalancerUpdateConfig extends AbstractObjectProcessLogic impleme
         if (request == null) {
             request = ConfigUpdateRequest.forResource(Agent.class, agent.getId());
             for (String item : ITEMS.get()) {
-                request.addItem(item).withApply(true).withIncrement(true).setCheckInSyncOnly(true);
+                request.addItem(item).withIncrement(true).setCheckInSyncOnly(true);
             }
         }
 
@@ -172,7 +173,13 @@ public class LoadBalancerUpdateConfig extends AbstractObjectProcessLogic impleme
         for (Long lbId : lbIds) {
             List<? extends Instance> lbInstances = new ArrayList<>();
             LoadBalancer lb = loadResource(LoadBalancer.class, lbId);
-            lbInstances = lbInstanceManager.createLoadBalancerInstances(lb);
+
+            boolean create = false;
+            if (process.getName().equalsIgnoreCase(LoadBalancerConstants.PROCESS_LB_HOST_MAP_CREATE)) {
+                create = true;
+            }
+
+            lbInstances = lbInstanceManager.createLoadBalancerInstances(lb, create);
             allLbInstances.addAll(lbInstances);
             lbInstancesMap.put(lbId, lbInstances);
         }

--- a/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/service/LoadBalancerInstanceManager.java
+++ b/code/iaas/lb-instance/src/main/java/io/cattle/platform/lb/instance/service/LoadBalancerInstanceManager.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public interface LoadBalancerInstanceManager {
 
-    List<? extends Instance> createLoadBalancerInstances(LoadBalancer loadBalancer);
+    List<? extends Instance> createLoadBalancerInstances(LoadBalancer loadBalancer, boolean create);
 
     boolean isLbInstance(Instance instance);
 


### PR DESCRIPTION
Wait for instance create/start only on lbhostmap.create

Similarly to config update, don't wait for lb instance.create/start unless its triggered by loadbalancerhostmap.create process - trigger point for lb instance launch. This code would become obsolte once standalone LB removal PR is gone

Also put a small fix to metadata to skip objects in Removing states when form metadata.