### PR TITLE
Random public port assignment to a service (if not specified)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .project
 .settings
 
+code/packaging/app/keys.properties
 dist
 docs/build
 resources/content/db/mysql/cattle_dump*.sql
@@ -29,3 +30,4 @@ tests/integration/MANIFEST
 *.pyo
 *.swp
 *~
+

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/AccountConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/AccountConstants.java
@@ -11,6 +11,7 @@ public class AccountConstants {
     public static final String USER_KIND = "user";
     public static final String ADMIN_KIND = "admin";
     public static final String PROJECT_KIND = "project";
+    public static final String FIELD_PORT_RANGE = "servicesPortRange";
 
     public static final String ACCOUNT_ID = ConstantsUtils.property(Account.class, "accountId");
     public static final String SYSTEM_UUID = "system";

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/util/PortRangeSpec.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/util/PortRangeSpec.java
@@ -1,0 +1,48 @@
+package io.cattle.platform.core.util;
+
+import io.github.ibuildthecloud.gdapi.exception.ClientVisibleException;
+import io.github.ibuildthecloud.gdapi.util.ResponseCodes;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class PortRangeSpec {
+    private static final Pattern PATTERN = Pattern.compile("(([0-9]+)-)([0-9]+)");
+
+    public static final String WRONG_FORMAT = "PortRangeWrongFormat";
+    public static final String INVALID_START_PORT = "PortInvalidStartPort";
+    public static final String INVALID_END_PORT = "PortInvalidEndPort";
+
+    int startPort;
+    int endPort;
+
+    public PortRangeSpec(String spec) {
+        Matcher m = PATTERN.matcher(spec);
+
+        if (!m.matches()) {
+            throw new ClientVisibleException(ResponseCodes.UNPROCESSABLE_ENTITY, WRONG_FORMAT);
+        }
+
+        int endPort = Integer.parseInt(m.group(3));
+        Integer startPort = m.group(2) == null ? null : Integer.parseInt(m.group(2));
+
+        if (endPort <= 0 || endPort > 65535) {
+            throw new ClientVisibleException(ResponseCodes.UNPROCESSABLE_ENTITY, INVALID_END_PORT);
+        }
+
+        if (startPort <= 0 || startPort > 65535) {
+            throw new ClientVisibleException(ResponseCodes.UNPROCESSABLE_ENTITY, INVALID_START_PORT);
+        }
+
+        this.startPort = startPort;
+        this.endPort = endPort;
+    }
+
+    public int getStartPort() {
+        return startPort;
+    }
+
+    public int getEndPort() {
+        return endPort;
+    }
+}

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/util/PortSpec.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/util/PortSpec.java
@@ -98,4 +98,9 @@ public class PortSpec {
         this.protocol = protocol;
     }
 
+    public String toSpec() {
+        String privatePortProto = this.privatePort + (this.protocol != null ? "/" + this.protocol : "");
+        String publicPort = this.publicPort != null ? this.publicPort.toString() + ":" : "";
+        return publicPort + privatePortProto;
+    }
 }

--- a/code/iaas/resource-pool/src/main/java/io/cattle/platform/resource/pool/port/EnvironmentPortGeneratorFactory.java
+++ b/code/iaas/resource-pool/src/main/java/io/cattle/platform/resource/pool/port/EnvironmentPortGeneratorFactory.java
@@ -1,0 +1,40 @@
+package io.cattle.platform.resource.pool.port;
+
+import io.cattle.platform.archaius.util.ArchaiusUtil;
+import io.cattle.platform.core.constants.AccountConstants;
+import io.cattle.platform.core.model.Account;
+import io.cattle.platform.core.util.PortRangeSpec;
+import io.cattle.platform.object.util.DataAccessor;
+import io.cattle.platform.resource.pool.PooledResourceItemGenerator;
+import io.cattle.platform.resource.pool.PooledResourceItemGeneratorFactory;
+import io.cattle.platform.resource.pool.impl.StringRangeGenerator;
+import io.cattle.platform.resource.pool.util.ResourcePoolConstants;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.netflix.config.DynamicStringProperty;
+
+public class EnvironmentPortGeneratorFactory implements PooledResourceItemGeneratorFactory {
+
+    /*
+     * Read from config file to support upgrade scenario when default port range is not set on account
+     */
+    private static final DynamicStringProperty ENV_PORT_RANGE = ArchaiusUtil
+            .getString("environment.services.port.range");
+
+    @Override
+    public PooledResourceItemGenerator getGenerator(Object pool, String qualifier) {
+        if ((pool instanceof Account) && ResourcePoolConstants.ENVIRONMENT_PORT.equals(qualifier)) {
+            Account env = (Account) pool;
+            PortRangeSpec spec = null;
+            String portRange = DataAccessor.fieldString(env, AccountConstants.FIELD_PORT_RANGE);
+            if (StringUtils.isEmpty(portRange)) {
+                spec = new PortRangeSpec(ENV_PORT_RANGE.get());
+            } else {
+                spec = new PortRangeSpec(portRange);
+            }
+            return new StringRangeGenerator(String.valueOf(spec.getStartPort()), String.valueOf(spec.getEndPort()));
+        }
+        return null;
+    }
+}

--- a/code/iaas/resource-pool/src/main/java/io/cattle/platform/resource/pool/util/ResourcePoolConstants.java
+++ b/code/iaas/resource-pool/src/main/java/io/cattle/platform/resource/pool/util/ResourcePoolConstants.java
@@ -6,5 +6,5 @@ public class ResourcePoolConstants {
     public static final String MAC = "mac";
     public static final String LINK_PORT = "linkPort";
     public static final String HOST_PORT = "hostPort";
-
+    public static final String ENVIRONMENT_PORT = "environmentPort";
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceCreate.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceCreate.java
@@ -33,6 +33,7 @@ public class ServiceCreate extends AbstractObjectProcessHandler {
     public HandlerResult handle(ProcessState state, ProcessInstance process) {
         Service service = (Service) state.getResource();
         sdService.setVIP(service);
+        sdService.setPorts(service);
         return null;
     }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceRemove.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceRemove.java
@@ -43,6 +43,8 @@ public class ServiceRemove extends AbstractObjectProcessHandler {
 
         sdService.releaseVip(service);
 
+        sdService.releasePorts(service);
+
         return null;
     }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
@@ -34,4 +34,8 @@ public interface ServiceDiscoveryService {
     boolean isGlobalService(Service service);
 
     void propagatePublicEndpoint(PublicEndpoint publicEndpoint, boolean add);
+
+    void setPorts(Service service);
+
+    void releasePorts(Service service);
 }

--- a/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/account/DockerAccountCreate.java
+++ b/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/account/DockerAccountCreate.java
@@ -59,7 +59,8 @@ public class DockerAccountCreate extends AbstractObjectProcessLogic implements P
         createNetwork(DockerNetworkConstants.KIND_DOCKER_BRIDGE, account, networksByKind, "Docker Bridge Network Mode", null);
 
         Network managedNetwork = createManagedNetwork(account, networksByKind);
-        return new HandlerResult(AccountConstants.FIELD_DEFAULT_NETWORK_ID, managedNetwork.getId()).withShouldContinue(true);
+        return new HandlerResult(AccountConstants.FIELD_DEFAULT_NETWORK_ID, managedNetwork.getId(),
+                AccountConstants.FIELD_PORT_RANGE, "49153-65535").withShouldContinue(true);
     }
 
     protected Network createManagedNetwork(Account account, Map<String, Network> networksByKind) {

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/system-services/pool-defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/system-services/pool-defaults.properties
@@ -7,3 +7,5 @@ link.internal.port.end=39999
 
 host.port.start=20000
 host.port.end=39999
+
+environment.services.port.range=49153-65535

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/system-services/spring-resource-pool-context.xml
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/system-services/spring-resource-pool-context.xml
@@ -23,5 +23,6 @@
     <bean class="io.cattle.platform.resource.pool.mac.MacAddressPrefixGeneratorFactory" />
     <bean class="io.cattle.platform.resource.pool.mac.MacAddressGeneratorFactory" />
     <bean class="io.cattle.platform.resource.pool.port.HostPortGeneratorFactory" />
+    <bean class="io.cattle.platform.resource.pool.port.EnvironmentPortGeneratorFactory" />
 
 </beans>

--- a/resources/content/schema/base/project.json
+++ b/resources/content/schema/base/project.json
@@ -61,6 +61,14 @@
       "attributes" : {
         "scheduleUpdate" : true
       }
+    },
+    "servicesPortRange": {
+        "type" : "string",
+        "default" : "49153-65535",
+        "nullable" : true,
+        "attributes" : {
+        "scheduleUpdate" : true
+      }
     }
   }
 }

