### PR TITLE
Omit duplicated "default" entries in dns config

### DIFF
--- a/resources/content/config-content/hosts/content-home/etc/cattle/dns/answers.json.ftl
+++ b/resources/content/config-content/hosts/content-home/etc/cattle/dns/answers.json.ftl
@@ -1,17 +1,10 @@
 {
-    "default": {
-        "recurse": [
-            PARENT_DNS
-        ],
-        "a": {
-        	"rancher-metadata.": {"answer": ["169.254.169.250"]},
-		"rancher-metadata.rancher.internal.": {"answer": ["169.254.169.250"]}
-		}
-    },
+<#assign setDefault = true/>
 <#if dnsEntries?? >
     <#list dnsEntries as dnsEntry>
         <#if dnsEntry.resolve?has_content && dnsEntry.sourceIpAddress.address??>
     "${dnsEntry.sourceIpAddress.address}": {
+    <#if dnsEntry.sourceIpAddress.address == "default"> <#assign setDefault = false/> </#if>
             <#if (dnsEntry.instance.data.fields.dns)?? && dnsEntry.instance.data.fields.dns?has_content >
         "recurse": [
                 <#list dnsEntry.instance.data.fields.dns as recurse >
@@ -52,5 +45,18 @@
         </#if>
     </#list>
     "": {}
+</#if>
+
+<#if setDefault == true>
+,
+"default": {
+        "recurse": [
+            PARENT_DNS
+        ],
+        "a": {
+        	"rancher-metadata.": {"answer": ["169.254.169.250"]},
+		"rancher-metadata.rancher.internal.": {"answer": ["169.254.169.250"]}
+		}
+    }
 </#if>
 }


### PR DESCRIPTION
When host has at least one container with host networking, "default" entry is generated for this container in java code (dnsEntry.sourceIpAddress.address="default" for such entry). We don't want to populate default "default" section in this case.

https://github.com/rancher/rancher/issues/2460