### PR TITLE
Unringing this bell

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/VolumeDao.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/VolumeDao.java
@@ -3,6 +3,7 @@ package io.cattle.platform.core.dao;
 import io.cattle.platform.core.model.StoragePool;
 import io.cattle.platform.core.model.Volume;
 
+import java.util.List;
 import java.util.Map;
 
 public interface VolumeDao {
@@ -10,9 +11,5 @@ public interface VolumeDao {
     
     void createVolumeInStoragePool(Map<String, Object> volumeData, String volumeName, StoragePool storagePool);
 
-    /**
-     * Does what the name says, but if storagePoolId is null, will look across all non-local storage pools
-     * if storagePoolId is not null, will restrict the lookup to that storage pool.
-     */
-    Volume findSharedVolume(long accountId, String driverName, String volumeName);
+    List<? extends Volume> findSharedOrUnmappedVolumes(long accountId, String volumeName);
 }


### PR DESCRIPTION
Change named dataVolume lookup behavior

In general, change behavior so that container.volumeDriver is only used
for volume creation, not named volume lookup. More specifically, change
behavior such that:
- 'local' is treated exactly the same as blank when specified as
container.volumeDriver.
- volume lookup is not restricted to the shared storage pool matching
  the volumeDriver field.