### PR TITLE
Fixed bug in Global Service Deployment planner and other bug fixes around reconnecting agents

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/GlobalServiceDeploymentPlanner.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/GlobalServiceDeploymentPlanner.java
@@ -8,6 +8,7 @@ import io.cattle.platform.servicediscovery.deployment.impl.DeploymentManagerImpl
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -34,6 +35,7 @@ public class GlobalServiceDeploymentPlanner extends ServiceDeploymentPlanner {
 
     @Override
     public List<DeploymentUnit> deployHealthyUnits() {
+        removeExtraUnits();
         if (this.healthyUnits.size() < hostIds.size()) {
             addMissingUnits();
         }
@@ -55,5 +57,19 @@ public class GlobalServiceDeploymentPlanner extends ServiceDeploymentPlanner {
     @Override
     public boolean needToReconcileDeploymentImpl() {
         return (healthyUnits.size() != hostIds.size());
+    }
+
+    private void removeExtraUnits() {
+        Iterator<DeploymentUnit> it = this.healthyUnits.iterator();
+        while (it.hasNext()) {
+            DeploymentUnit unit = it.next();
+            Map<String, String> unitLabels = unit.getLabels();
+            Long hostId = Long.valueOf(unitLabels.get(ServiceDiscoveryConstants.LABEL_SERVICE_REQUESTED_HOST_ID));
+            if (!hostIds.contains(hostId)) {
+                unit.remove(true);
+                it.remove();
+                hostToUnits.remove(hostIds);
+            }
+        }
     }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServicesReconcilePostTrigger.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServicesReconcilePostTrigger.java
@@ -1,5 +1,6 @@
 package io.cattle.platform.servicediscovery.process;
 
+import io.cattle.platform.core.constants.AgentConstants;
 import io.cattle.platform.core.constants.HostConstants;
 import io.cattle.platform.core.constants.LabelConstants;
 import io.cattle.platform.core.model.Service;
@@ -32,7 +33,8 @@ public class ServicesReconcilePostTrigger extends AbstractObjectProcessLogic imp
                 HostConstants.PROCESS_REMOVE,
                 HostConstants.PROCESS_ACTIVATE,
                 LabelConstants.PROCESS_HOSTLABELMAP_CREATE,
-                LabelConstants.PROCESS_HOSTLABELMAP_REMOVE
+                LabelConstants.PROCESS_HOSTLABELMAP_REMOVE,
+                AgentConstants.PROCESS_RECONNECT
         };
     }
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
@@ -39,4 +39,5 @@ public interface ServiceDiscoveryService {
 
     List<String> getServiceActiveStates(boolean includeUpgrading);
 
+    boolean isGlobalService(Service service);
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/AgentServiceLookup.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/AgentServiceLookup.java
@@ -1,0 +1,50 @@
+package io.cattle.platform.servicediscovery.service.impl;
+
+import static io.cattle.platform.core.model.tables.HostTable.HOST;
+import static io.cattle.platform.core.model.tables.ServiceTable.SERVICE;
+import io.cattle.platform.core.model.Agent;
+import io.cattle.platform.core.model.Host;
+import io.cattle.platform.core.model.Service;
+import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
+import io.cattle.platform.object.ObjectManager;
+import io.cattle.platform.servicediscovery.service.ServiceDiscoveryService;
+import io.cattle.platform.servicediscovery.service.ServiceLookup;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import javax.inject.Inject;
+
+public class AgentServiceLookup extends AbstractJooqDao implements ServiceLookup {
+    @Inject
+    ObjectManager objMgr;
+
+    @Inject
+    ServiceDiscoveryService sdService;
+
+    @Override
+    public Collection<? extends Service> getServices(Object obj) {
+        if (!(obj instanceof Agent)) {
+            return null;
+        }
+        Agent agent = (Agent) obj;
+        Host host = objMgr.findAny(Host.class, HOST.AGENT_ID, agent.getId(), HOST.REMOVED, null);
+        if (host == null) {
+            return null;
+        }
+        List<? extends Service> allServices = objMgr.find(Service.class, SERVICE.ACCOUNT_ID, host.getAccountId(),
+                SERVICE.REMOVED, null);
+        List<Service> globalServices = new ArrayList<>();
+        for (Service service : allServices) {
+            if (!sdService.isActiveService(service)) {
+                continue;
+            }
+            if (sdService.isGlobalService(service)) {
+                globalServices.add(service);
+            }
+        }
+        return globalServices;
+    }
+
+}

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
@@ -6,6 +6,7 @@ import static io.cattle.platform.core.model.tables.LoadBalancerListenerTable.LOA
 import static io.cattle.platform.core.model.tables.LoadBalancerTable.LOAD_BALANCER;
 import static io.cattle.platform.core.model.tables.SubnetTable.SUBNET;
 import io.cattle.iaas.lb.service.LoadBalancerService;
+import io.cattle.platform.allocator.service.AllocatorService;
 import io.cattle.platform.core.addon.LoadBalancerServiceLink;
 import io.cattle.platform.core.addon.LoadBalancerTargetInput;
 import io.cattle.platform.core.addon.ServiceLink;
@@ -95,6 +96,9 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
 
     @Inject
     LockManager lockManager;
+
+    @Inject
+    AllocatorService allocatorService;
 
     protected long getServiceNetworkId(Service service) {
         Network network = ntwkDao.getNetworkForObject(service, NetworkConstants.KIND_HOSTONLY);
@@ -606,5 +610,15 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
     @Override
     public boolean isServiceInstance(Service service, Instance instance) {
         return exposeMapDao.getServiceInstanceMap(service, instance) != null;
+    }
+
+    @Override
+    public boolean isGlobalService(Service service) {
+        Map<String, String> serviceLabels = ServiceDiscoveryUtil.getServiceLabels(service, allocatorService);
+        String globalService = serviceLabels.get(ServiceDiscoveryConstants.LABEL_SERVICE_GLOBAL);
+        if (globalService != null && Boolean.valueOf(globalService).equals(true)) {
+            return true;
+        }
+        return false;
     }
 }

--- a/code/iaas/service-discovery/server/src/main/resources/META-INF/cattle/system-services/spring-service-discovery-server-context.xml
+++ b/code/iaas/service-discovery/server/src/main/resources/META-INF/cattle/system-services/spring-service-discovery-server-context.xml
@@ -66,7 +66,8 @@
     <bean class="io.cattle.platform.servicediscovery.service.impl.ServiceDiscoveryServiceImpl" />
     <bean class="io.cattle.platform.servicediscovery.service.impl.GlobalHostActivateServiceLookup" />
     <bean class="io.cattle.platform.servicediscovery.service.impl.HostServiceLookup" />
-    <bean class="io.cattle.platform.servicediscovery.service.impl.InstanceServiceLookup" /> 
+    <bean class="io.cattle.platform.servicediscovery.service.impl.InstanceServiceLookup" />
+    <bean class="io.cattle.platform.servicediscovery.service.impl.AgentServiceLookup" />
     
     <bean class="io.cattle.platform.servicediscovery.deployment.impl.DeploymentManagerImpl" />
     <bean class="io.cattle.platform.servicediscovery.deployment.impl.DeploymentUnitInstanceFactoryImpl" />


### PR DESCRIPTION
1) Cleanup instances that exist on an inactive host when do global deployment

https://github.com/rancher/rancher/issues/2711


2) Update: one more fix coming as a part of this PR - for standalone LB fix. Wait for the LB instance full start only when lb instance creation is requested by loadbalancerhostmap.create. This fix wouldn't be needed (and would be removed) once the "Killed standalone LB" PR is merged.

https://github.com/rancher/rancher/issues/2712

3) Update: trigger global service reconcile on agent reconnect:

https://github.com/rancher/rancher/issues/2713