### PR TITLE
Health check for host level containers

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/DnsInfoDao.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/DnsInfoDao.java
@@ -2,11 +2,15 @@ package io.cattle.platform.configitem.context.dao;
 
 import io.cattle.platform.configitem.context.data.DnsEntryData;
 import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.IpAddress;
 
 import java.util.List;
+import java.util.Map;
 
 public interface DnsInfoDao {
     List<DnsEntryData> getInstanceLinksDnsData(Instance instance);
 
     List<DnsEntryData> getServiceDnsData(Instance instance, boolean isVIPProvider);
+
+    Map<Long, IpAddress> getInstanceWithHostNetworkingToIpMap(long accountId);
 }

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/DnsInfoDaoImpl.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/DnsInfoDaoImpl.java
@@ -337,7 +337,8 @@ public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
         return null;
     }
 
-    protected Map<Long, IpAddress> getInstanceWithHostNetworkingToIpMap(long accountId) {
+    @Override
+    public Map<Long, IpAddress> getInstanceWithHostNetworkingToIpMap(long accountId) {
         List<HostInstanceIpData> data = getHostContainerIpData(accountId);
         Map<Long, IpAddress> instanceIdToHostIpMap = new HashMap<>();
         for (HostInstanceIpData entry : data) {

--- a/tests/integration/cattletest/core/test_svc_discovery_lb.py
+++ b/tests/integration/cattletest/core/test_svc_discovery_lb.py
@@ -188,8 +188,8 @@ def test_restart_stack(client, context):
     service_link = {"serviceId": web_service.id, "ports": ["a.com:90"]}
     lb_svc = lb_svc.addservicelink(serviceLink=service_link)
 
-    env = client.wait_success(env.activateservices(), 120)
-    lb_svc = client.wait_success(lb_svc)
+    env = client.wait_success(env.activateservices())
+    lb_svc = client.wait_success(lb_svc, 120)
     assert lb_svc.state == 'active'
     web_svc = client.wait_success(lb_svc)
     assert web_svc.state == 'active'
@@ -200,8 +200,8 @@ def test_restart_stack(client, context):
     web_svc = client.wait_success(web_svc)
     assert web_svc.state == 'inactive'
 
-    env = client.wait_success(env.activateservices(), 120)
-    lb_svc = client.wait_success(lb_svc)
+    env = client.wait_success(env.activateservices())
+    lb_svc = client.wait_success(lb_svc, 120)
     assert lb_svc.state == 'active'
     web_svc = client.wait_success(lb_svc)
     assert web_svc.state == 'active'


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/2432

In order to use Rancher services - dns and healthcheck - service has to have a "io.rancher.container.dns" label set to true. When set to true, container gets a secondary nic on Rancher managed network on Rancher network container's vnet - that enables the container to be picked for a health check/dns discovery.