--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -17,6 +17,7 @@
         ".*\\.uuid" : "r",
 
         "account": "r",
+        "portRange": "cru",
 
         "apiKey" : "crud",
         "apiKey.publicValue" : "r",
@@ -262,6 +263,7 @@
         "project.members" : "cr",
         "project.swarm" : "cru",
         "project.kubernetes" : "cru",
+        "project.servicesPortRange": "cru",
 
         "projectMember" : "cr",
         "projectMember.accountId" : "",

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -498,6 +498,7 @@ def test_project_auth(admin_user_client, user_client, project_client):
         'members': 'cr',
         'swarm': 'cru',
         'kubernetes': 'cru',
+        'servicesPortRange': 'cru',
     })
 
     auth_check(user_client.schema, 'project', 'crud', {
@@ -508,6 +509,7 @@ def test_project_auth(admin_user_client, user_client, project_client):
         'members': 'cr',
         'swarm': 'cru',
         'kubernetes': 'cru',
+        'servicesPortRange': 'cru',
     })
 
     auth_check(project_client.schema, 'project', 'r', {
@@ -518,6 +520,7 @@ def test_project_auth(admin_user_client, user_client, project_client):
         'members': 'r',
         'swarm': 'r',
         'kubernetes': 'r',
+        'servicesPortRange': 'r',
     })
 
 

--- a/tests/integration/cattletest/core/test_svc_api_validation.py
+++ b/tests/integration/cattletest/core/test_svc_api_validation.py
@@ -1,0 +1,221 @@
+from common_fixtures import *  # NOQA
+from cattle import ApiError
+
+
+def _create_stack(client):
+    env = client.create_environment(name=random_str())
+    env = client.wait_success(env)
+    assert env.state == "active"
+    return env
+
+
+def test_create_duplicated_services(client, context):
+    env = _create_stack(client)
+
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": image_uuid}
+    service_name = random_str()
+    service1 = client.create_service(name=service_name,
+                                     environmentId=env.id,
+                                     launchConfig=launch_config)
+    client.wait_success(service1)
+
+    with pytest.raises(ApiError) as e:
+        client.create_service(name=service_name,
+                              environmentId=env.id,
+                              launchConfig=launch_config)
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'NotUnique'
+    assert e.value.error.fieldName == 'name'
+
+    with pytest.raises(ApiError) as e:
+        client.create_externalService(name=service_name,
+                                      environmentId=env.id,
+                                      launchConfig=launch_config,
+                                      externalIpAddresses=["72.22.16.5"])
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'NotUnique'
+    assert e.value.error.fieldName == 'name'
+
+    with pytest.raises(ApiError) as e:
+        client.create_dnsService(name=service_name,
+                                 environmentId=env.id)
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'NotUnique'
+    assert e.value.error.fieldName == 'name'
+
+    # try to update the service with duplicated service name
+    service = client.create_service(name=random_str(),
+                                    environmentId=env.id,
+                                    launchConfig=launch_config)
+    service = client.wait_success(service)
+    with pytest.raises(ApiError) as e:
+        client.update(service, name=service_name)
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'NotUnique'
+    assert e.value.error.fieldName == 'name'
+
+    # remove the service and try to re-use its name
+    client.wait_success(service1.remove())
+    client.create_service(name=service_name,
+                          environmentId=env.id,
+                          launchConfig=launch_config)
+
+
+def test_external_service_w_hostname(client, context):
+    env = _create_stack(client)
+    # try to create external service with both hostname externalips
+    with pytest.raises(ApiError) as e:
+        ips = ["72.22.16.5", '192.168.0.10']
+        client.create_externalService(name=random_str(),
+                                      environmentId=env.id,
+                                      hostname="a.com",
+                                      externalIpAddresses=ips)
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'InvalidOption'
+
+
+def test_circular_refs(client, context):
+    env = _create_stack(client)
+
+    # test direct circular ref
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": image_uuid,
+                     "dataVolumesFromLaunchConfigs": ['secondary']}
+
+    secondary_lc = {"imageUuid": image_uuid, "name": "secondary",
+                    "dataVolumesFromLaunchConfigs": ['primary']}
+
+    with pytest.raises(ApiError) as e:
+        client.create_service(name="primary",
+                              environmentId=env.id,
+                              launchConfig=launch_config,
+                              secondaryLaunchConfigs=[secondary_lc])
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'InvalidReference'
+
+    # test indirect circular ref
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": image_uuid,
+                     "dataVolumesFromLaunchConfigs": ['secondary1']}
+
+    s_lc1 = {"imageUuid": image_uuid, "name": "secondary1",
+             "dataVolumesFromLaunchConfigs": ['secondary2']}
+
+    s_lc2 = {"imageUuid": image_uuid, "name": "secondary2",
+             "dataVolumesFromLaunchConfigs": ['primary']}
+
+    with pytest.raises(ApiError) as e:
+        client.create_service(name="primary",
+                              environmentId=env.id,
+                              launchConfig=launch_config,
+                              secondaryLaunchConfigs=[s_lc1, s_lc2])
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'InvalidReference'
+
+
+def test_validate_image(client, context):
+    env = _create_stack(client)
+
+    # 1. invalide image in primary config
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": "ubuntu:14:04"}
+
+    secondary_lc = {"imageUuid": image_uuid, "name": "secondary"}
+
+    with pytest.raises(ApiError) as e:
+        client.create_service(name=random_str(),
+                              environmentId=env.id,
+                              launchConfig=launch_config,
+                              secondaryLaunchConfigs=[secondary_lc])
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'InvalidReference'
+    assert e.value.error.fieldName == 'imageUuid'
+
+    # 2. invalide image in secondary config
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": image_uuid}
+
+    secondary_lc = {"imageUuid": "ubuntu:14:04", "name": "secondary"}
+
+    with pytest.raises(ApiError) as e:
+        client.create_service(name=random_str(),
+                              environmentId=env.id,
+                              launchConfig=launch_config,
+                              secondaryLaunchConfigs=[secondary_lc])
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'InvalidReference'
+    assert e.value.error.fieldName == 'imageUuid'
+
+
+def test_vip_requested_ip(client, context):
+    env = _create_stack(client)
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": image_uuid}
+    # vip out of the range
+    with pytest.raises(ApiError) as e:
+        vip = "169.255.65.30"
+        client.create_service(name=random_str(),
+                              environmentId=env.id,
+                              launchConfig=launch_config,
+                              vip=vip)
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'InvalidOption'
+
+
+def test_add_svc_to_removed_stack(client, context):
+    env = _create_stack(client)
+
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": image_uuid}
+
+    client.create_service(name=random_str(),
+                          environmentId=env.id,
+                          launchConfig=launch_config)
+
+    client.create_service(name=random_str(),
+                          environmentId=env.id,
+                          launchConfig=launch_config)
+
+    env.remove()
+
+    with pytest.raises(ApiError) as e:
+        client.create_service(name=random_str(),
+                              environmentId=env.id,
+                              launchConfig=launch_config)
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'InvalidState'
+    assert e.value.error.fieldName == 'environment'
+
+    with pytest.raises(ApiError) as e:
+        client.create_service(name=random_str(),
+                              environmentId=env.id,
+                              launchConfig=launch_config)
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'InvalidState'
+    assert e.value.error.fieldName == 'environment'
+
+
+def test_validate_launch_config_name(client, context):
+    env = _create_stack(client)
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": image_uuid}
+    svc_name = random_str()
+    service = client.create_service(name=svc_name,
+                                    environmentId=env.id,
+                                    launchConfig=launch_config)
+
+    client.wait_success(service)
+
+    launch_config = {"imageUuid": image_uuid}
+
+    secondary_lc = {"imageUuid": image_uuid,
+                    "name": svc_name}
+
+    with pytest.raises(ApiError) as e:
+        client.create_service(name=random_str(),
+                              environmentId=env.id,
+                              launchConfig=launch_config,
+                              secondaryLaunchConfigs=[secondary_lc])
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'NotUnique'

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -1,5 +1,4 @@
 from common_fixtures import *  # NOQA
