### PR TITLE
Lookup volumes by driver, not pool id

### DIFF
--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/BaseConstraintsProvider.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/BaseConstraintsProvider.java
@@ -156,7 +156,7 @@ public class BaseConstraintsProvider implements AllocationConstraintsProvider, P
 
         if (attempt.getInstance() != null) {
             String driver = DataAccessor.fieldString(attempt.getInstance(), InstanceConstants.FIELD_VOLUME_DRIVER);
-            if (StringUtils.isNotEmpty(driver)) {
+            if (StringUtils.isNotEmpty(driver) && !VolumeConstants.LOCAL_DRIVER.equals(driver)) {
                 StoragePool pool = storagePoolDao.findStoragePoolByDriverName(attempt.getInstance().getAccountId(), driver);
                 if (pool != null) {
                     storagePoolToHostConstraint(constraints, pool);

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/externalevent/ExternalEventCreate.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/externalevent/ExternalEventCreate.java
@@ -28,7 +28,6 @@ import io.cattle.platform.object.process.StandardProcess;
 import io.cattle.platform.object.util.DataAccessor;
 import io.cattle.platform.object.util.DataUtils;
 import io.cattle.platform.process.base.AbstractDefaultProcessHandler;
-import io.cattle.platform.process.common.util.ProcessUtils;
 import io.cattle.platform.util.type.CollectionUtils;
 
 import java.util.ArrayList;
@@ -123,14 +122,15 @@ public class ExternalEventCreate extends AbstractDefaultProcessHandler {
                     }
                     break;
                 case ExternalEventConstants.TYPE_VOLUME_DELETE:
-                    if (volume != null) {
-                        try {
-                            objectProcessManager.scheduleStandardProcess(StandardProcess.DEACTIVATE, volume,
-                                    ProcessUtils.chainInData(new HashMap<String, Object>(), PROC_VOL_DEACTIVATE, PROC_VOL_REMOVE));
-                        } catch (ProcessCancelException e) {
-                            log.info("Deactivate and remove process cancelled for volume {}. ProcessCancelException message: {}", volume, e.getMessage());
-                        }
-                    }
+                    // TODO Re-enable delete when we figure out how to properly delete volumes
+                    // if (volume != null) {
+                    // try {
+                    // objectProcessManager.scheduleStandardProcess(StandardProcess.DEACTIVATE, volume,
+                    // ProcessUtils.chainInData(new HashMap<String, Object>(), PROC_VOL_DEACTIVATE, PROC_VOL_REMOVE));
+                    // } catch (ProcessCancelException e) {
+                    // log.info("Deactivate and remove process cancelled for volume {}. ProcessCancelException message: {}", volume, e.getMessage());
+                    // }
+                    // }
                     break;
                 default:
                     log.error("Unknown event type: {} for event {}", event.getEventType(), event);

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/VolumeDao.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/VolumeDao.java
@@ -14,5 +14,5 @@ public interface VolumeDao {
      * Does what the name says, but if storagePoolId is null, will look across all non-local storage pools
      * if storagePoolId is not null, will restrict the lookup to that storage pool.
      */
-    Volume findSharedVolume(long accountId, Long storagePoolId, String volumeName);
+    Volume findSharedVolume(long accountId, String driverName, String volumeName);
 }

--- a/tests/integration/cattletest/core/test_shared_volumes.py
+++ b/tests/integration/cattletest/core/test_shared_volumes.py
@@ -3,7 +3,6 @@ from cattle import ClientApiError
 
 SP_CREATE = "storagepool.create"
 VOLUME_CREATE = "volume.create"
-VOLUME_DELETE = "volume.delete"
 
 
 def more_hosts(context):
@@ -293,13 +292,6 @@ def test_external_volume_event(super_client, new_context):
                         VOLUME_CREATE, external_id, driver=sp_name, uri=uri)
     volumes = client.list_volume(externalId=external_id)
     assert len(volumes) == 1
-
-    # Delete volume event
-    create_volume_event(client, agent_client, new_context, VOLUME_DELETE,
-                        external_id, driver=sp_name, uri=uri)
-
-    volume = client.wait_success(volume)
-    assert volume.state == 'removed'
 
 
 def test_external_storage_pool_event(new_context):


### PR DESCRIPTION
When a volume is first created via the API, it is not in a storage
pool. If that volume is referenced by name in an instance, look it up
by driver instead of storage pool id, since it may not yet be in a
storage pool.

Bonus: disable volume delete event logic.
Double bonus: don't unnecessarily query for storage pools when driver
is local in allocatio logic.

Addresses rancher/rancher#2755