### PR TITLE
Fix race condition for volume external event

### DIFF
--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/externalevent/ExternalEventConstants.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/externalevent/ExternalEventConstants.java
@@ -25,6 +25,7 @@ public class ExternalEventConstants {
     public static final String FIELD_SERVICE = "service";
     public static final String FIELD_ZONE_ID = "zoneId";
     public static final String FIELD_DRIVER = "driver";
+    public static final String FIELD_NAME = "name";
     public static final String FIELD_DRIVER_NAME = "driverName";
     public static final String FIELD_ATTACHED_STATE = "attachedState";
     public static final String FIELD_ALLOC_STATE = "allocationState";

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/externalevent/ExternalEventCreate.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/externalevent/ExternalEventCreate.java
@@ -87,8 +87,9 @@ public class ExternalEventCreate extends AbstractDefaultProcessHandler {
             @Override
             public void doWithLockNoResult() {
                 Object driver = CollectionUtils.getNestedValue(DataUtils.getFields(event), FIELD_VOLUME, FIELD_DRIVER);
-                if (driver == null) {
-                    log.warn("Driver not specified. Returning. Event: {}", event);
+                Object name = CollectionUtils.getNestedValue(DataUtils.getFields(event), FIELD_VOLUME, FIELD_NAME);
+                if (driver == null || name == null) {
+                    log.warn("Driver or volume name not specified. Returning. Event: {}", event);
                     return;
                 }
                 String driverName = driver.toString();
@@ -114,7 +115,7 @@ public class ExternalEventCreate extends AbstractDefaultProcessHandler {
                         volumeData.put(FIELD_DEV_NUM, -1);
 
                         try {
-                            volumeDao.createVolumeInStoragePool(volumeData, storagePool);
+                            volumeDao.createVolumeInStoragePool(volumeData, name.toString(), storagePool);
                         } catch (ProcessCancelException e) {
                             log.info("Create process cancelled for volumeData {}. ProcessCancelException message: {}", volumeData, e.getMessage());
                         }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/VolumeDao.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/VolumeDao.java
@@ -8,7 +8,7 @@ import java.util.Map;
 public interface VolumeDao {
     Volume findVolumeByExternalId(Long storagePoolId, String externalId);
     
-    void createVolumeInStoragePool(Map<String, Object> volumeData, StoragePool storagePool);
+    void createVolumeInStoragePool(Map<String, Object> volumeData, String volumeName, StoragePool storagePool);
 
     /**
      * Does what the name says, but if storagePoolId is null, will look across all non-local storage pools

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/VolumeDaoImpl.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/VolumeDaoImpl.java
@@ -53,8 +53,12 @@ public class VolumeDaoImpl extends AbstractJooqDao implements VolumeDao {
     }
 
     @Override
-    public void createVolumeInStoragePool(Map<String, Object> volumeData, StoragePool storagePool) {
-        Volume volume = resourceDao.createAndSchedule(Volume.class, volumeData);
+    public void createVolumeInStoragePool(Map<String, Object> volumeData, String volumeName, StoragePool storagePool) {
+        Volume volume = findSharedVolume(storagePool.getAccountId(), storagePool.getId(), volumeName);
+        if (volume != null) {
+            return;
+        }
+        volume = resourceDao.createAndSchedule(Volume.class, volumeData);
         Map<String, Object> vspm = new HashMap<String, Object>();
         vspm.put("volumeId", volume.getId());
         vspm.put("storagePoolId", storagePool.getId());

--- a/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/dao/impl/DockerComputeDaoImpl.java
+++ b/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/dao/impl/DockerComputeDaoImpl.java
@@ -103,7 +103,12 @@ public class DockerComputeDaoImpl extends AbstractJooqDao implements DockerCompu
     @Override
     public Volume createDockerVolumeInPool(Long accountId, String name, String volumeUri, String externalId, String driver, StoragePool storagePool,
             boolean isHostPath) {
-        Volume volume = objectManager.create(Volume.class,
+        Volume volume = getDockerVolumeInPool(volumeUri, externalId, storagePool);
+        if (volume != null) {
+            return volume;
+        }
+
+        volume = objectManager.create(Volume.class,
                 VOLUME.ACCOUNT_ID, accountId,
                 VOLUME.NAME, name,
                 VOLUME.ATTACHED_STATE, CommonStatesConstants.INACTIVE,

--- a/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/instancehostmap/DockerPostInstanceHostMapActivate.java
+++ b/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/instancehostmap/DockerPostInstanceHostMapActivate.java
@@ -205,13 +205,8 @@ public class DockerPostInstanceHostMapActivate extends AbstractObjectProcessLogi
         return lockManager.lock(new DockerStoragePoolVolumeCreateLock(storagePool, dVol.getUri()), new LockCallback<Volume>() {
             @Override
             public Volume doWithLock() {
-                Volume volume = dockerDao.getDockerVolumeInPool(dVol.getUri(), dVol.getExternalId(), storagePool);
-                if (volume != null)
-                    return volume;
-
-                volume = dockerDao.createDockerVolumeInPool(instance.getAccountId(), dVol.getName(), dVol.getUri(), dVol.getExternalId(),
+                Volume volume = dockerDao.createDockerVolumeInPool(instance.getAccountId(), dVol.getName(), dVol.getUri(), dVol.getExternalId(),
                         dVol.getDriver(), storagePool, dVol.isBindMount());
-
                 return volume;
             }
         });


### PR DESCRIPTION
If an external volume event comes in at the same time as we are doing
native-docker population, it is possible to hit a race condition where
a volume is created twice. This fix prevents that by doing an
in-transaction lookup of the volume in the storage pool before creating
it.