-from cattle import ApiError
 import yaml
 from netaddr import IPNetwork, IPAddress
 
@@ -399,39 +398,6 @@ def test_remove_inactive_service(client, context):
     _validate_compose_instance_removed(client, service, env)
 
 
-def test_upgrade_env(client):
-    env = client.create_environment(name='env-' + random_str())
-    env = client.wait_success(env)
-    assert env.state == 'active'
-
-    env = env.upgrade()
-    assert env.state == 'upgrading'
-
-    env = client.wait_success(env)
-    assert env.state == 'upgraded'
-
-
-def test_upgrade_rollback_env(client):
-    env = client.create_environment(name='env-' + random_str())
-    env = client.wait_success(env)
-
-    assert env.state == 'active'
-    assert 'upgrade' in env
-
-    env = env.upgrade()
-    assert env.state == 'upgrading'
-
-    env = client.wait_success(env)
-    assert env.state == 'upgraded'
-    assert 'rollback' in env
-
-    env = env.rollback()
-    assert env.state == 'rolling-back'
-
-    env = client.wait_success(env)
-    assert env.state == 'active'
-
-
 def test_remove_environment(client, context):
     env = _create_stack(client)
 
@@ -469,156 +435,6 @@ def test_remove_environment(client, context):
     wait_for_condition(
         client, service, _resource_is_removed,
         lambda x: 'State is: ' + x.state)
-
-
-def test_create_duplicated_services(client, context):
-    env = _create_stack(client)
-
-    image_uuid = context.image_uuid
-    launch_config = {"imageUuid": image_uuid}
-    service_name = random_str()
-    service1 = client.create_service(name=service_name,
-                                     environmentId=env.id,
-                                     launchConfig=launch_config)
-    client.wait_success(service1)
-
-    with pytest.raises(ApiError) as e:
-        client.create_service(name=service_name,
-                              environmentId=env.id,
-                              launchConfig=launch_config)
-    assert e.value.error.status == 422
-    assert e.value.error.code == 'NotUnique'
-    assert e.value.error.fieldName == 'name'
-
-    with pytest.raises(ApiError) as e:
-        client.create_externalService(name=service_name,
-                                      environmentId=env.id,
-                                      launchConfig=launch_config,
-                                      externalIpAddresses=["72.22.16.5"])
-    assert e.value.error.status == 422
-    assert e.value.error.code == 'NotUnique'
-    assert e.value.error.fieldName == 'name'
-
-    with pytest.raises(ApiError) as e:
-        client.create_dnsService(name=service_name,
-                                 environmentId=env.id)
-    assert e.value.error.status == 422
-    assert e.value.error.code == 'NotUnique'
-    assert e.value.error.fieldName == 'name'
-
-    # try to update the service with duplicated service name
-    service = client.create_service(name=random_str(),
-                                    environmentId=env.id,
-                                    launchConfig=launch_config)
-    service = client.wait_success(service)
-    with pytest.raises(ApiError) as e:
-        client.update(service, name=service_name)
-    assert e.value.error.status == 422
-    assert e.value.error.code == 'NotUnique'
-    assert e.value.error.fieldName == 'name'
-
-    # remove the service and try to re-use its name
-    client.wait_success(service1.remove())
-    client.create_service(name=service_name,
-                          environmentId=env.id,
-                          launchConfig=launch_config)
-
-
-def test_service_add_remove_service_link(client, context):
-    env = _create_stack(client)
-
-    image_uuid = context.image_uuid
-    launch_config = {"imageUuid": image_uuid}
-
-    service1 = client.create_service(name=random_str(),
-                                     environmentId=env.id,
-                                     launchConfig=launch_config)
-    service1 = client.wait_success(service1)
-
-    service2 = client.create_service(name=random_str(),
-                                     environmentId=env.id,
-                                     launchConfig=launch_config)
-    service2 = client.wait_success(service2)
-
-    # link service2 to service1
-    service_link = {"serviceId": service2.id}
-    service1 = service1.addservicelink(serviceLink=service_link)
-    _validate_add_service_link(service1, service2, client)
-
-    # remove service link
-    service1 = service1.removeservicelink(serviceLink=service_link)
-    _validate_remove_service_link(service1, service2, client)
-
-    # validate adding link with the name
-    service_link = {"serviceId": service2.id, "name": 'myLink'}
-    service1 = service1.addservicelink(serviceLink=service_link)
-    service_maps = client. \
-        list_serviceConsumeMap(serviceId=service1.id,
-                               consumedServiceId=service2.id, name='mylink')
-    assert len(service_maps) == 1
-
-
-def test_link_service_twice(client, context):
-    env = _create_stack(client)
-
-    image_uuid = context.image_uuid
-    launch_config = {"imageUuid": image_uuid}
-
-    service1 = client.create_service(name=random_str(),
-                                     environmentId=env.id,
-                                     launchConfig=launch_config)
-    service1 = client.wait_success(service1)
-
-    service2 = client.create_service(name=random_str(),
-                                     environmentId=env.id,
-                                     launchConfig=launch_config)
-    service2 = client.wait_success(service2)
-
-    # link service2 to service1
-    service_link = {"serviceId": service2.id}
-    service1 = service1.addservicelink(serviceLink=service_link)
-    _validate_add_service_link(service1, service2, client)
-
-    # try to link again
-    with pytest.raises(ApiError) as e:
-        service1.addservicelink(serviceLink=service_link)
-
-    assert e.value.error.status == 422
-    assert e.value.error.code == 'NotUnique'
-    assert e.value.error.fieldName == 'serviceId'
-
-
-def test_links_after_service_remove(client, context):
-    env = _create_stack(client)
-
-    image_uuid = context.image_uuid
-    launch_config = {"imageUuid": image_uuid}
-    service1 = client.create_service(name=random_str(),
-                                     environmentId=env.id,
-                                     launchConfig=launch_config)
-    service1 = client.wait_success(service1)
-
-    service2 = client.create_service(name=random_str(),
-                                     environmentId=env.id,
-                                     launchConfig=launch_config)
-    service2 = client.wait_success(service2)
-
-    # link servic2 to service1
-    service_link = {"serviceId": service2.id}
-    service1 = service1.addservicelink(serviceLink=service_link)
-    _validate_add_service_link(service1, service2, client)
-
-    # link service1 to service2
-    service_link = {"serviceId": service1.id}
-    service2 = service2.addservicelink(serviceLink=service_link)
-    _validate_add_service_link(service2, service1, client)
-
-    # remove service1
-    service1 = client.wait_success(service1.remove())
-
-    _validate_remove_service_link(service1, service2, client)
-
-    _validate_remove_service_link(service2, service1, client)
 
 
 def test_link_volumes(client, context):
@@ -884,93 +700,6 @@ def test_validate_service_scaleup_scaledown(client, context):
     instance42 = _validate_compose_instance_start(client, service, env, "4")
     assert instance42.createIndex > instance41.createIndex
     assert service.createIndex == instance42.createIndex
