### PR TITLE
Fixes for bugs caused by Standalone LB removal refactoring 

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/LoadBalancerDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/LoadBalancerDeploymentUnitInstance.java
@@ -57,14 +57,16 @@ public class LoadBalancerDeploymentUnitInstance extends DefaultDeploymentUnitIns
     protected void setPorts(Map<String, Object> launchConfigData) {
         List<String> ports = (List<String>) launchConfigData.get(InstanceConstants.FIELD_PORTS);
         List<String> newPorts = new ArrayList<>();
-        for (String port : ports) {
-            PortSpec spec = new PortSpec(port);
-            if (spec.getPublicPort() == null) {
-                spec.setPublicPort(spec.getPrivatePort());
+        if (ports != null) {
+            for (String port : ports) {
+                PortSpec spec = new PortSpec(port);
+                if (spec.getPublicPort() == null) {
+                    spec.setPublicPort(spec.getPrivatePort());
+                }
+                String fullPort = spec.getPublicPort().toString() + ":" + spec.getPublicPort().toString();
+                newPorts.add(fullPort);
             }
-            String fullPort = spec.getPublicPort().toString() + ":" + spec.getPublicPort().toString();
-            newPorts.add(fullPort);
+            launchConfigData.put(InstanceConstants.FIELD_PORTS, newPorts);
         }
-        launchConfigData.put(InstanceConstants.FIELD_PORTS, newPorts);
     }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceUpdateConfig.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceUpdateConfig.java
@@ -14,7 +14,6 @@ import io.cattle.platform.engine.process.ProcessInstance;
 import io.cattle.platform.engine.process.ProcessState;
 import io.cattle.platform.json.JsonMapper;
 import io.cattle.platform.object.resource.ResourceMonitor;
-import io.cattle.platform.object.resource.ResourcePredicate;
 import io.cattle.platform.process.common.handler.AbstractObjectProcessLogic;
 import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
 import io.cattle.platform.servicediscovery.service.ServiceDiscoveryService;
@@ -138,14 +137,6 @@ public class LoadBalancerServiceUpdateConfig extends AbstractObjectProcessLogic 
         List<Instance> lbInstances = new ArrayList<>();
         for (Service lbService : activeLbServices) {
             lbInstances.addAll(instanceDao.findInstancesFor(lbService));
-        }
-        for (Instance lbInstance : lbInstances) {
-            lbInstance = resourceMonitor.waitFor(lbInstance, new ResourcePredicate<Instance>() {
-                @Override
-                public boolean evaluate(Instance obj) {
-                    return InstanceConstants.STATE_RUNNING.equals(obj.getState());
-                }
-            });
         }
         return lbInstances;
     }

--- a/tests/integration/cattletest/core/test_svc_discovery_lb.py
+++ b/tests/integration/cattletest/core/test_svc_discovery_lb.py
@@ -183,7 +183,6 @@ def test_restart_stack(client, context):
                                    launchConfig=lb_launch_config)
     lb_svc = client.wait_success(lb_svc)
     assert lb_svc.state == "inactive"
-    lb_svc = client.wait_success(lb_svc.activate(), 120)
 
     # map web service to lb service
     service_link = {"serviceId": web_service.id, "ports": ["a.com:90"]}
@@ -206,6 +205,23 @@ def test_restart_stack(client, context):
     assert lb_svc.state == 'active'
     web_svc = client.wait_success(lb_svc)
     assert web_svc.state == 'active'
+
+
+def test_internal_lb(client, context):
+    env = _create_stack(client)
+
+    image_uuid = context.image_uuid
+
+    lb_launch_config = {"imageUuid": image_uuid,
+                        "expose": [8051]}
+    lb_svc = client. \
+        create_loadBalancerService(name=random_str(),
+                                   environmentId=env.id,
+                                   launchConfig=lb_launch_config)
+    lb_svc = client.wait_success(lb_svc)
+    assert lb_svc.state == "inactive"
+    lb_svc = client.wait_success(lb_svc.activate())
+    assert lb_svc.state == 'active'
 
 
 def _validate_config_item_update(super_client, bf, agent_id):

--- a/tests/integration/cattletest/core/test_svc_discovery_lb.py
+++ b/tests/integration/cattletest/core/test_svc_discovery_lb.py
@@ -162,6 +162,52 @@ def test_targets(super_client, client, context):
     _validate_config_item_update(super_client, item_before, agent_id)
 
 
+def test_restart_stack(client, context):
+    env = _create_stack(client)
+
+    # create lb and web services
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": image_uuid}
+    web_service = client. \
+        create_service(name=random_str() + "web",
+                       environmentId=env.id,
+                       launchConfig=launch_config)
+
+    web_service = client.wait_success(web_service)
+
+    lb_launch_config = {"imageUuid": image_uuid,
+                        "ports": [8051, '808:1001']}
+    lb_svc = client. \
+        create_loadBalancerService(name=random_str(),
+                                   environmentId=env.id,
+                                   launchConfig=lb_launch_config)
+    lb_svc = client.wait_success(lb_svc)
+    assert lb_svc.state == "inactive"
+    lb_svc = client.wait_success(lb_svc.activate(), 120)
+
+    # map web service to lb service
+    service_link = {"serviceId": web_service.id, "ports": ["a.com:90"]}
+    lb_svc = lb_svc.addservicelink(serviceLink=service_link)
+
+    env = client.wait_success(env.activateservices())
+    lb_svc = client.wait_success(lb_svc)
+    assert lb_svc.state == 'active'
+    web_svc = client.wait_success(lb_svc)
+    assert web_svc.state == 'active'
+
+    env = client.wait_success(env.deactivateservices())
+    lb_svc = client.wait_success(lb_svc)
+    assert lb_svc.state == 'inactive'
+    web_svc = client.wait_success(web_svc)
+    assert web_svc.state == 'inactive'
+
+    env = client.wait_success(env.activateservices())
+    lb_svc = client.wait_success(lb_svc)
+    assert lb_svc.state == 'active'
+    web_svc = client.wait_success(lb_svc)
+    assert web_svc.state == 'active'
+
+
 def _validate_config_item_update(super_client, bf, agent_id):
     wait_for(
         lambda: find_one(super_client.list_config_item_status,


### PR DESCRIPTION
1) Fixed stack.restart use case for lb service

https://github.com/rancher/rancher/issues/2735

2) Added not null check for ports: can be null for internal LB

https://github.com/rancher/rancher/issues/2737