### PR TITLE
Added publicIp/port information to host/service

### DIFF
--- a/code/framework/eventing/src/main/java/io/cattle/platform/eventing/util/EventUtils.java
+++ b/code/framework/eventing/src/main/java/io/cattle/platform/eventing/util/EventUtils.java
@@ -41,7 +41,8 @@ public class EventUtils {
     }
 
     public static EventCallOptions chainOptions(Event event) {
-        return new EventCallOptions().withProgressIsKeepAlive(true).withRetry(0).withTimeoutMillis(event.getTimeoutMillis());
+        return new EventCallOptions().withProgressIsKeepAlive(true).withRetry(0)
+                .withTimeoutMillis(event.getTimeoutMillis());
     }
 
     public static boolean isTransitioningEvent(Event event) {

--- a/code/framework/events/src/main/java/io/cattle/platform/framework/event/util/EventUtils.java
+++ b/code/framework/events/src/main/java/io/cattle/platform/framework/event/util/EventUtils.java
@@ -1,0 +1,21 @@
+package io.cattle.platform.framework.event.util;
+
+import io.cattle.platform.eventing.EventService;
+import io.cattle.platform.eventing.model.Event;
+import io.cattle.platform.eventing.model.EventVO;
+import io.cattle.platform.framework.event.FrameworkEvents;
+
+import java.util.Map;
+
+public class EventUtils {
+
+    public static void TriggerStateChanged(EventService eventService, String resourceId, String resourceType,
+            Map<String, Object> data) {
+        Event event = EventVO.newEvent(FrameworkEvents.STATE_CHANGE)
+                .withData(data)
+                .withResourceType(resourceType)
+                .withResourceId(resourceId.toString());
+
+        eventService.publish(event);
+    }
+}

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/lock/HostEndpointsUpdateLock.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/lock/HostEndpointsUpdateLock.java
@@ -1,0 +1,11 @@
+package io.cattle.platform.process.lock;
+
+import io.cattle.platform.core.model.Host;
+import io.cattle.platform.lock.definition.AbstractBlockingLockDefintion;
+
+public class HostEndpointsUpdateLock extends AbstractBlockingLockDefintion {
+
+    public HostEndpointsUpdateLock(Host host) {
+        super("HOST." + host.getId() + "ENDPOINTS.UPDATE");
+    }
+}

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/addon/PublicEndpoint.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/addon/PublicEndpoint.java
@@ -1,0 +1,63 @@
+package io.cattle.platform.core.addon;
+
+import io.github.ibuildthecloud.gdapi.annotation.Type;
+
+@Type(list = false)
+public class PublicEndpoint {
+    String ipAddress;
+    Integer port;
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    public PublicEndpoint(String ipAddress, Integer port) {
+        this.ipAddress = ipAddress;
+        this.port = port;
+    }
+
+    public PublicEndpoint() {
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((ipAddress == null) ? 0 : ipAddress.hashCode());
+        result = prime * result + ((port == null) ? 0 : port.hashCode());
+        return result;
+    }
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        PublicEndpoint other = (PublicEndpoint) obj;
+        if (ipAddress == null) {
+            if (other.ipAddress != null)
+                return false;
+        } else if (!ipAddress.equals(other.ipAddress))
+            return false;
+        if (port == null) {
+            if (other.port != null)
+                return false;
+        } else if (!port.equals(other.port))
+            return false;
+        return true;
+    }
+}

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/PortConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/PortConstants.java
@@ -5,4 +5,7 @@ public class PortConstants {
     public static final String KIND_USER = "userPort";
     public static final String KIND_IMAGE = "imagePort";
 
+    public static final String PROCESS_PORT_ACTIVATE = "port.activate";
+    public static final String PROCESS_PORT_DEACTIVATE = "port.deactivate";
+
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/HostDao.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/HostDao.java
@@ -1,6 +1,7 @@
 package io.cattle.platform.core.dao;
 
 import io.cattle.platform.core.model.Host;
+import io.cattle.platform.core.model.IpAddress;
 
 import java.util.List;
 
@@ -9,4 +10,8 @@ public interface HostDao {
     List<? extends Host> getHosts(Long accountId, List<String> uuids);
 
     List<? extends Host> getActiveHosts(Long accountId);
+
+    List<? extends IpAddress> getHostIpAddresses(long hostId);
+
+    Host getHostForIpAddress(long ipAddressId);
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/InstanceDao.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/InstanceDao.java
@@ -24,4 +24,8 @@ public interface InstanceDao {
 
     List<? extends Instance> findInstancesFor(Service service);
 
+    Long getInstanceHostId(long instanceId);
+
+    Service getServiceManaging(long instanceId);
+
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/HostDaoImpl.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/HostDaoImpl.java
@@ -1,14 +1,25 @@
 package io.cattle.platform.core.dao.impl;
 
-import static io.cattle.platform.core.model.tables.HostTable.*;
+import static io.cattle.platform.core.model.tables.HostIpAddressMapTable.HOST_IP_ADDRESS_MAP;
+import static io.cattle.platform.core.model.tables.HostTable.HOST;
+import static io.cattle.platform.core.model.tables.IpAddressTable.IP_ADDRESS;
 import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.dao.HostDao;
 import io.cattle.platform.core.model.Host;
+import io.cattle.platform.core.model.IpAddress;
+import io.cattle.platform.core.model.tables.records.HostRecord;
+import io.cattle.platform.core.model.tables.records.IpAddressRecord;
 import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
+import io.cattle.platform.object.ObjectManager;
 
 import java.util.List;
 
+import javax.inject.Inject;
+
 public class HostDaoImpl extends AbstractJooqDao implements HostDao {
+    
+    @Inject
+    ObjectManager objectManager;
 
     @Override
     public List<? extends Host> getHosts(Long accountId, List<String> uuids) {
@@ -26,5 +37,37 @@ public class HostDaoImpl extends AbstractJooqDao implements HostDao {
             .where(HOST.ACCOUNT_ID.eq(accountId)
             .and(HOST.STATE.in(CommonStatesConstants.ACTIVATING, CommonStatesConstants.ACTIVE)))
             .fetch();
+    }
+
+    @Override
+    public List<? extends IpAddress> getHostIpAddresses(long hostId) {
+        return create()
+                .select(IP_ADDRESS.fields())
+                .from(IP_ADDRESS)
+                .join(HOST_IP_ADDRESS_MAP)
+                .on(HOST_IP_ADDRESS_MAP.IP_ADDRESS_ID.eq(IP_ADDRESS.ID))
+                .where(HOST_IP_ADDRESS_MAP.HOST_ID.eq(hostId)
+                .and(IP_ADDRESS.REMOVED.isNull())
+                .and(HOST_IP_ADDRESS_MAP.REMOVED.isNull()))
+                .fetchInto(IpAddressRecord.class);
+    }
+
+    @Override
+    public Host getHostForIpAddress(long ipAddressId) {
+        List<? extends Host> hosts = create()
+                .select(HOST.fields())
+                .from(HOST)
+                .join(HOST_IP_ADDRESS_MAP)
+                .on(HOST_IP_ADDRESS_MAP.HOST_ID.eq(HOST.ID))
+                .where(HOST_IP_ADDRESS_MAP.IP_ADDRESS_ID.eq(ipAddressId)
+                        .and(HOST.REMOVED.isNull())
+                        .and(HOST_IP_ADDRESS_MAP.REMOVED.isNull()))
+                .fetchInto(HostRecord.class);
+
+        if (hosts.isEmpty()) {
+            return null;
+        }
+        return hosts.get(0);
+
     }
 }

--- a/code/iaas/model/src/main/resources/META-INF/cattle/core-model/spring-core-model-context.xml
+++ b/code/iaas/model/src/main/resources/META-INF/cattle/core-model/spring-core-model-context.xml
@@ -29,6 +29,7 @@
                 <value>io.cattle.platform.core.addon.ServiceUpgradeStrategy</value>
                 <value>io.cattle.platform.core.addon.InServiceUpgradeStrategy</value>
                 <value>io.cattle.platform.core.addon.ToServiceUpgradeStrategy</value>
+                <value>io.cattle.platform.core.addon.PublicEndpoint</value>
             </set>
         </property>
     </bean>

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
@@ -38,6 +38,7 @@ public class ServiceDiscoveryConstants {
     public static final String FIELD_TO_SERVICE_STRATEGY = "toServiceStrategy";
     public static final String FIELD_FQDN = "fqdn";
     public static final String FIELD_OUTPUTS = "outputs";
+    public static final String FIELD_PUBLIC_ENDPOINTS = "publicEndpoints";
 
     public static final String STACK_FIELD_DOCKER_COMPOSE = "dockerCompose";
     public static final String STACK_FIELD_RANCHER_COMPOSE = "rancherCompose";

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/ServiceEndpointsUpdateLock.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/ServiceEndpointsUpdateLock.java
@@ -1,0 +1,11 @@
+package io.cattle.platform.servicediscovery.deployment.impl;
+
+import io.cattle.platform.core.model.Service;
+import io.cattle.platform.lock.definition.AbstractBlockingLockDefintion;
+
+public class ServiceEndpointsUpdateLock extends AbstractBlockingLockDefintion {
+
+    public ServiceEndpointsUpdateLock(Service service) {
+        super("SERVICE." + service.getId() + "ENDPOINTS.UPDATE");
+    }
+}

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/PortActivateDeactivatePostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/PortActivateDeactivatePostListener.java
@@ -1,0 +1,78 @@
+package io.cattle.platform.servicediscovery.process;
+
+import static io.cattle.platform.core.model.tables.IpAddressTable.IP_ADDRESS;
+import io.cattle.platform.core.addon.PublicEndpoint;
+import io.cattle.platform.core.constants.PortConstants;
+import io.cattle.platform.core.dao.HostDao;
+import io.cattle.platform.core.dao.InstanceDao;
+import io.cattle.platform.core.model.Host;
+import io.cattle.platform.core.model.IpAddress;
+import io.cattle.platform.core.model.Port;
+import io.cattle.platform.core.model.Service;
+import io.cattle.platform.engine.handler.HandlerResult;
+import io.cattle.platform.engine.handler.ProcessPostListener;
+import io.cattle.platform.engine.process.ProcessInstance;
+import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.process.common.handler.AbstractObjectProcessLogic;
+import io.cattle.platform.servicediscovery.service.ServiceDiscoveryService;
+import io.cattle.platform.util.type.Priority;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named
+public class PortActivateDeactivatePostListener extends AbstractObjectProcessLogic implements ProcessPostListener, Priority {
+    @Inject
+    InstanceDao instanceDao;
+
+    @Inject
+    ServiceDiscoveryService sdService;
+
+    @Inject
+    HostDao hostDao;
+
+    @Override
+    public String[] getProcessNames() {
+        return new String[] { PortConstants.PROCESS_PORT_ACTIVATE, PortConstants.PROCESS_PORT_DEACTIVATE };
+    }
+
+    @Override
+    public HandlerResult handle(ProcessState state, ProcessInstance process) {
+        Port port = (Port) state.getResource();
+        IpAddress ip = objectManager.findOne(IpAddress.class, IP_ADDRESS.ID, port.getPublicIpAddressId(),
+                IP_ADDRESS.REMOVED, null);
+        if (ip == null) {
+            return null;
+        }
+
+        boolean add = process.getName().equalsIgnoreCase(PortConstants.PROCESS_PORT_ACTIVATE);
+
+        PublicEndpoint endPoint = new PublicEndpoint(ip.getAddress(), port.getPublicPort());
+
+        updateServiceEndpoints(port, add, endPoint);
+
+        updateHostEndPoints(ip, add, endPoint);
+
+        return null;
+    }
+
+    protected void updateHostEndPoints(IpAddress ip, boolean add, PublicEndpoint endPoint) {
+        Host host = hostDao.getHostForIpAddress(ip.getId());
+        if (host != null) {
+            sdService.updateHostPublicEndpoints(host, endPoint, add);
+        }
+    }
+
+    protected void updateServiceEndpoints(Port port, boolean add, PublicEndpoint endPoint) {
+        Service service = instanceDao.getServiceManaging(port.getInstanceId());
+        if (service != null) {
+            sdService.updateServicePublicEndpoints(service, endPoint, add);
+        }
+    }
+
+    @Override
+    public int getPriority() {
+        return Priority.DEFAULT;
+    }
+
+}

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
@@ -1,6 +1,8 @@
 package io.cattle.platform.servicediscovery.service;
 
+import io.cattle.platform.core.addon.PublicEndpoint;
 import io.cattle.platform.core.addon.ServiceLink;
+import io.cattle.platform.core.model.Host;
 import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.Service;
 
@@ -31,4 +33,8 @@ public interface ServiceDiscoveryService {
     List<String> getServiceActiveStates(boolean includeUpgrading);
 
     boolean isGlobalService(Service service);
+
+    void updateServicePublicEndpoints(Service service, PublicEndpoint publicEndpoint, boolean add);
+
+    void updateHostPublicEndpoints(Host host, PublicEndpoint publicEndpoint, boolean add);
 }

--- a/code/iaas/service-discovery/server/src/main/resources/META-INF/cattle/system-services/spring-service-discovery-server-context.xml
+++ b/code/iaas/service-discovery/server/src/main/resources/META-INF/cattle/system-services/spring-service-discovery-server-context.xml
@@ -34,6 +34,8 @@
     <bean class="io.cattle.platform.servicediscovery.process.ServiceRemovePostListener" />
     <bean class="io.cattle.platform.servicediscovery.process.SelectorInstancePostListener" />
     <bean class="io.cattle.platform.servicediscovery.process.ServiceExposeMapCreate" />
+    <bean class="io.cattle.platform.servicediscovery.process.PortActivateDeactivatePostListener" />
+
     <bean class="io.cattle.platform.servicediscovery.process.EnvironmentRemove" />
     <bean class="io.cattle.platform.servicediscovery.process.ServiceDiscoveryInstanceRemovePreListener" />
     <bean class="io.cattle.platform.servicediscovery.process.ServicesReconcilePostTrigger" />

--- a/resources/content/schema/base/host.json
+++ b/resources/content/schema/base/host.json
@@ -16,6 +16,11 @@
             "attributes" : {
                 "scheduleUpdate" : true
             }
+        },
+        "publicEndpoints":{
+            "type": "array[publicEndpoint]",
+            "required": false,
+            "nullable": true
         }
     }
 }

--- a/resources/content/schema/base/service.json
+++ b/resources/content/schema/base/service.json
@@ -58,6 +58,11 @@
             "type": "map[schema]",
             "nullable": true,
             "required": false
+        },
+        "publicEndpoints":{
+            "type": "array[publicEndpoint]",
+            "required": false,
+            "nullable": true
         }
     },
     "resourceActions" : {

--- a/resources/content/schema/project/project-auth.json
+++ b/resources/content/schema/project/project-auth.json
@@ -51,7 +51,7 @@
         "fieldDocumentation": "r",
         "inServiceUpgradeStrategy" : "cr",
         "toServiceUpgradeStrategy" : "cr",
-
+        "publicEndpoint" : "r",
         "end" : ""
     }
 }

