### PR TITLE
Fix volumeDriver to pool to host allocation bug

### DIFF
--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/BaseConstraintsProvider.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/BaseConstraintsProvider.java
@@ -153,6 +153,16 @@ public class BaseConstraintsProvider implements AllocationConstraintsProvider, P
                 constraints.add(new UnmanagedStoragePoolKindConstraint(volume));
             }
         }
+
+        if (attempt.getInstance() != null) {
+            String driver = DataAccessor.fieldString(attempt.getInstance(), InstanceConstants.FIELD_VOLUME_DRIVER);
+            if (StringUtils.isNotEmpty(driver)) {
+                StoragePool pool = storagePoolDao.findStoragePoolByDriverName(attempt.getInstance().getAccountId(), driver);
+                if (pool != null) {
+                    storagePoolToHostConstraint(constraints, pool);
+                }
+            }
+        }
     }
 
     void storagePoolToHostConstraint(List<Constraint> constraints, StoragePool pool) {


### PR DESCRIPTION
If a volumeDriver is specified on an instance and that volumeDriver
resolves to a pool, allocation should be restricted to hosts belonging
to that storage pool.