### PR TITLE
Performance improvements to DNS records generation

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/DnsInfoDao.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/DnsInfoDao.java
@@ -6,13 +6,7 @@ import io.cattle.platform.core.model.Instance;
 import java.util.List;
 
 public interface DnsInfoDao {
-    List<DnsEntryData> getInstanceLinksHostDnsData(Instance instance);
+    List<DnsEntryData> getInstanceLinksDnsData(Instance instance);
 
     List<DnsEntryData> getServiceDnsData(Instance instance, boolean isVIPProvider, boolean links);
-
-    List<DnsEntryData> getSelfServiceData(Instance instance, boolean isVIPProvider);
-
-    List<DnsEntryData> getExternalServiceDnsData(Instance instance, boolean links);
-
-    List<DnsEntryData> getDnsServiceLinksData(Instance instance, boolean isVIPProvider, boolean links);
 }

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/DnsInfoDaoImpl.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/DnsInfoDaoImpl.java
@@ -394,7 +394,8 @@ public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
             condition = ipAddress.ROLE.eq(IpAddressConstants.ROLE_PRIMARY).and(nic.VNET_ID.eq(vnetId));
         } else {
             condition = (ipAddress.ROLE.isNull().and(ipAddress.ADDRESS.isNull())).or(ipAddress.ROLE
-                    .eq(IpAddressConstants.ROLE_PRIMARY));
+                    .eq(IpAddressConstants.ROLE_PRIMARY)).and(instance.HEALTH_STATE.isNull().or(
+                    instance.HEALTH_STATE.eq(HealthcheckConstants.HEALTH_STATE_HEALTHY)));
         }
 
         return create()
@@ -418,8 +419,6 @@ public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
                 .and(instance.REMOVED.isNull())
                 .and(instance.STATE.isNull().or(instance.STATE.in(InstanceConstants.STATE_RUNNING,
                         InstanceConstants.STATE_STARTING)))
