### PR TITLE
Fix volume storage pool allocation

### DIFF
--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/UnmanagedStoragePoolKindConstraint.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/UnmanagedStoragePoolKindConstraint.java
@@ -2,20 +2,17 @@ package io.cattle.platform.allocator.constraint;
 
 import io.cattle.platform.allocator.service.AllocationAttempt;
 import io.cattle.platform.allocator.service.AllocationCandidate;
+import io.cattle.platform.allocator.util.AllocatorUtils;
 import io.cattle.platform.core.model.StoragePool;
 import io.cattle.platform.core.model.Volume;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
-public class ImageVolumeStoragePoolKindConstraint extends HardConstraint implements Constraint {
-
-    private static final Set<String> VALID_POOL_KINDS = new HashSet<String>(Arrays.asList("sim", "docker"));
+public class UnmanagedStoragePoolKindConstraint extends HardConstraint implements Constraint {
 
     private Volume volume;
 
-    public ImageVolumeStoragePoolKindConstraint(Volume volume) {
+    public UnmanagedStoragePoolKindConstraint(Volume volume) {
         super();
         this.volume = volume;
     }
@@ -25,7 +22,7 @@ public class ImageVolumeStoragePoolKindConstraint extends HardConstraint impleme
         Set<Long> poolIds = candidate.getPools().get(volume.getId());
         for (Long id : poolIds) {
             StoragePool pool = candidate.loadResource(StoragePool.class, id);
-            if (!VALID_POOL_KINDS.contains(pool.getKind())) {
+            if (!AllocatorUtils.UNMANGED_STORAGE_POOLS.contains(pool.getKind())) {
                 return false;
             }
         }
@@ -34,6 +31,6 @@ public class ImageVolumeStoragePoolKindConstraint extends HardConstraint impleme
 
     @Override
     public String toString() {
-        return String.format("storage pool for volume %s must be one of kind %s", volume.getId(), VALID_POOL_KINDS);
+        return String.format("storage pool for volume %s must be one of kind %s", volume.getId(), AllocatorUtils.UNMANGED_STORAGE_POOLS);
     }
 }

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/AllocatorDao.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/AllocatorDao.java
@@ -15,7 +15,7 @@ public interface AllocatorDao {
 
     List<? extends StoragePool> getAssociatedPools(Volume volume);
 
-    List<? extends StoragePool> getAssociatedPools(Host host);
+    List<? extends StoragePool> getAssociatedUnmanagedPools(Host host);
 
     List<? extends Host> getHosts(Instance instance);
 

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/impl/AllocatorDaoImpl.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/impl/AllocatorDaoImpl.java
@@ -1,23 +1,23 @@
 package io.cattle.platform.allocator.dao.impl;
 
-import static io.cattle.platform.core.model.tables.AgentTable.AGENT;
-import static io.cattle.platform.core.model.tables.HostLabelMapTable.HOST_LABEL_MAP;
-import static io.cattle.platform.core.model.tables.HostTable.HOST;
-import static io.cattle.platform.core.model.tables.HostVnetMapTable.HOST_VNET_MAP;
-import static io.cattle.platform.core.model.tables.ImageStoragePoolMapTable.IMAGE_STORAGE_POOL_MAP;
-import static io.cattle.platform.core.model.tables.ImageTable.IMAGE;
-import static io.cattle.platform.core.model.tables.InstanceHostMapTable.INSTANCE_HOST_MAP;
-import static io.cattle.platform.core.model.tables.InstanceLabelMapTable.INSTANCE_LABEL_MAP;
-import static io.cattle.platform.core.model.tables.InstanceTable.INSTANCE;
-import static io.cattle.platform.core.model.tables.LabelTable.LABEL;
-import static io.cattle.platform.core.model.tables.NicTable.NIC;
-import static io.cattle.platform.core.model.tables.PortTable.PORT;
-import static io.cattle.platform.core.model.tables.ServiceExposeMapTable.SERVICE_EXPOSE_MAP;
-import static io.cattle.platform.core.model.tables.StoragePoolHostMapTable.STORAGE_POOL_HOST_MAP;
-import static io.cattle.platform.core.model.tables.StoragePoolTable.STORAGE_POOL;
-import static io.cattle.platform.core.model.tables.SubnetVnetMapTable.SUBNET_VNET_MAP;
-import static io.cattle.platform.core.model.tables.VnetTable.VNET;
-import static io.cattle.platform.core.model.tables.VolumeStoragePoolMapTable.VOLUME_STORAGE_POOL_MAP;
+import static io.cattle.platform.core.model.tables.AgentTable.*;
+import static io.cattle.platform.core.model.tables.HostLabelMapTable.*;
+import static io.cattle.platform.core.model.tables.HostTable.*;
+import static io.cattle.platform.core.model.tables.HostVnetMapTable.*;
+import static io.cattle.platform.core.model.tables.ImageStoragePoolMapTable.*;
+import static io.cattle.platform.core.model.tables.ImageTable.*;
+import static io.cattle.platform.core.model.tables.InstanceHostMapTable.*;
+import static io.cattle.platform.core.model.tables.InstanceLabelMapTable.*;
+import static io.cattle.platform.core.model.tables.InstanceTable.*;
+import static io.cattle.platform.core.model.tables.LabelTable.*;
+import static io.cattle.platform.core.model.tables.NicTable.*;
+import static io.cattle.platform.core.model.tables.PortTable.*;
+import static io.cattle.platform.core.model.tables.ServiceExposeMapTable.*;
+import static io.cattle.platform.core.model.tables.StoragePoolHostMapTable.*;
+import static io.cattle.platform.core.model.tables.StoragePoolTable.*;
+import static io.cattle.platform.core.model.tables.SubnetVnetMapTable.*;
+import static io.cattle.platform.core.model.tables.VnetTable.*;
+import static io.cattle.platform.core.model.tables.VolumeStoragePoolMapTable.*;
 import io.cattle.platform.allocator.dao.AllocatorDao;
 import io.cattle.platform.allocator.service.AllocationAttempt;
 import io.cattle.platform.allocator.service.AllocationCandidate;
@@ -100,7 +100,7 @@ public class AllocatorDaoImpl extends AbstractJooqDao implements AllocatorDao {
     }
 
     @Override
-    public List<? extends StoragePool> getAssociatedPools(Host host) {
+    public List<? extends StoragePool> getAssociatedUnmanagedPools(Host host) {
         return create()
                 .select(STORAGE_POOL.fields())
                 .from(STORAGE_POOL)
@@ -108,7 +108,8 @@ public class AllocatorDaoImpl extends AbstractJooqDao implements AllocatorDao {
                     .on(STORAGE_POOL_HOST_MAP.STORAGE_POOL_ID.eq(STORAGE_POOL.ID))
                 .where(
                     STORAGE_POOL_HOST_MAP.REMOVED.isNull()
-                    .and(STORAGE_POOL_HOST_MAP.HOST_ID.eq(host.getId())))
+                    .and(STORAGE_POOL_HOST_MAP.HOST_ID.eq(host.getId())
+                    .and(STORAGE_POOL.KIND.in(AllocatorUtils.UNMANGED_STORAGE_POOLS))))
                 .fetchInto(StoragePoolRecord.class);
     }
 

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/util/AllocatorUtils.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/util/AllocatorUtils.java
@@ -4,12 +4,18 @@ import io.cattle.platform.archaius.util.ArchaiusUtil;
 import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.model.Instance;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.netflix.config.DynamicLongProperty;
 
 public class AllocatorUtils {
+
+    public static final Set<String> UNMANGED_STORAGE_POOLS = new HashSet<String>(Arrays.asList(new String[]{"docker", "sim"}));
 
     public static final DynamicLongProperty DEFAULT_COMPUTE = ArchaiusUtil.getLong("instance.compute.default");
 

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/externalevent/ExternalEventConstants.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/externalevent/ExternalEventConstants.java
@@ -24,7 +24,6 @@ public class ExternalEventConstants {
     public static final String FIELD_VOLUME = "volume";
     public static final String FIELD_SERVICE = "service";
     public static final String FIELD_ZONE_ID = "zoneId";
-    public static final String FIELD_DRIVER = "driver";
     public static final String FIELD_NAME = "name";
     public static final String FIELD_DRIVER_NAME = "driverName";
     public static final String FIELD_ATTACHED_STATE = "attachedState";

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/externalevent/ExternalEventCreate.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/externalevent/ExternalEventCreate.java
@@ -4,6 +4,7 @@ import static io.cattle.platform.core.model.tables.EnvironmentTable.*;
 import static io.cattle.platform.core.model.tables.ServiceTable.*;
 import static io.cattle.platform.process.externalevent.ExternalEventConstants.*;
 import io.cattle.platform.core.constants.CommonStatesConstants;
+import io.cattle.platform.core.constants.VolumeConstants;
 import io.cattle.platform.core.dao.AccountDao;
 import io.cattle.platform.core.dao.GenericResourceDao;
 import io.cattle.platform.core.dao.HostDao;
@@ -86,7 +87,7 @@ public class ExternalEventCreate extends AbstractDefaultProcessHandler {
         lockManager.lock(new ExternalEventLock(VOLUME_POOL_LOCK_NAME, event.getAccountId(), event.getExternalId()), new LockCallbackNoReturn() {
             @Override
             public void doWithLockNoResult() {
-                Object driver = CollectionUtils.getNestedValue(DataUtils.getFields(event), FIELD_VOLUME, FIELD_DRIVER);
+                Object driver = CollectionUtils.getNestedValue(DataUtils.getFields(event), FIELD_VOLUME, VolumeConstants.FIELD_VOLUME_DRIVER);
                 Object name = CollectionUtils.getNestedValue(DataUtils.getFields(event), FIELD_VOLUME, FIELD_NAME);
                 if (driver == null || name == null) {
                     log.warn("Driver or volume name not specified. Returning. Event: {}", event);

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceVolumeLookupPreCreate.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceVolumeLookupPreCreate.java
@@ -1,6 +1,7 @@
 package io.cattle.platform.process.instance;
 
 import io.cattle.platform.core.constants.InstanceConstants;
+import io.cattle.platform.core.constants.VolumeConstants;
 import io.cattle.platform.core.dao.StoragePoolDao;
 import io.cattle.platform.core.dao.VolumeDao;
 import io.cattle.platform.core.model.Instance;
@@ -32,7 +33,6 @@ import org.slf4j.LoggerFactory;
 public class InstanceVolumeLookupPreCreate extends AbstractObjectProcessLogic implements ProcessPreListener {
 
     private static final Logger log = LoggerFactory.getLogger(InstanceVolumeLookupPreCreate.class);
-    private static final String LOCAL = "local";
 
     @Inject
     ObjectManager objectManager;
@@ -65,7 +65,7 @@ public class InstanceVolumeLookupPreCreate extends AbstractObjectProcessLogic im
         }
 
         String vd = DataAccessor.fieldString(instance, InstanceConstants.FIELD_VOLUME_DRIVER);
-        if (LOCAL.equals(vd)) {
+        if (VolumeConstants.LOCAL_DRIVER.equals(vd)) {
             return null;
         }
 

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/VolumeConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/VolumeConstants.java
@@ -16,4 +16,6 @@ public class VolumeConstants {
     
     public static final String FIELD_DEVICE_NUM = "deviceNumber";
 
+    public static final String LOCAL_DRIVER = "local";
+
 }

--- a/code/implementation/docker/common/src/main/java/io/cattle/platform/docker/constants/DockerInstanceConstants.java
+++ b/code/implementation/docker/common/src/main/java/io/cattle/platform/docker/constants/DockerInstanceConstants.java
@@ -44,6 +44,5 @@ public class DockerInstanceConstants {
     public static final String DOCKER_TTY = "Tty";
     public static final String DOCKER_CMD = "Cmd";
     public static final String DOCKER_CONTAINER = "Container";
-    public static final String DOCKER_LOCAL_DRIVER = "local";
 
 }

--- a/code/implementation/docker/common/src/main/java/io/cattle/platform/docker/transform/DockerTransformerImpl.java
+++ b/code/implementation/docker/common/src/main/java/io/cattle/platform/docker/transform/DockerTransformerImpl.java
@@ -49,7 +49,6 @@ public class DockerTransformerImpl implements DockerTransformer {
     private static final String DRIVER = "Driver";
     private static final String DEST = "Destination";
     private static final String SRC = "Source";
-    private static final String LOCAL = "local";
     private static final String NAME = "Name";
 
     @Inject
@@ -106,7 +105,7 @@ public class DockerTransformerImpl implements DockerTransformer {
             boolean isBindMount = (dr == null);
             // TODO When we implement proper volume deletion in py-agent, we can change this so that if the driver is explicitly, local, we don't
             // use 'file://'
-            String uriPrefix = StringUtils.isEmpty(dr) || StringUtils.equals(dr, LOCAL) ? VolumeConstants.FILE_PREFIX : dr;
+            String uriPrefix = StringUtils.isEmpty(dr) || StringUtils.equals(dr, VolumeConstants.LOCAL_DRIVER) ? VolumeConstants.FILE_PREFIX : dr;
             String uri = String.format(VolumeConstants.URI_FORMAT, uriPrefix, hostPath);
             volumes.add(new DockerInspectTransformVolume(containerPath, uri, am, isBindMount, dr, name, externalId));
         }

--- a/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/instancehostmap/DockerPostInstanceHostMapActivate.java
+++ b/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/instancehostmap/DockerPostInstanceHostMapActivate.java
@@ -8,6 +8,7 @@ import io.cattle.iaas.labels.service.LabelsService;
 import io.cattle.platform.archaius.util.ArchaiusUtil;
 import io.cattle.platform.core.constants.NetworkServiceConstants;
 import io.cattle.platform.core.constants.PortConstants;
+import io.cattle.platform.core.constants.VolumeConstants;
 import io.cattle.platform.core.dao.ClusterHostMapDao;
 import io.cattle.platform.core.dao.GenericMapDao;
 import io.cattle.platform.core.dao.IpAddressDao;
@@ -158,7 +159,7 @@ public class DockerPostInstanceHostMapActivate extends AbstractObjectProcessLogi
         Map<String, StoragePool> pools = new HashMap<String, StoragePool>();
         for (StoragePool pool : objectManager.mappedChildren(host, StoragePool.class)) {
             if (DockerStoragePoolDriver.isDockerPool(pool) && 
-                    (DOCKER_LOCAL_DRIVER.equals(pool.getDriverName()) || StringUtils.isEmpty(pool.getDriverName()))) {
+                    (VolumeConstants.LOCAL_DRIVER.equals(pool.getDriverName()) || StringUtils.isEmpty(pool.getDriverName()))) {
                 dockerLocalStoragePool = pool;
             }
             if (StringUtils.isNotEmpty(pool.getDriverName())) {
@@ -169,7 +170,7 @@ public class DockerPostInstanceHostMapActivate extends AbstractObjectProcessLogi
         for (DockerInspectTransformVolume dVol : dockerVolumes) {
             String driver = dVol.getDriver();
             StoragePool pool = null;
-            if (StringUtils.isEmpty(driver) || DOCKER_LOCAL_DRIVER.equals(driver)) {
+            if (StringUtils.isEmpty(driver) || VolumeConstants.LOCAL_DRIVER.equals(driver)) {
                 pool = dockerLocalStoragePool;
             } else {
                 pool = pools.get(dVol.getDriver());


### PR DESCRIPTION
If the volume's driver matches an existing storage pool driver name,
restrict the allocation to that storage pool;
otherwise, allow it to allocate to any pool that is not managed by
rancher.