### PR TITLE
And the award for most confusing bug with simplest fix goes to...

### DIFF
--- a/code/iaas/simple-allocator/src/main/java/io/cattle/platform/simple/allocator/dao/impl/SimpleAllocatorDaoImpl.java
+++ b/code/iaas/simple-allocator/src/main/java/io/cattle/platform/simple/allocator/dao/impl/SimpleAllocatorDaoImpl.java
@@ -58,7 +58,7 @@ public class SimpleAllocatorDaoImpl extends AbstractJooqDao implements SimpleAll
                     .and(HOST.STATE.in(CommonStatesConstants.ACTIVE, CommonStatesConstants.UPDATING_ACTIVE))
                     .and(STORAGE_POOL.STATE.eq(CommonStatesConstants.ACTIVE))
                     .and(getQueryOptionCondition(options)))
-                .orderBy(SPREAD.get() ? HOST.COMPUTE_FREE.desc() : HOST.COMPUTE_FREE.asc())
+                .orderBy((SPREAD.get() ? HOST.COMPUTE_FREE.desc() : HOST.COMPUTE_FREE.asc()), HOST.ID.asc())
                 .fetchLazy();
 
         return new AllocationCandidateIterator(objectManager, cursor, volumes, hosts, callback);


### PR DESCRIPTION
Fix allocation query ordering

This query returns combinations of host and storage pool ids order by
compute_free. The code that uses this query expects hosts will be
grouped together by id such that results look like this:
```
host1, spA
host1, spB
host2, spA
host2, spC
```
but the secondary ordering by host was not guaranteed and you could end
up with a result set like this:
 ```
host1, spA
host2, spA
host1, spB
host2, spC
```