-
-
-def test_link_services_from_diff_env(client, context):
-    env1 = _create_stack(client)
-
-    image_uuid = context.image_uuid
-    launch_config = {"imageUuid": image_uuid}
-
-    service1 = client.create_service(name=random_str(),
-                                     environmentId=env1.id,
-                                     launchConfig=launch_config)
-    service1 = client.wait_success(service1)
-
-    env2 = _create_stack(client)
-    service2 = client.create_service(name=random_str(),
-                                     environmentId=env2.id,
-                                     launchConfig=launch_config)
-    service2 = client.wait_success(service2)
-
-    # try to link - should work
-    service_link = {"serviceId": service2.id}
-    service1.addservicelink(serviceLink=service_link)
-    _validate_add_service_link(service1, service2, client)
-
-
-def test_set_service_links(client, context):
-    env1 = _create_stack(client)
-
-    image_uuid = context.image_uuid
-    launch_config = {"imageUuid": image_uuid}
-
-    service1 = client.create_service(name=random_str(),
-                                     environmentId=env1.id,
-                                     launchConfig=launch_config)
-    service1 = client.wait_success(service1)
-
-    service2 = client.create_service(name=random_str(),
-                                     environmentId=env1.id,
-                                     launchConfig=launch_config)
-    service2 = client.wait_success(service2)
-
-    service3 = client.create_service(name=random_str(),
-                                     environmentId=env1.id,
-                                     launchConfig=launch_config)
-    service3 = client.wait_success(service3)
-
-    # set service2, service3 links for service1
-    service_link1 = {"serviceId": service2.id, "name": "link1"}
-    service_link2 = {"serviceId": service3.id, "name": "link2"}
-    service1 = service1. \
-        setservicelinks(serviceLinks=[service_link1, service_link2])
-    _validate_add_service_link(service1, service2, client, "link1")
-    _validate_add_service_link(service1, service3, client, "link2")
-
-    # update the link with new name
-    service_link1 = {"serviceId": service2.id, "name": "link3"}
-    service_link2 = {"serviceId": service3.id, "name": "link4"}
-    service1 = service1. \
-        setservicelinks(serviceLinks=[service_link1, service_link2])
-    _validate_remove_service_link(service1, service2, client, "link1")
-    _validate_remove_service_link(service1, service3, client, "link2")
-    _validate_add_service_link(service1, service2, client, "link3")
-    _validate_add_service_link(service1, service3, client, "link4")
-
-    # set service2 links for service1
-    service_link = {"serviceId": service2.id}
-    service1 = service1. \
-        setservicelinks(serviceLinks=[service_link])
-    _validate_remove_service_link(service1, service3, client, "link4")
-
-    # set empty service link set
-    service1 = service1.setservicelinks(serviceLinks=[])
-    _validate_remove_service_link(service1, service2, client, "link3")
-
-    # try to link to the service from diff environment - should work
-    env2 = _create_stack(client)
-
-    service4 = client.create_service(name=random_str(),
-                                     environmentId=env2.id,
-                                     launchConfig=launch_config)
-    service4 = client.wait_success(service4)
-
-    service_link = {"serviceId": service4.id}
-    service1.setservicelinks(serviceLinks=[service_link])
-
-    env1.remove()
-    env2.remove()
 
 
 def _instance_remove(instance, client):
@@ -1491,17 +1220,6 @@ def test_external_service_w_hostname(client, context):
     service2 = client.wait_success(service2.remove())
     assert service2.state == "removed"
 
-    # try to create external service with both hostname externalips
-    with pytest.raises(ApiError) as e:
-        ips = ["72.22.16.5", '192.168.0.10']
-        client.create_externalService(name=random_str(),
-                                      environmentId=env.id,
-                                      launchConfig=launch_config,
-                                      hostname="a.com",
-                                      externalIpAddresses=ips)
-    assert e.value.error.status == 422
-    assert e.value.error.code == 'InvalidOption'
-
 
 def test_service_spread_deployment(super_client, new_context):
     client = new_context.client
@@ -1696,55 +1414,6 @@ def test_global_add_host(new_context):
     service.deactivate()
 
 
