### PR TITLE
Fuzzy search for LB hostname routing rules

### DIFF
--- a/code/iaas/model/src/test/java/io/cattle/platform/core/util/LoadBalancerTargetPortSpecTest.java
+++ b/code/iaas/model/src/test/java/io/cattle/platform/core/util/LoadBalancerTargetPortSpecTest.java
@@ -1,0 +1,30 @@
+package io.cattle.platform.core.util;
+
+import static org.junit.Assert.assertEquals;
+import io.github.ibuildthecloud.gdapi.exception.ClientVisibleException;
+
+import org.junit.Test;
+
+public class LoadBalancerTargetPortSpecTest {
+
+
+    @Test(expected = ClientVisibleException.class)
+    public void testInvalid() {
+        new LoadBalancerTargetPortSpec("foo{");
+    }
+
+    @Test
+    public void testValid() {
+        LoadBalancerTargetPortSpec portSpec = new LoadBalancerTargetPortSpec("example.com{end}:80/path{beg}");
+        assertEquals(portSpec.getHostCondition().name(), "end");
+        assertEquals(portSpec.getPathCondition().name(), "beg");
+
+        portSpec = new LoadBalancerTargetPortSpec("example.com{dir}:80/path{dom}=81");
+        assertEquals(portSpec.getHostCondition().name(), "dir");
+        assertEquals(portSpec.getPathCondition().name(), "dom");
+
+        portSpec = new LoadBalancerTargetPortSpec("example.com{reg}:80/path/path/path{sub}");
+        assertEquals(portSpec.getHostCondition().name(), "reg");
+        assertEquals(portSpec.getPathCondition().name(), "sub");
+    }
+}

--- a/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
+++ b/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
@@ -46,11 +46,19 @@ frontend ${listener.uuid}_frontend
         <#list backends[listener.uuid] as backend >
         <#if (listener.sourceProtocol == "http" || listener.sourceProtocol == "https") && (backend.portSpec.domain != "default" || backend.portSpec.path != "default")>
         <#if backend.portSpec.domain != "default">
-        acl ${backend.uuid}_host hdr(host) -i ${backend.portSpec.domain}
-        acl ${backend.uuid}_host hdr(host) -i ${backend.portSpec.domain}:${sourcePort}
+        <#assign hostCondition="">
+        <#if backend.portSpec.hostCondition??>
+        	<#assign hostCondition="_" + backend.portSpec.hostCondition>
+        </#if>
+        acl ${backend.uuid}_host hdr${hostCondition}(host) -i ${backend.portSpec.domain}
+        acl ${backend.uuid}_host hdr${hostCondition}(host) -i ${backend.portSpec.domain}:${sourcePort}
     	</#if>
     	<#if backend.portSpec.path != "default">
-        acl ${backend.uuid}_path path_beg -i ${backend.portSpec.path}
+    	<#assign pathCondition="beg">
+        <#if backend.portSpec.pathCondition??>
+        	<#assign pathCondition="_" + backend.portSpec.pathCondition>
+        </#if>
+        acl ${backend.uuid}_path path${pathCondition} -i ${backend.portSpec.path}
     	</#if>
     	use_backend ${listener.uuid}_${backend.uuid}_backend if <#if backend.portSpec.domain != "default">${backend.uuid}_host</#if> <#if backend.portSpec.path != "default">${backend.uuid}_path</#if>
         <#elseif backend.portSpec.domain == "default" && backend.portSpec.path == "default">


### PR DESCRIPTION
Path and domain can be appended with condition. Condition format {condition}. Example:
 * example.com{end}/path{beg}=81

supported prefixes:

* beg (prefix match)
* dir (subdir match)
* dom (domain match)
* end (suffix match)
* reg (regex match)
* sub (substring match)

Description for all prefixes can be found here:

https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#7.3.6-req.hdr

Default value - exact match