### PR TITLE
Propagate "health_state" and "expose" fields to metadata

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/MetaDataInfoDaoImpl.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/MetaDataInfoDaoImpl.java
@@ -95,7 +95,7 @@ public class MetaDataInfoDaoImpl extends AbstractJooqDao implements MetaDataInfo
                 .and(instance.STATE.notIn(CommonStatesConstants.REMOVING, CommonStatesConstants.REMOVED))
                 .and(exposeMap.REMOVED.isNull())
                 .and(exposeMap.STATE.notIn(CommonStatesConstants.REMOVING, CommonStatesConstants.REMOVED))
-                .orderBy(instance.CREATE_INDEX)
+                .orderBy(instance.ID)
                 .fetch().map(mapper);
     }
 

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/ContainerMetaData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/ContainerMetaData.java
@@ -31,6 +31,7 @@ public class ContainerMetaData {
     Long create_index;
     String host_uuid;
     String hostname;
+    String health_state;
 
     public ContainerMetaData() {
     }
@@ -92,6 +93,7 @@ public class ContainerMetaData {
             }
         }
         this.create_index = instance.getCreateIndex();
+        this.health_state = instance.getHealthState();
     }
 
     public void setService_name(String service_name) {
@@ -138,5 +140,9 @@ public class ContainerMetaData {
 
     public String getUuid() {
         return uuid;
+    }
+
+    public String getHealth_state() {
+        return health_state;
     }
 }

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/ServiceMetaData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/ServiceMetaData.java
@@ -35,6 +35,7 @@ public class ServiceMetaData {
     Map<String, Object> metadata;
     Integer scale;
     String fqdn;
+    List<String> expose = new ArrayList<>();
 
     public ServiceMetaData(Service service, String serviceName, Environment env, List<String> sidekicks,
             Map<String, Object> metadata) {
@@ -64,6 +65,11 @@ public class ServiceMetaData {
                 InstanceConstants.FIELD_PORTS);
         if (portsObj != null) {
             this.ports.addAll((List<String>) portsObj);
+        }
+        Object exposeObj = ServiceDiscoveryUtil.getLaunchConfigObject(service, serviceName,
+                InstanceConstants.FIELD_EXPOSE);
+        if (exposeObj != null) {
+            this.expose.addAll((List<String>) exposeObj);
         }
     }
 
@@ -164,5 +170,9 @@ public class ServiceMetaData {
 
     public String getUuid() {
         return uuid;
+    }
+
+    public List<String> getExpose() {
+        return expose;
     }
 }

--- a/tests/integration/cattletest/core/test_svc_discovery_lb.py
+++ b/tests/integration/cattletest/core/test_svc_discovery_lb.py
@@ -188,7 +188,7 @@ def test_restart_stack(client, context):
     service_link = {"serviceId": web_service.id, "ports": ["a.com:90"]}
     lb_svc = lb_svc.addservicelink(serviceLink=service_link)
 
-    env = client.wait_success(env.activateservices())
+    env = client.wait_success(env.activateservices(), 120)
     lb_svc = client.wait_success(lb_svc)
     assert lb_svc.state == 'active'
     web_svc = client.wait_success(lb_svc)
@@ -200,7 +200,7 @@ def test_restart_stack(client, context):
     web_svc = client.wait_success(web_svc)
     assert web_svc.state == 'inactive'
 
-    env = client.wait_success(env.activateservices())
+    env = client.wait_success(env.activateservices(), 120)
     lb_svc = client.wait_success(lb_svc)
     assert lb_svc.state == 'active'
     web_svc = client.wait_success(lb_svc)


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/2811 ("health_state" for container)
https://github.com/rancher/rancher/issues/2774
https://github.com/rancher/rancher/issues/2877 - "expose" field for lb service (populated for internal lb)