-                .and(instance.HEALTH_STATE.isNull().or(
-                        instance.HEALTH_STATE.eq(HealthcheckConstants.HEALTH_STATE_HEALTHY)))
                 .and(condition)
                 .fetch().map(mapper);
     }

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/ServiceInstanceData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/ServiceInstanceData.java
@@ -1,0 +1,63 @@
+package io.cattle.platform.configitem.context.dao.impl;
+
+import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.IpAddress;
+import io.cattle.platform.core.model.Nic;
+import io.cattle.platform.core.model.Service;
+import io.cattle.platform.core.model.ServiceExposeMap;
+
+public class ServiceInstanceData {
+    Service service;
+    IpAddress ipAddress;
+    Instance instance;
+    ServiceExposeMap exposeMap;
+    Nic nic;
+
+    public ServiceInstanceData(Service service, IpAddress ipAddress, Instance instance, ServiceExposeMap exposeMap,
+            Nic nic) {
+        super();
+        this.service = service;
+        this.ipAddress = ipAddress;
+        this.instance = instance;
+        this.exposeMap = exposeMap;
+        this.nic = nic;
+    }
+    public Service getService() {
+        return service;
+    }
+    public void setService(Service service) {
+        this.service = service;
+    }
+
+    public IpAddress getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(IpAddress ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+    public Instance getInstance() {
+        return instance;
+    }
+
+    public void setInstance(Instance instance) {
+        this.instance = instance;
+    }
+
+    public ServiceExposeMap getExposeMap() {
+        return exposeMap;
+    }
+
+    public void setExposeMap(ServiceExposeMap exposeMap) {
+        this.exposeMap = exposeMap;
+    }
+
+    public Nic getNic() {
+        return nic;
+    }
+
+    public void setNic(Nic nic) {
+        this.nic = nic;
+    }
+
+}

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/DnsEntryData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/DnsEntryData.java
@@ -1,7 +1,6 @@
 package io.cattle.platform.configitem.context.data;
 
 import io.cattle.platform.core.model.Instance;
-import io.cattle.platform.core.model.IpAddress;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -11,21 +10,20 @@ import java.util.Map;
 import com.google.common.collect.Lists;
 
 public class DnsEntryData {
-    IpAddress sourceIpAddress;
+    String sourceIpAddress;
     Map<String, Map<String, String>> resolveServicesAndContainers = new HashMap<>();
     Map<String, List<String>> resolve = new HashMap<>();
     Map<String, String> resolveCname = new HashMap<>();
     Instance instance;
-    Long clientServiceId;
 
     public DnsEntryData() {
     }
 
-    public IpAddress getSourceIpAddress() {
+    public String getSourceIpAddress() {
         return sourceIpAddress;
     }
 
-    public void setSourceIpAddress(IpAddress sourceIpAddress) {
+    public void setSourceIpAddress(String sourceIpAddress) {
         this.sourceIpAddress = sourceIpAddress;
     }
 
@@ -63,14 +61,6 @@ public class DnsEntryData {
 
     public void setResolveCname(Map<String, String> resolveCname) {
         this.resolveCname = resolveCname;
-    }
-
-    public Long getClientServiceId() {
-        return clientServiceId;
-    }
-
-    public void setClientServiceId(Long clientServiceId) {
-        this.clientServiceId = clientServiceId;
     }
 
     public Map<String, List<String>> getResolve() {

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/ServiceDnsEntryData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/ServiceDnsEntryData.java
@@ -1,0 +1,42 @@
+package io.cattle.platform.configitem.context.data;
+
+import io.cattle.platform.core.model.Service;
+import io.cattle.platform.core.model.ServiceConsumeMap;
+
+public class ServiceDnsEntryData {
+    Service clientService;
+    Service targetService;
+    ServiceConsumeMap consumeMap;
+
+    public Service getClientService() {
+        return clientService;
+    }
+
+    public void setClientService(Service clientService) {
+        this.clientService = clientService;
+    }
+
+    public Service getTargetService() {
+        return targetService;
+    }
+
+    public void setTargetService(Service targetService) {
+        this.targetService = targetService;
+    }
+
+    public ServiceConsumeMap getConsumeMap() {
+        return consumeMap;
+    }
+
+    public void setConsumeMap(ServiceConsumeMap consumeMap) {
+        this.consumeMap = consumeMap;
+    }
+
+    public ServiceDnsEntryData(Service clientService, Service targetService, ServiceConsumeMap consumeMap) {
+        super();
+        this.clientService = clientService;
+        this.targetService = targetService;
+        this.consumeMap = consumeMap;
+    }
+
+}

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/DnsInfoFactory.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/DnsInfoFactory.java
@@ -32,32 +32,24 @@ public class DnsInfoFactory extends AbstractAgentBaseContextFactory {
         boolean isVIPProviderConfigured = isVIPProviderConfigured(instance);
         List<DnsEntryData> dnsEntries = new ArrayList<DnsEntryData>();
         // 1. retrieve all instance links for the hosts
-        dnsEntries.addAll(dnsInfoDao.getInstanceLinksHostDnsData(instance));
-        // 2. retrieve regular service dns records
+        dnsEntries.addAll(dnsInfoDao.getInstanceLinksDnsData(instance));
+        // 2. retrieve service dns records
         dnsEntries.addAll(dnsInfoDao.getServiceDnsData(instance, isVIPProviderConfigured, true));
         dnsEntries.addAll(dnsInfoDao.getServiceDnsData(instance, isVIPProviderConfigured, false));
-        // 3. retrieve self service links
-        dnsEntries.addAll(dnsInfoDao.getSelfServiceData(instance, isVIPProviderConfigured));
-        // 4. retrieve external service dns records
-        dnsEntries.addAll(dnsInfoDao.getExternalServiceDnsData(instance, true));
-        dnsEntries.addAll(dnsInfoDao.getExternalServiceDnsData(instance, false));
-        // 5. get dns service dns records
-        dnsEntries.addAll(dnsInfoDao.getDnsServiceLinksData(instance, isVIPProviderConfigured, true));
-        dnsEntries.addAll(dnsInfoDao.getDnsServiceLinksData(instance, isVIPProviderConfigured, false));
 
         // aggregate the links based on the source ip address
         Map<String, DnsEntryData> processedDnsEntries = new HashMap<>();
         for (DnsEntryData dnsEntry : dnsEntries) {
             DnsEntryData newData = null;
-            if (processedDnsEntries.containsKey(dnsEntry.getSourceIpAddress().getAddress())) {
-                newData = processedDnsEntries.get(dnsEntry.getSourceIpAddress().getAddress());
+            if (processedDnsEntries.containsKey(dnsEntry.getSourceIpAddress())) {
+                newData = processedDnsEntries.get(dnsEntry.getSourceIpAddress());
                 populateARecords(dnsEntry, newData);
                 populateCnameRecords(dnsEntry, newData);
             } else {
                 newData = dnsEntry;
             }
 
-            processedDnsEntries.put(dnsEntry.getSourceIpAddress().getAddress(), newData);
+            processedDnsEntries.put(dnsEntry.getSourceIpAddress(), newData);
         }
         context.getData().put("dnsEntries", processedDnsEntries.values());
     }

--- a/resources/content/config-content/hosts/content-home/etc/cattle/dns/answers.json.ftl
+++ b/resources/content/config-content/hosts/content-home/etc/cattle/dns/answers.json.ftl
@@ -2,9 +2,9 @@
 <#assign setDefault = true/>
 <#if dnsEntries?? >
     <#list dnsEntries as dnsEntry>
-        <#if dnsEntry.resolve?has_content && dnsEntry.sourceIpAddress.address??>
-    "${dnsEntry.sourceIpAddress.address}": {
-    <#if dnsEntry.sourceIpAddress.address == "default"> <#assign setDefault = false/> </#if>
+        <#if dnsEntry.resolve?has_content && dnsEntry.sourceIpAddress??>
+    "${dnsEntry.sourceIpAddress}": {
+    <#if dnsEntry.sourceIpAddress == "default"> <#assign setDefault = false/> </#if>
             <#if (dnsEntry.instance.data.fields.dns)?? && dnsEntry.instance.data.fields.dns?has_content >
         "recurse": [
                 <#list dnsEntry.instance.data.fields.dns as recurse >


### PR DESCRIPTION
Query db just 2 times to get a) all services with their instances b) relationship between the services; store this info in memory. Form dns records based on this data