### PR TITLE
Not null check in lb agent search

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceUpdateConfig.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceUpdateConfig.java
@@ -1,5 +1,6 @@
 package io.cattle.platform.servicediscovery.process;
 
+import static io.cattle.platform.core.model.tables.AgentTable.AGENT;
 import io.cattle.platform.configitem.request.ConfigUpdateRequest;
 import io.cattle.platform.configitem.request.util.ConfigUpdateRequestUtils;
 import io.cattle.platform.configitem.version.ConfigItemStatusManager;
@@ -101,8 +102,8 @@ public class LoadBalancerServiceUpdateConfig extends AbstractObjectProcessLogic 
     private void updateLoadBalancerConfigs(ProcessState state, List<? extends Instance> lbInstances) {
         Map<Long, Agent> agents = new HashMap<>();
         for (Instance lbInstance : lbInstances) {
-            Agent agent = objectManager.loadResource(Agent.class, lbInstance.getAgentId());
-            if (agent.getRemoved() == null) {
+            Agent agent = objectManager.findAny(Agent.class, AGENT.ID, lbInstance.getAgentId(), AGENT.REMOVED, null);
+            if (agent != null) {
                 agents.put(agent.getId(), agent);
             }
         }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/2749

This fix mostly addresses issue that can happen on the upgraded setup. Before lb refactoring, agent and lbinstance were controlled separately, and race condition when instance exists but the agent is gone, was possible. 