--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -160,6 +160,7 @@
         "host.physicalHostId" : "r",
         "host.zoneId" : "ru",
         "host.labels" : "ru",
+        "host.publicEndpoints" : "r",
 
         "addLabelInput" : "cr",
         "addLabelInput.key" : "cr",
@@ -390,6 +391,7 @@
         "service.selectorLink" : "cr",
         "service.selectorContainer" : "cr",
         "service.fqdn" : "r",
+        "service.publicEndpoints" : "r",
 
         "addRemoveServiceLinkInput" : "r",
         "addRemoveServiceLinkInput.serviceLink" : "cr",
@@ -447,6 +449,7 @@
         "externalService.healthCheck" : "cr",
         "externalService.createIndex" : "",
         "externalService.selectorContainer" : "",
+        "externalService.publicEndpoints" : "",
 
         "dnsService" : "r",
         "dnsService.scale" : "",
@@ -455,6 +458,7 @@
         "dnsService.vip" : "",
         "dnsService.createIndex" : "",
         "dnsService.selectorContainer" : "",
+        "dnsService.publicEndpoints" : "",
 
         "serviceEvent" : "r",
         "serviceEvent.instanceId" : "r",
@@ -524,6 +528,10 @@
         "environmentUpgrade.rancherCompose" : "cr",
         "environmentUpgrade.environment" : "cr",
         "environmentUpgrade.externalId" : "cr",
