### PR TITLE
Add a volume affinity label to assist in placement

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/VolumeDaoImpl.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/VolumeDaoImpl.java
@@ -98,16 +98,16 @@ public class VolumeDaoImpl extends AbstractJooqDao implements VolumeDao {
                 .and(STORAGE_POOL.KIND.notIn(LOCAL_POOL_KINDS).or(STORAGE_POOL.KIND.isNull()))
             .fetchInto(VolumeRecord.class);
 
-        List<VolumeRecord> volumes = null;
-        if (StringUtils.isNotBlank(driverName)) {
-            volumes = new ArrayList<VolumeRecord>();
-            for (VolumeRecord v : result) {
-                if (StringUtils.equals(driverName, DataAccessor.fieldString(v, VolumeConstants.FIELD_VOLUME_DRIVER))){
-                    volumes.add(v);
-                }
+        List<VolumeRecord> volumes = new ArrayList<VolumeRecord>();
+        for (VolumeRecord v : result) {
+            String volDriver = DataAccessor.fieldString(v, VolumeConstants.FIELD_VOLUME_DRIVER);
+            if (VolumeConstants.LOCAL_DRIVER.equals(volDriver)) {
+                continue;
             }
-        } else {
-            volumes = result;
+            if ((StringUtils.isNotBlank(driverName) && StringUtils.equals(driverName, volDriver)) || 
+                    StringUtils.isBlank(driverName)) {
+                volumes.add(v);
+            }
         }
 
         if (volumes.size() <= 0) {


### PR DESCRIPTION
Volume affinity
io.rancher.scheduler.affinity:volume = volume1,volume2

Behavior:
- If this label is present while scheduling, constrain the scheduling of the container to hosts where those volumes are already available, regardless of whether those volumes are part of shared or local pools.
- If the labels point at shared volume, the container can land on any host in the storage pool.
- If the values in this label conflict with each or with the values of dataVolumeMounts, it is a scheduling failure.
- If this label is present, looking up volumes in shared storage pools _still_ takes precedence over local storage pools.
- If a value is in the label but not in volumeMounts, the label is ignored.