### PR TITLE
Fix query that looks up volumes by name

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/VolumeDaoImpl.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/VolumeDaoImpl.java
@@ -70,17 +70,17 @@ public class VolumeDaoImpl extends AbstractJooqDao implements VolumeDao {
         List<VolumeRecord> volumes = null;
         if (storagePoolId == null) {
             volumes = create()
-            .select(VOLUME.fields())
+            .selectDistinct(VOLUME.fields())
             .from(VOLUME)
-            .join(VOLUME_STORAGE_POOL_MAP)
+            .leftOuterJoin(VOLUME_STORAGE_POOL_MAP)
                 .on(VOLUME_STORAGE_POOL_MAP.VOLUME_ID.eq(VOLUME.ID))
-            .join(STORAGE_POOL)
+            .leftOuterJoin(STORAGE_POOL)
                 .on(VOLUME_STORAGE_POOL_MAP.STORAGE_POOL_ID.eq(STORAGE_POOL.ID)
-                .and(STORAGE_POOL.KIND.notIn(LOCAL_POOL_KINDS)))
-                .and(STORAGE_POOL.REMOVED.isNull())
+                .and(STORAGE_POOL.REMOVED.isNull()))
             .where(VOLUME.NAME.eq(volumeName)
-                .and((VOLUME.REMOVED.isNull().or(VOLUME.STATE.eq(CommonStatesConstants.REMOVING)))))
+                .and((VOLUME.REMOVED.isNull())))
                 .and(VOLUME.ACCOUNT_ID.eq(accountId))
+                .and(STORAGE_POOL.KIND.notIn(LOCAL_POOL_KINDS).or(STORAGE_POOL.KIND.isNull()))
             .fetchInto(VolumeRecord.class);
         } else {
             volumes = create()


### PR DESCRIPTION
Query was unintentionally restricting results to volumes that had
already been allocated to a storage pool. But brands new volumes
created via the API are not allocated to a pool until after they are
used by a container.

Addresses rancher/rancher#2727
Also maybe rancher/rancher#2726, but I need to research that one more.