### PR TITLE
Metadata: order containers by start_index, and other bug fixes

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/MetaDataInfoDaoImpl.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/MetaDataInfoDaoImpl.java
@@ -95,6 +95,7 @@ public class MetaDataInfoDaoImpl extends AbstractJooqDao implements MetaDataInfo
                 .and(instance.STATE.notIn(CommonStatesConstants.REMOVING, CommonStatesConstants.REMOVED))
                 .and(exposeMap.REMOVED.isNull())
                 .and(exposeMap.STATE.notIn(CommonStatesConstants.REMOVING, CommonStatesConstants.REMOVED))
+                .orderBy(instance.START_COUNT)
                 .fetch().map(mapper);
     }
 

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/InstanceDao.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/InstanceDao.java
@@ -25,7 +25,4 @@ public interface InstanceDao {
     List<? extends Instance> findInstancesFor(Service service);
 
     Long getInstanceHostId(long instanceId);
-
-    Service getServiceManaging(long instanceId);
-
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/InstanceDaoImpl.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/InstanceDaoImpl.java
@@ -159,19 +159,4 @@ public class InstanceDaoImpl extends AbstractJooqDao implements InstanceDao {
         return maps.get(0).getHostId();
     }
 
-    @Override
-    public Service getServiceManaging(long instanceId) {
-        List<? extends Service> services = create().select(SERVICE.fields())
-                .from(SERVICE)
-                .join(SERVICE_EXPOSE_MAP)
-                .on(SERVICE_EXPOSE_MAP.SERVICE_ID.eq(SERVICE.ID))
-                .where(SERVICE_EXPOSE_MAP.INSTANCE_ID.eq(instanceId)
-                        .and(SERVICE_EXPOSE_MAP.MANAGED.eq(true)))
-                .fetchInto(ServiceRecord.class);
-        if (services.size() == 0) {
-            return null;
-        }
-        return services.get(0);
-    }
-
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/PortActivateDeactivatePostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/PortActivateDeactivatePostListener.java
@@ -40,10 +40,6 @@ public class PortActivateDeactivatePostListener extends AbstractObjectProcessLog
     public HandlerResult handle(ProcessState state, ProcessInstance process) {
         Port port = (Port) state.getResource();
 
-        if (port.getPublicIpAddressId() == null || port.getPublicPort() == null) {
-            return null;
-        }
-
         IpAddress ip = objectManager.findOne(IpAddress.class, IP_ADDRESS.ID, port.getPublicIpAddressId(),
                 IP_ADDRESS.REMOVED, null);
         if (ip == null) {

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/PortActivateDeactivatePostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/PortActivateDeactivatePostListener.java
@@ -6,6 +6,7 @@ import io.cattle.platform.core.constants.PortConstants;
 import io.cattle.platform.core.dao.HostDao;
 import io.cattle.platform.core.dao.InstanceDao;
 import io.cattle.platform.core.model.Host;
+import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.IpAddress;
 import io.cattle.platform.core.model.Port;
 import io.cattle.platform.core.model.Service;
@@ -16,6 +17,8 @@ import io.cattle.platform.engine.process.ProcessState;
 import io.cattle.platform.process.common.handler.AbstractObjectProcessLogic;
 import io.cattle.platform.servicediscovery.service.ServiceDiscoveryService;
 import io.cattle.platform.util.type.Priority;
+
+import java.util.List;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -65,8 +68,9 @@ public class PortActivateDeactivatePostListener extends AbstractObjectProcessLog
     }
 
     protected void updateServiceEndpoints(Port port, boolean add, PublicEndpoint endPoint) {
-        Service service = instanceDao.getServiceManaging(port.getInstanceId());
-        if (service != null) {
+        List<? extends Service> services = instanceDao.findServicesFor(objectManager.loadResource(Instance.class,
+                port.getInstanceId()));
+        for (Service service : services) {
             sdService.updateServicePublicEndpoints(service, endPoint, add);
         }
     }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/PortUpdatePostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/PortUpdatePostListener.java
@@ -41,10 +41,6 @@ public class PortUpdatePostListener extends AbstractObjectProcessLogic implement
     public HandlerResult handle(ProcessState state, ProcessInstance process) {
         Port port = (Port) state.getResource();
 
-        if (port.getPublicIpAddressId() == null || port.getPublicPort() == null) {
-            return null;
-        }
-
         IpAddress ip = objectManager.findOne(IpAddress.class, IP_ADDRESS.ID, port.getPublicIpAddressId(),
                 IP_ADDRESS.REMOVED, null);
         if (ip == null) {
@@ -60,15 +56,11 @@ public class PortUpdatePostListener extends AbstractObjectProcessLogic implement
                 oldPublicPort = (Integer) old.get(PortConstants.FIELD_PUBLIC_POST);
             }
         }
-        
-        if (oldPublicPort == null) {
-            return null;
-        }
 
         PublicEndpoint newEndPoint = new PublicEndpoint(ip.getAddress(), port.getPublicPort());
 
         PublicEndpoint oldEndPoint = new PublicEndpoint(ip.getAddress(), oldPublicPort);
-
+        
         updateServiceEndpoints(port, newEndPoint, oldEndPoint);
 
         updateHostEndPoints(ip, newEndPoint, oldEndPoint);

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/PortUpdatePostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/PortUpdatePostListener.java
@@ -6,6 +6,7 @@ import io.cattle.platform.core.constants.PortConstants;
 import io.cattle.platform.core.dao.HostDao;
 import io.cattle.platform.core.dao.InstanceDao;
 import io.cattle.platform.core.model.Host;
+import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.IpAddress;
 import io.cattle.platform.core.model.Port;
 import io.cattle.platform.core.model.Service;
@@ -18,6 +19,7 @@ import io.cattle.platform.servicediscovery.service.ServiceDiscoveryService;
 import io.cattle.platform.util.type.CollectionUtils;
 import io.cattle.platform.util.type.Priority;
 
+import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -77,8 +79,9 @@ public class PortUpdatePostListener extends AbstractObjectProcessLogic implement
     }
 
     protected void updateServiceEndpoints(Port port, PublicEndpoint newEndPoint, PublicEndpoint oldEndPoint) {
-        Service service = instanceDao.getServiceManaging(port.getInstanceId());
-        if (service != null) {
+        List<? extends Service> services = instanceDao.findServicesFor(objectManager.loadResource(Instance.class,
+                port.getInstanceId()));
+        for (Service service : services) {
             sdService.updateServicePublicEndpoints(service, newEndPoint, true);
             sdService.updateServicePublicEndpoints(service, oldEndPoint, false);
         }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
@@ -336,6 +336,10 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
         // have to reload the object to get the latest update for publicEndpoint
         // if don't reload, its possible that n concurrent updates would lack information.
         // update would be performed on the original object
+
+        if (publicEndpoint.getPort() == null || publicEndpoint.getIpAddress() == null) {
+            return;
+        }
         Object reloaded = objectManager.reload(object);
         List<PublicEndpoint> publicEndpoints = new ArrayList<>();
         publicEndpoints.addAll(DataAccessor.fields(reloaded)

--- a/resources/content/schema/base/environment.json
+++ b/resources/content/schema/base/environment.json
@@ -4,6 +4,7 @@
             "required": true,
             "validChars": "a-zA-Z0-9-",
             "minLength": 1,
+            "maxLength": 63,
              "attributes" : {
                 "scheduleUpdate" : true
             }

--- a/resources/content/schema/base/secondaryLaunchConfig.json
+++ b/resources/content/schema/base/secondaryLaunchConfig.json
@@ -4,7 +4,9 @@
         "name":{
             "type": "string",
             "required": true,
-            "nullable": false
+            "nullable": false,
+            "minLength": 1,
+            "maxLength": 63
         }
     }
 }

--- a/resources/content/schema/base/service.json
+++ b/resources/content/schema/base/service.json
@@ -21,6 +21,7 @@
             "required": true,
             "validChars": "a-zA-Z0-9-",
             "minLength": 1,
+            "maxLength": 63,
              "attributes" : {
                 "scheduleUpdate" : true
             }

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -2515,7 +2515,7 @@ def test_validate_long_hostname_with_domainname_override(client, context):
         }
     }
     first_service_name = "MyServiceNameLongerThanDNSPrefixLength" \
-                         "AllowedMyServiceNameLonger"
+                         "AllowedMyServiceNameLonge"
     service1 = client.create_service(name=first_service_name,
                                      environmentId=env.id,
                                      launchConfig=launch_config1)


### PR DESCRIPTION
1) Metadata: order containers by start_index

https://github.com/rancher/rancher/issues/2774

@cloudnautique @ibuildthecloud this small PR is to ensure that container order in metadata is done based on start_index. Currently done in ascending order, please comment if you think it should be DESC.

2) Limit length for stack.name, service.name and sidekick.name to 63 chars as its the max allowed length for dns labels.

https://github.com/rancher/rancher/issues/2742

3) Handle publicEndpoint update for the case when privately exposed port gets updated with a public port:

https://github.com/rancher/rancher/issues/2770

4) Update service.publicEndpoints for all instances, not just managed:

https://github.com/rancher/rancher/issues/2787