+
+        "publicEndpoint" : "r",
+        "publicEndpoint.ipAddress" : "r",
+        "publicEndpoint.port" : "r",
 
         "end" : ""
     }

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -142,7 +142,8 @@ def test_user_types(user_client, adds=set(), removes=set()):
         'serviceUpgradeStrategy',
         'toServiceUpgradeStrategy',
         'inServiceUpgradeStrategy',
-        'ubiquityConfig'
+        'ubiquityConfig',
+        'publicEndpoint'
     }
     types.update(adds)
     types.difference_update(removes)
@@ -343,7 +344,8 @@ def test_admin_types(admin_user_client, adds=set(), removes=set()):
         'serviceUpgradeStrategy',
         'toServiceUpgradeStrategy',
         'inServiceUpgradeStrategy',
-        'ubiquityConfig'
+        'ubiquityConfig',
+        'publicEndpoint'
     }
     types.update(adds)
     types.difference_update(removes)
@@ -516,7 +518,8 @@ def test_host_auth(admin_user_client, user_client, project_client):
         'data': 'r',
         'physicalHostId': 'r',
         'info': 'r',
-        'labels': 'r'
+        'labels': 'r',
+        'publicEndpoints': 'r'
     })
 
     auth_check(user_client.schema, 'host', 'r', {
@@ -525,7 +528,8 @@ def test_host_auth(admin_user_client, user_client, project_client):
         'computeTotal': 'r',
         'physicalHostId': 'r',
         'info': 'r',
-        'labels': 'r'
+        'labels': 'r',
+        'publicEndpoints': 'r'
     })
 
     auth_check(project_client.schema, 'host', 'rud', {
@@ -534,7 +538,8 @@ def test_host_auth(admin_user_client, user_client, project_client):
         'computeTotal': 'r',
         'physicalHostId': 'r',
         'info': 'r',
-        'labels': 'ru'
+        'labels': 'ru',
+        'publicEndpoints': 'r'
     })
 
 