-def test_dns_service(client, context):
-    env = _create_stack(client)
-    # create 1 app service, 1 dns service and 2 web services
-    # app service would link to dns, and dns to the web services
-    image_uuid = context.image_uuid
-    launch_config = {"imageUuid": image_uuid}
-
-    web1 = client.create_service(name=random_str(),
-                                 environmentId=env.id,
-                                 launchConfig=launch_config)
-    web1 = client.wait_success(web1)
-
-    web2 = client.create_service(name=random_str(),
-                                 environmentId=env.id,
-                                 launchConfig=launch_config)
-    web2 = client.wait_success(web2)
-
-    app = client.create_service(name=random_str(),
-                                environmentId=env.id,
-                                launchConfig=launch_config)
-    app = client.wait_success(app)
-
-    dns = client.create_dnsService(name='tata',
-                                   environmentId=env.id)
-    dns = client.wait_success(dns)
-
-    env.activateservices()
-    web1 = client.wait_success(web1, 120)
-    web2 = client.wait_success(web2)
-    app = client.wait_success(app)
-    dns = client.wait_success(dns)
-    assert web1.state == 'active'
-    assert web2.state == 'active'
-    assert app.state == 'active'
-    assert dns.state == 'active'
-
-    service_link = {"serviceId": web1.id}
-    dns = app.addservicelink(serviceLink=service_link)
-    _validate_add_service_link(dns, web1, client)
-
-    service_link = {"serviceId": web2.id}
-    dns = app.addservicelink(serviceLink=service_link)
-    _validate_add_service_link(dns, web2, client)
-
-    service_link = {"serviceId": dns.id}
-    app = app.addservicelink(serviceLink=service_link)
-    _validate_add_service_link(app, dns, client)
-
-
 def test_svc_container_reg_cred_and_image(super_client, client):
     server = 'server{0}.io'.format(random_num())
     registry = client.create_registry(serverAddress=server,
@@ -1819,45 +1488,6 @@ def test_network_from_service(client, context):
     assert s12_container.networkMode == 'container'
     assert s21_container.networkMode == 'managed'
     assert s22_container.networkMode == 'managed'
-
-
-def test_circular_refs(client, context):
-    env = _create_stack(client)
-
-    # test direct circular ref
-    image_uuid = context.image_uuid
-    launch_config = {"imageUuid": image_uuid,
-                     "dataVolumesFromLaunchConfigs": ['secondary']}
-
-    secondary_lc = {"imageUuid": image_uuid, "name": "secondary",
-                    "dataVolumesFromLaunchConfigs": ['primary']}
-
-    with pytest.raises(ApiError) as e:
-        client.create_service(name="primary",
-                              environmentId=env.id,
-                              launchConfig=launch_config,
-                              secondaryLaunchConfigs=[secondary_lc])
-    assert e.value.error.status == 422
-    assert e.value.error.code == 'InvalidReference'
-
-    # test indirect circular ref
-    image_uuid = context.image_uuid
-    launch_config = {"imageUuid": image_uuid,
-                     "dataVolumesFromLaunchConfigs": ['secondary1']}
-
-    s_lc1 = {"imageUuid": image_uuid, "name": "secondary1",
-             "dataVolumesFromLaunchConfigs": ['secondary2']}
-
-    s_lc2 = {"imageUuid": image_uuid, "name": "secondary2",
-             "dataVolumesFromLaunchConfigs": ['primary']}
-
-    with pytest.raises(ApiError) as e:
-        client.create_service(name="primary",
-                              environmentId=env.id,
-                              launchConfig=launch_config,
-                              secondaryLaunchConfigs=[s_lc1, s_lc2])
-    assert e.value.error.status == 422
-    assert e.value.error.code == 'InvalidReference'
 
 
 def _wait_compose_instance_start(client, service, env, number, timeout=30):
@@ -2151,105 +1781,6 @@ def test_host_delete_reconcile_service(super_client, new_context):
     service = client.wait_success(service.deactivate(), 120)
 
 
-def test_service_link_emu_docker_link(super_client, client, context):
-    env = _create_stack(client)
-
-    dns = client.create_dns_service(name='dns', environmentId=env.id)
-
-    server = client.create_service(name='server', launchConfig={
-        'imageUuid': context.image_uuid
-    }, environmentId=env.id)
-
-    server2 = client.create_service(name='server2', launchConfig={
-        'imageUuid': context.image_uuid
-    }, environmentId=env.id)
-
-    service = client.create_service(name='client', launchConfig={
-        'imageUuid': context.image_uuid
-    }, environmentId=env.id)
-
-    server3 = client.create_service(name='server3', launchConfig={
-        'imageUuid': context.image_uuid
-    }, environmentId=env.id)
-
-    server4 = client.create_service(name='server4', launchConfig={
-        'imageUuid': context.image_uuid
-    }, environmentId=env.id)
-
-    service_link1 = {"serviceId": dns.id, "name": "dns"}
-    service_link2 = {"serviceId": server.id, "name": "other"}
-    service_link3 = {"serviceId": server2.id, "name": "server2"}
-    service_link4 = {"serviceId": server3.id}
-    service_link5 = {"serviceId": server4.id, "name": ""}
-    service. \
-        setservicelinks(serviceLinks=[service_link1,
-                                      service_link2, service_link3,
-                                      service_link4, service_link5])
-
-    dns = client.wait_success(dns)
-    assert dns.state == 'inactive'
-
-    server = client.wait_success(server)
-    assert server.state == 'inactive'
-
-    server2 = client.wait_success(server2)
-    assert server2.state == 'inactive'
-
-    service = client.wait_success(service)
-    assert service.state == 'inactive'
-
-    server3 = client.wait_success(server3)
-    assert server3.state == 'inactive'
-
-    server4 = client.wait_success(server4)
-    assert server4.state == 'inactive'
-
-    dns = client.wait_success(dns.activate())
-    assert dns.state == 'active'
-
-    server = client.wait_success(server.activate())
-    assert server.state == 'active'
-
-    server2 = client.wait_success(server2.activate())
-    assert server2.state == 'active'
-
-    server3 = client.wait_success(server3.activate())
-    assert server3.state == 'active'
-
-    server4 = client.wait_success(server4.activate())
-    assert server4.state == 'active'
-
-    service = client.wait_success(service.activate())
-    assert service.state == 'active'
-
-    instance = find_one(service.instances)
-    instance = super_client.reload(instance)
-
-    links = instance.instanceLinks()
-
-    assert len(links) == 4
-
-    for link in links:
-        map = link.serviceConsumeMap()
-        assert map.consumedServiceId in {server.id, server2.id,
-                                         server3.id, server4.id}
-        assert link.instanceId is not None
-        expose_map = link.targetInstance().serviceExposeMaps()[0]
-        if map.consumedServiceId == server.id:
-            assert link.linkName == 'other'
-            assert expose_map.serviceId == server.id
-            assert expose_map.managed == 1
-        elif map.consumedServiceId == server2.id:
-            assert link.linkName == 'server2'
-            assert expose_map.serviceId == server2.id
-        elif map.consumedServiceId == server3.id:
-            assert link.linkName == 'server3'
-            assert expose_map.serviceId == server3.id
-        elif map.consumedServiceId == server4.id:
-            assert link.linkName == 'server4'
-            assert expose_map.serviceId == server4.id
-
-
 def test_export_config(client, context):
     env = _create_stack(client)
 
@@ -2284,40 +1815,6 @@ def test_export_config(client, context):
     metadata = {"$$bar": {"metadata": [updated]}}
     assert rancher_yml[service.name]['metadata'] is not None
     assert rancher_yml[service.name]['metadata'] == metadata
-
-
-def test_validate_image(client, context):
-    env = _create_stack(client)
-
-    # 1. invalide image in primary config
-    image_uuid = context.image_uuid
-    launch_config = {"imageUuid": "ubuntu:14:04"}
-
-    secondary_lc = {"imageUuid": image_uuid, "name": "secondary"}
-
-    with pytest.raises(ApiError) as e:
-        client.create_service(name=random_str(),
-                              environmentId=env.id,
-                              launchConfig=launch_config,
-                              secondaryLaunchConfigs=[secondary_lc])
-    assert e.value.error.status == 422
-    assert e.value.error.code == 'InvalidReference'
-    assert e.value.error.fieldName == 'imageUuid'
-
-    # 2. invalide image in secondary config
-    image_uuid = context.image_uuid
-    launch_config = {"imageUuid": image_uuid}
-
-    secondary_lc = {"imageUuid": "ubuntu:14:04", "name": "secondary"}
-
-    with pytest.raises(ApiError) as e:
-        client.create_service(name=random_str(),
-                              environmentId=env.id,
-                              launchConfig=launch_config,
-                              secondaryLaunchConfigs=[secondary_lc])
-    assert e.value.error.status == 422
-    assert e.value.error.code == 'InvalidReference'
-    assert e.value.error.fieldName == 'imageUuid'
 
 
 def test_validate_create_only_containers(client, context):
@@ -2633,44 +2130,6 @@ def test_vip_requested_ip(client, context):
     assert service.state == "inactive"
     assert service.vip is not None
     assert service.vip == vip
-    # vip out of the range
-    with pytest.raises(ApiError) as e:
-        vip = "169.255.65.30"
-        client.create_service(name=random_str(),
-                              environmentId=env.id,
-                              launchConfig=launch_config,
-                              vip=vip)
-    assert e.value.error.status == 422
-    assert e.value.error.code == 'InvalidOption'
-
-
-def test_external_svc_healthcheck(client, context):
-    env = _create_stack(client)
-
-    # test that external service was set with healtcheck
-    health_check = {"name": "check1", "responseTimeout": 3,
-                    "interval": 4, "healthyThreshold": 5,
-                    "unhealthyThreshold": 6, "requestLine": "index.html",
-                    "port": 200}
-    ips = ["72.22.16.5", '192.168.0.10']
-    service = client.create_externalService(name=random_str(),
-                                            environmentId=env.id,
-                                            externalIpAddresses=ips,
-                                            healthCheck=health_check)
-    service = client.wait_success(service)
-    assert service.healthCheck.name == "check1"
-    assert service.healthCheck.responseTimeout == 3
-    assert service.healthCheck.interval == 4
-    assert service.healthCheck.healthyThreshold == 5
-    assert service.healthCheck.unhealthyThreshold == 6
-    assert service.healthCheck.requestLine == "index.html"
-    assert service.healthCheck.port == 200
-
-    # test rancher-compose export
-    compose_config = env.exportconfig()
-    assert compose_config is not None
-    document = yaml.load(compose_config.rancherComposeConfig)
-    assert document[service.name]['health_check'] is not None
 
 
 def test_validate_scaledown_updating(client, context):
@@ -2770,94 +2229,10 @@ def test_metadata(client, context, super_client):
     assert service.metadata == metadata
 
 
-def test_healtcheck(client, context, super_client):
-    stack = _create_stack(client)
-    image_uuid = context.image_uuid
-    register_simulated_host(context)
-
-    # test that external service was set with healtcheck
-    health_check = {"name": "check1", "responseTimeout": 3,
-                    "interval": 4, "healthyThreshold": 5,
-                    "unhealthyThreshold": 6, "requestLine": "index.html",
-                    "port": 200}
-    launch_config = {"imageUuid": image_uuid, "healthCheck": health_check}
-    service = client.create_service(name=random_str(),
-                                    environmentId=stack.id,
-                                    launchConfig=launch_config)
-    service = client.wait_success(service)
-    service = client.wait_success(service.activate(), 120)
-    c = _wait_for_compose_instance_start(client, service, stack, "1")
-    c_host_id = super_client.reload(c).instanceHostMaps()[0].hostId
-    health_c = super_client. \
-        list_healthcheckInstance(accountId=service.accountId, instanceId=c.id)
-    assert len(health_c) > 0
-    health_id = health_c[0].id
-
-    def validate_container_host(host_maps):
-        for host_map in host_maps:
-            assert host_map.hostId != c_host_id
-
-    host_maps = _wait_health_host_count(super_client, health_id, 3)
-    validate_container_host(host_maps)
-
-    # reactivate the service and
-    # verify that its still has less than 3 healthchecks
-    service = client.wait_success(service.deactivate(), 120)
-    service = client.wait_success(service.activate(), 120)
-
-    host_maps = _wait_health_host_count(super_client, health_id, 3)
-    validate_container_host(host_maps)
-
-    # reactivate the service, add 3 more hosts and verify
-    # that healthcheckers number was completed to 3, excluding
-    # container's host
-    service = client.wait_success(service.deactivate(), 120)
-    register_simulated_host(context)
-    register_simulated_host(context)
-    register_simulated_host(context)
-    client.wait_success(service.activate(), 120)
-
-    host_maps = _wait_health_host_count(super_client, health_id, 3)
-    validate_container_host(host_maps)
-
-
 def test_env_external_id(client):
     env = client.create_environment(name='env-' + random_str(),
                                     externalId='something')
     assert env.externalId == 'something'
-
-
-def test_add_svc_to_removed_stack(client, context):
-    env = _create_stack(client)
-
-    image_uuid = context.image_uuid
-    launch_config = {"imageUuid": image_uuid}
-
-    client.create_service(name=random_str(),
-                          environmentId=env.id,
-                          launchConfig=launch_config)
-
-    client.create_service(name=random_str(),
-                          environmentId=env.id,
-                          launchConfig=launch_config)
-
-    env.remove()
-
-    with pytest.raises(ApiError) as e:
-        client.create_service(name=random_str(),
-                              environmentId=env.id,
-                              launchConfig=launch_config)
-    assert e.value.error.status == 422
-    assert e.value.error.code == 'InvalidState'
-    assert e.value.error.fieldName == 'environment'
-
-    with pytest.raises(ApiError) as e:
-        client.create_service(name=random_str(),
-                              environmentId=env.id,
-                              launchConfig=launch_config)
-    assert e.value.error.status == 422
-    assert e.value.error.code == 'InvalidState'
-    assert e.value.error.fieldName == 'environment'
 
 
 def test_sidekick_labels_merge(new_context):
@@ -2976,6 +2351,56 @@ def test_public_endpoints(new_context):
     wait_for(lambda: len(client.reload(host2).publicEndpoints) == 1)
 
 
+def test_random_ports(new_context):
+    client = new_context.client
+    user_client = new_context.user_client
+    new_context.host
+    register_simulated_host(new_context)
+    env = _create_stack(client)
+
+    image_uuid = new_context.image_uuid
+    launch_config = {"imageUuid": image_uuid, "ports": ['6666', '7775']}
+    svc = client.create_service(name=random_str(),
+                                environmentId=env.id,
+                                launchConfig=launch_config,
+                                scale=2)
+    svc = client.wait_success(svc)
+    assert svc.state == "inactive"
+    svc = client.wait_success(svc.activate())
+    assert svc.state == "active"
+    c1 = _wait_for_compose_instance_start(client, svc, env, "1")
+    c2 = _wait_for_compose_instance_start(client, svc, env, "1")
+    port11 = c1.ports_link()[0]
+    port12 = c1.ports_link()[1]
+    port21 = c2.ports_link()[0]
+    port22 = c2.ports_link()[1]
+    assert port11.publicPort is not None
+    assert port12.publicPort is not None
+    assert port21.publicPort is not None
+    assert port22.publicPort is not None
+    assert port11.publicPort != port12.publicPort
+    assert port11.publicPort == port21.publicPort
+    assert 49153 <= port11.publicPort <= 65535
+    assert 49153 <= port12.publicPort <= 65535
+    assert 49153 <= port21.publicPort <= 65535
+    assert 49153 <= port22.publicPort <= 65535
+
+    new_range = "65533-65535"
+    p = user_client.update(new_context.project,
+                           servicesPortRange="65533-65535")
+    p = user_client.wait_success(p)
+    assert p.servicesPortRange == new_range
+    svc = client.create_service(name=random_str(),
+                                environmentId=env.id,
+                                launchConfig=launch_config)
+    svc = client.wait_success(svc)
+    svc = client.wait_success(svc.activate())
+    c = _wait_for_compose_instance_start(client, svc, env, "1")
+    port = c.ports_link()[0]
+    assert port.publicPort is not None
+    assert 65533 <= port.publicPort <= 65535
+
+
 def test_update_port_endpoint(new_context):
     client = new_context.client
     host1 = new_context.host
@@ -3030,74 +2455,6 @@ def test_update_port_endpoint(new_context):
     _validate_endpoint(endpoints, port2, hosts[0], svc)
 
 
-def test_set_service_links_duplicated_service(client, context):
-    env1 = _create_stack(client)
-
-    image_uuid = context.image_uuid
-    launch_config = {"imageUuid": image_uuid}
-
-    service1 = client.create_service(name=random_str(),
-                                     environmentId=env1.id,
-                                     launchConfig=launch_config)
-    service1 = client.wait_success(service1)
-
-    service2 = client.create_service(name=random_str(),
-                                     environmentId=env1.id,
-                                     launchConfig=launch_config)
-    service2 = client.wait_success(service2)
-
-    # set service links having same service id, diff name
-    service_link1 = {"serviceId": service2.id, "name": "link1"}
-    service_link2 = {"serviceId": service2.id, "name": "link2"}
-
-    service1 = service1. \
-        setservicelinks(serviceLinks=[service_link1, service_link2])
-    _validate_add_service_link(service1, service2, client, "link1")
-    _validate_add_service_link(service1, service2, client, "link2")
-
-    with pytest.raises(ApiError) as e:
-        service1. \
-            setservicelinks(serviceLinks=[service_link1, service_link1])
-    assert e.value.error.status == 422
-    assert e.value.error.code == 'NotUnique'
-
-
-def test_validate_launch_config_name(client, context):
-    env = _create_stack(client)
-    image_uuid = context.image_uuid
-    launch_config = {"imageUuid": image_uuid}
-    svc_name = random_str()
-    service = client.create_service(name=svc_name,
-                                    environmentId=env.id,
-                                    launchConfig=launch_config)
-
-    client.wait_success(service)
-
-    launch_config = {"imageUuid": image_uuid}
-
-    secondary_lc = {"imageUuid": image_uuid,
-                    "name": svc_name}
-
-    with pytest.raises(ApiError) as e:
-        client.create_service(name=random_str(),
-                              environmentId=env.id,
-                              launchConfig=launch_config,
-                              secondaryLaunchConfigs=[secondary_lc])
-    assert e.value.error.status == 422
-    assert e.value.error.code == 'NotUnique'
-
-
-def _wait_health_host_count(super_client, health_id, count):
-    def active_len():
-        match = super_client. \
-            list_healthcheckInstanceHostMap(healthcheckInstanceId=health_id,
-                                            state='active')
-        if len(match) <= count:
-            return match
-
-    return wait_for(active_len)
-
-
 def _get_instance_for_service(super_client, serviceId):
     instances = []
     instance_service_maps = super_client. \
@@ -3113,48 +2470,6 @@ def _resource_is_stopped(resource):
 
 def _resource_is_running(resource):
     return resource.state == 'running'
-
-
-def _validate_add_service_link(service,
-                               consumedService, client, link_name=None):
-    if link_name is None:
-        service_maps = client. \
-            list_serviceConsumeMap(serviceId=service.id,
-                                   consumedServiceId=consumedService.id)
-    else:
-        service_maps = client. \
-            list_serviceConsumeMap(serviceId=service.id,
-                                   consumedServiceId=consumedService.id,
-                                   name=link_name)
-
-    assert len(service_maps) == 1
-    if link_name is not None:
-        assert service_maps[0].name is not None
-
-    service_map = service_maps[0]
-    wait_for_condition(
-        client, service_map, _resource_is_active,
-        lambda x: 'State is: ' + x.state)
-
-
-def _validate_remove_service_link(service,
-                                  consumedService, client, link_name=None):
-    if link_name is None:
-        service_maps = client. \
-            list_serviceConsumeMap(serviceId=service.id,
-                                   consumedServiceId=consumedService.id)
-    else:
-        service_maps = client. \
-            list_serviceConsumeMap(serviceId=service.id,
-                                   consumedServiceId=consumedService.id,
-                                   name=link_name)
-
-    assert len(service_maps) == 1
-
-    service_map = service_maps[0]
-    wait_for_condition(
-        client, service_map, _resource_is_removed,
-        lambda x: 'State is: ' + x.state)
 
 
 def _resource_is_active(resource):

--- a/tests/integration/cattletest/core/test_svc_links.py
+++ b/tests/integration/cattletest/core/test_svc_links.py
@@ -1,0 +1,423 @@
+from common_fixtures import *  # NOQA
+from cattle import ApiError
+
+
+def _create_stack(client):
+    env = client.create_environment(name=random_str())
+    env = client.wait_success(env)
+    assert env.state == "active"
+    return env
+
+
+def test_service_add_remove_service_link(client, context):
+    env = _create_stack(client)
+
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": image_uuid}
+
+    service1 = client.create_service(name=random_str(),
+                                     environmentId=env.id,
+                                     launchConfig=launch_config)
+    service1 = client.wait_success(service1)
+
+    service2 = client.create_service(name=random_str(),
+                                     environmentId=env.id,
+                                     launchConfig=launch_config)
+    service2 = client.wait_success(service2)
+
+    # link service2 to service1
+    service_link = {"serviceId": service2.id}
+    service1 = service1.addservicelink(serviceLink=service_link)
+    _validate_add_service_link(service1, service2, client)
+
+    # remove service link
+    service1 = service1.removeservicelink(serviceLink=service_link)
+    _validate_remove_service_link(service1, service2, client)
+
+    # validate adding link with the name
+    service_link = {"serviceId": service2.id, "name": 'myLink'}
+    service1 = service1.addservicelink(serviceLink=service_link)
+    service_maps = client. \
+        list_serviceConsumeMap(serviceId=service1.id,
+                               consumedServiceId=service2.id, name='mylink')
+    assert len(service_maps) == 1
+
+
+def test_links_after_service_remove(client, context):
+    env = _create_stack(client)
+
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": image_uuid}
+    service1 = client.create_service(name=random_str(),
+                                     environmentId=env.id,
+                                     launchConfig=launch_config)
+    service1 = client.wait_success(service1)
+
+    service2 = client.create_service(name=random_str(),
+                                     environmentId=env.id,
+                                     launchConfig=launch_config)
+    service2 = client.wait_success(service2)
+
+    # link servic2 to service1
+    service_link = {"serviceId": service2.id}
+    service1 = service1.addservicelink(serviceLink=service_link)
+    _validate_add_service_link(service1, service2, client)
+
+    # link service1 to service2
+    service_link = {"serviceId": service1.id}
+    service2 = service2.addservicelink(serviceLink=service_link)
+    _validate_add_service_link(service2, service1, client)
+
+    # remove service1
+    service1 = client.wait_success(service1.remove())
+
+    _validate_remove_service_link(service1, service2, client)
+
+    _validate_remove_service_link(service2, service1, client)
+
+
+def test_link_services_from_diff_env(client, context):
+    env1 = _create_stack(client)
+
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": image_uuid}
+
+    service1 = client.create_service(name=random_str(),
+                                     environmentId=env1.id,
+                                     launchConfig=launch_config)
+    service1 = client.wait_success(service1)
+
+    env2 = _create_stack(client)
+    service2 = client.create_service(name=random_str(),
+                                     environmentId=env2.id,
+                                     launchConfig=launch_config)
+    service2 = client.wait_success(service2)
+
+    # try to link - should work
+    service_link = {"serviceId": service2.id}
+    service1.addservicelink(serviceLink=service_link)
+    _validate_add_service_link(service1, service2, client)
+
+
+def test_set_service_links(client, context):
+    env1 = _create_stack(client)
+
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": image_uuid}
+
+    service1 = client.create_service(name=random_str(),
+                                     environmentId=env1.id,
+                                     launchConfig=launch_config)
+    service1 = client.wait_success(service1)
+
+    service2 = client.create_service(name=random_str(),
+                                     environmentId=env1.id,
+                                     launchConfig=launch_config)
+    service2 = client.wait_success(service2)
+
+    service3 = client.create_service(name=random_str(),
+                                     environmentId=env1.id,
+                                     launchConfig=launch_config)
+    service3 = client.wait_success(service3)
+
+    # set service2, service3 links for service1
+    service_link1 = {"serviceId": service2.id, "name": "link1"}
+    service_link2 = {"serviceId": service3.id, "name": "link2"}
+    service1 = service1. \
+        setservicelinks(serviceLinks=[service_link1, service_link2])
+    _validate_add_service_link(service1, service2, client, "link1")
+    _validate_add_service_link(service1, service3, client, "link2")
+
+    # update the link with new name
+    service_link1 = {"serviceId": service2.id, "name": "link3"}
+    service_link2 = {"serviceId": service3.id, "name": "link4"}
+    service1 = service1. \
+        setservicelinks(serviceLinks=[service_link1, service_link2])
+    _validate_remove_service_link(service1, service2, client, "link1")
+    _validate_remove_service_link(service1, service3, client, "link2")
+    _validate_add_service_link(service1, service2, client, "link3")
+    _validate_add_service_link(service1, service3, client, "link4")
+
+    # set service2 links for service1
+    service_link = {"serviceId": service2.id}
+    service1 = service1. \
+        setservicelinks(serviceLinks=[service_link])
+    _validate_remove_service_link(service1, service3, client, "link4")
+
+    # set empty service link set
+    service1 = service1.setservicelinks(serviceLinks=[])
+    _validate_remove_service_link(service1, service2, client, "link3")
+
+    # try to link to the service from diff environment - should work
+    env2 = _create_stack(client)
+
+    service4 = client.create_service(name=random_str(),
+                                     environmentId=env2.id,
+                                     launchConfig=launch_config)
+    service4 = client.wait_success(service4)
+
+    service_link = {"serviceId": service4.id}
+    service1.setservicelinks(serviceLinks=[service_link])
+
+    env1.remove()
+    env2.remove()
+
+
+def test_link_service_twice(client, context):
+    env = _create_stack(client)
+
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": image_uuid}
+
+    service1 = client.create_service(name=random_str(),
+                                     environmentId=env.id,
+                                     launchConfig=launch_config)
+    service1 = client.wait_success(service1)
+
+    service2 = client.create_service(name=random_str(),
+                                     environmentId=env.id,
+                                     launchConfig=launch_config)
+    service2 = client.wait_success(service2)
+
+    # link service2 to service1
+    service_link = {"serviceId": service2.id}
+    service1 = service1.addservicelink(serviceLink=service_link)
+    _validate_add_service_link(service1, service2, client)
+
+    # try to link again
+    with pytest.raises(ApiError) as e:
+        service1.addservicelink(serviceLink=service_link)
+
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'NotUnique'
+    assert e.value.error.fieldName == 'serviceId'
+
+
+def test_dns_service(client, context):
+    env = _create_stack(client)
+    # create 1 app service, 1 dns service and 2 web services
+    # app service would link to dns, and dns to the web services
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": image_uuid}
+
+    web1 = client.create_service(name=random_str(),
+                                 environmentId=env.id,
+                                 launchConfig=launch_config)
+    web1 = client.wait_success(web1)
+
+    web2 = client.create_service(name=random_str(),
+                                 environmentId=env.id,
+                                 launchConfig=launch_config)
+    web2 = client.wait_success(web2)
+
+    app = client.create_service(name=random_str(),
+                                environmentId=env.id,
+                                launchConfig=launch_config)
+    app = client.wait_success(app)
+
+    dns = client.create_dnsService(name='tata',
+                                   environmentId=env.id)
+    dns = client.wait_success(dns)
+
+    env.activateservices()
+    web1 = client.wait_success(web1, 120)
+    web2 = client.wait_success(web2)
+    app = client.wait_success(app)
+    dns = client.wait_success(dns)
+    assert web1.state == 'active'
+    assert web2.state == 'active'
+    assert app.state == 'active'
+    assert dns.state == 'active'
+
+    service_link = {"serviceId": web1.id}
+    dns = app.addservicelink(serviceLink=service_link)
+    _validate_add_service_link(dns, web1, client)
+
+    service_link = {"serviceId": web2.id}
+    dns = app.addservicelink(serviceLink=service_link)
+    _validate_add_service_link(dns, web2, client)
+
+    service_link = {"serviceId": dns.id}
+    app = app.addservicelink(serviceLink=service_link)
+    _validate_add_service_link(app, dns, client)
+
+
+def test_service_link_emu_docker_link(super_client, client, context):
+    env = _create_stack(client)
+
+    dns = client.create_dns_service(name='dns', environmentId=env.id)
+
+    server = client.create_service(name='server', launchConfig={
+        'imageUuid': context.image_uuid
+    }, environmentId=env.id)
+
+    server2 = client.create_service(name='server2', launchConfig={
+        'imageUuid': context.image_uuid
+    }, environmentId=env.id)
+
+    service = client.create_service(name='client', launchConfig={
+        'imageUuid': context.image_uuid
+    }, environmentId=env.id)
+
+    server3 = client.create_service(name='server3', launchConfig={
+        'imageUuid': context.image_uuid
+    }, environmentId=env.id)
+
+    server4 = client.create_service(name='server4', launchConfig={
+        'imageUuid': context.image_uuid
+    }, environmentId=env.id)
+
+    service_link1 = {"serviceId": dns.id, "name": "dns"}
+    service_link2 = {"serviceId": server.id, "name": "other"}
+    service_link3 = {"serviceId": server2.id, "name": "server2"}
+    service_link4 = {"serviceId": server3.id}
+    service_link5 = {"serviceId": server4.id, "name": ""}
+    service. \
+        setservicelinks(serviceLinks=[service_link1,
+                                      service_link2, service_link3,
+                                      service_link4, service_link5])
+
+    dns = client.wait_success(dns)
+    assert dns.state == 'inactive'
+
+    server = client.wait_success(server)
+    assert server.state == 'inactive'
+
+    server2 = client.wait_success(server2)
+    assert server2.state == 'inactive'
+
+    service = client.wait_success(service)
+    assert service.state == 'inactive'
+
+    server3 = client.wait_success(server3)
+    assert server3.state == 'inactive'
+
+    server4 = client.wait_success(server4)
+    assert server4.state == 'inactive'
+
+    dns = client.wait_success(dns.activate())
+    assert dns.state == 'active'
+
+    server = client.wait_success(server.activate())
+    assert server.state == 'active'
+
+    server2 = client.wait_success(server2.activate())
+    assert server2.state == 'active'
+
+    server3 = client.wait_success(server3.activate())
+    assert server3.state == 'active'
+
+    server4 = client.wait_success(server4.activate())
+    assert server4.state == 'active'
+
+    service = client.wait_success(service.activate())
+    assert service.state == 'active'
+
+    instance = find_one(service.instances)
+    instance = super_client.reload(instance)
+
+    links = instance.instanceLinks()
+
+    assert len(links) == 4
+
+    for link in links:
+        map = link.serviceConsumeMap()
+        assert map.consumedServiceId in {server.id, server2.id,
+                                         server3.id, server4.id}
+        assert link.instanceId is not None
+        expose_map = link.targetInstance().serviceExposeMaps()[0]
+        if map.consumedServiceId == server.id:
+            assert link.linkName == 'other'
+            assert expose_map.serviceId == server.id
+            assert expose_map.managed == 1
+        elif map.consumedServiceId == server2.id:
+            assert link.linkName == 'server2'
+            assert expose_map.serviceId == server2.id
+        elif map.consumedServiceId == server3.id:
+            assert link.linkName == 'server3'
+            assert expose_map.serviceId == server3.id
+        elif map.consumedServiceId == server4.id:
+            assert link.linkName == 'server4'
+            assert expose_map.serviceId == server4.id
+
+
+def test_set_service_links_duplicated_service(client, context):
+    env1 = _create_stack(client)
+
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": image_uuid}
+
+    service1 = client.create_service(name=random_str(),
+                                     environmentId=env1.id,
+                                     launchConfig=launch_config)
+    service1 = client.wait_success(service1)
+
+    service2 = client.create_service(name=random_str(),
+                                     environmentId=env1.id,
+                                     launchConfig=launch_config)
+    service2 = client.wait_success(service2)
+
+    # set service links having same service id, diff name
+    service_link1 = {"serviceId": service2.id, "name": "link1"}
+    service_link2 = {"serviceId": service2.id, "name": "link2"}
+
+    service1 = service1. \
+        setservicelinks(serviceLinks=[service_link1, service_link2])
+    _validate_add_service_link(service1, service2, client, "link1")
+    _validate_add_service_link(service1, service2, client, "link2")
+
+    with pytest.raises(ApiError) as e:
+        service1. \
+            setservicelinks(serviceLinks=[service_link1, service_link1])
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'NotUnique'
+
+
+def _validate_add_service_link(service,
+                               consumedService, client, link_name=None):
+    if link_name is None:
+        service_maps = client. \
+            list_serviceConsumeMap(serviceId=service.id,
+                                   consumedServiceId=consumedService.id)
+    else:
+        service_maps = client. \
+            list_serviceConsumeMap(serviceId=service.id,
+                                   consumedServiceId=consumedService.id,
+                                   name=link_name)
+
+    assert len(service_maps) == 1
+    if link_name is not None:
+        assert service_maps[0].name is not None
+
+    service_map = service_maps[0]
+    wait_for_condition(
+        client, service_map, _resource_is_active,
+        lambda x: 'State is: ' + x.state)
+
+
+def _validate_remove_service_link(service,
+                                  consumedService, client, link_name=None):
+    if link_name is None:
+        service_maps = client. \
+            list_serviceConsumeMap(serviceId=service.id,
+                                   consumedServiceId=consumedService.id)
+    else:
+        service_maps = client. \
+            list_serviceConsumeMap(serviceId=service.id,
+                                   consumedServiceId=consumedService.id,
+                                   name=link_name)
+
+    assert len(service_maps) == 1
+
+    service_map = service_maps[0]
+    wait_for_condition(
+        client, service_map, _resource_is_removed,
+        lambda x: 'State is: ' + x.state)
+
+
+def _resource_is_active(resource):
+    return resource.state == 'active'
+
+
+def _resource_is_removed(resource):
+    return resource.state == 'removed'


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/2097

1) Port range is defined on per environment (project) basis. New API field is introduced for the project:

servicesPortRange (string, optional, default value "49153-65535", CRU permissions)

2) If service has a port defined as "80" or "80/tcp" (with no public port specified), public port will get automatically assigned to the port from environment.servicesPortRange

3) Port gets assigned to the service on its creation, and the assignment gets removed after service is removed. Once disassociated, the port can be used by other services.

Random port can't have duplicates among other ports generated in random manner.
We don't validate random port against public ports specified by the user explicitly. The assumption is that the servicesPortRange is reserved for random allocation, and user shouldn't specify ports from this range when creates service/standalone instance.

@ibuildthecloud @vincent99 please review

Also split test_svc_discovery test into smaller files