### PR TITLE
Add context to the callable.

### DIFF
--- a/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/context/ApiContext.java
+++ b/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/context/ApiContext.java
@@ -33,6 +33,10 @@ public class ApiContext {
         return TL.get();
     }
 
+    public static void setContext(ApiContext context) {
+        TL.set(context);
+    }
+
     public static SchemaFactory getSchemaFactory() {
         return getContext().getApiRequest().getSchemaFactory();
     }


### PR DESCRIPTION
Fix an issue where the context is null during a callable that requires it.
This as a result made it so that the identityprovider for github was unable to
get an access token for github.