@@ -1539,7 +1544,8 @@ def test_svc_discovery_service(admin_user_client, user_client, project_client):
         'metadata': 'r',
         'selectorLink': 'r',
         'selectorContainer': 'r',
-        'fqdn': 'r'
+        'fqdn': 'r',
+        'publicEndpoints': 'r'
     })
 
     auth_check(user_client.schema, 'service', 'r', {
@@ -1557,7 +1563,8 @@ def test_svc_discovery_service(admin_user_client, user_client, project_client):
         'metadata': 'r',
         'selectorLink': 'r',
         'selectorContainer': 'r',
-        'fqdn': 'r'
+        'fqdn': 'r',
+        'publicEndpoints': 'r'
     })
 
     auth_check(project_client.schema, 'service', 'crud', {
@@ -1575,7 +1582,8 @@ def test_svc_discovery_service(admin_user_client, user_client, project_client):
         'metadata': 'cru',
         'selectorLink': 'cr',
         'selectorContainer': 'cr',
-        'fqdn': 'r'
+        'fqdn': 'r',
+        'publicEndpoints': 'r'
     })
 
 
@@ -1636,7 +1644,8 @@ def test_svc_discovery_lb_service(admin_user_client, user_client,
         'certificateIds': 'r',
         'metadata': 'r',
         'selectorLink': 'r',
-        'fqdn': 'r'
+        'fqdn': 'r',
+        'publicEndpoints': 'r'
     })
 
     auth_check(user_client.schema, 'loadBalancerService', 'r', {
@@ -1653,7 +1662,8 @@ def test_svc_discovery_lb_service(admin_user_client, user_client,
         'certificateIds': 'r',
         'metadata': 'r',
         'selectorLink': 'r',
-        'fqdn': 'r'
+        'fqdn': 'r',
+        'publicEndpoints': 'r'
     })
 
     auth_check(project_client.schema, 'loadBalancerService', 'crud', {
@@ -1670,7 +1680,8 @@ def test_svc_discovery_lb_service(admin_user_client, user_client,
         'certificateIds': 'cru',
         'metadata': 'cru',
         'selectorLink': 'cr',
-        'fqdn': 'r'
+        'fqdn': 'r',
+        'publicEndpoints': 'r'
     })
 
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/2695

With this PR, "service" and "host" objects get one extra API field called "publicEndpoints". Each endpoint has 2 fields:

* port (int)
* ipAddress (string)

Field name is debatable, I would agree with any name having better representation of ip/port combo.

Field gets populated for service/host on every nic.activate/nic.deactivate event for the instance having port exposed. Supported for both service and standalone instances; in standalone instance case only host object will get an update.

This model will be valid even in the future, when we add support for multiple interfaces for hosts + mapping port to a particular interface.

@vincent99 @ibuildthecloud API police, please review