### PR TITLE
Port ranges bug fixes

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/addon/ServicesPortRange.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/addon/ServicesPortRange.java
@@ -1,0 +1,36 @@
+package io.cattle.platform.core.addon;
+
+import io.github.ibuildthecloud.gdapi.annotation.Field;
+import io.github.ibuildthecloud.gdapi.annotation.Type;
+
+@Type(list = false)
+public class ServicesPortRange {
+    Integer startPort;
+    Integer endPort;
+
+    @Field(min = 1, max = 65535, required = true)
+    public Integer getStartPort() {
+        return startPort;
+    }
+
+    public void setStartPort(Integer startPort) {
+        this.startPort = startPort;
+    }
+
+    @Field(min = 1, max = 65535, required = true)
+    public Integer getEndPort() {
+        return endPort;
+    }
+
+    public void setEndPort(Integer endPort) {
+        this.endPort = endPort;
+    }
+
+    public ServicesPortRange(Integer startPort, Integer endPort) {
+        this.startPort = startPort;
+        this.endPort = endPort;
+    }
+
+    public ServicesPortRange() {
+    }
+}

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/AccountConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/AccountConstants.java
@@ -1,9 +1,20 @@
 package io.cattle.platform.core.constants;
 
+import io.cattle.platform.archaius.util.ArchaiusUtil;
+import io.cattle.platform.core.addon.ServicesPortRange;
 import io.cattle.platform.core.model.Account;
 import io.cattle.platform.core.util.ConstantsUtils;
+import io.cattle.platform.core.util.PortRangeSpec;
+
+import com.netflix.config.DynamicStringProperty;
 
 public class AccountConstants {
+
+    /*
+     * Read from config file to support upgrade scenario when default port range is not set on account
+     */
+    private static final DynamicStringProperty ENV_PORT_RANGE = ArchaiusUtil
+            .getString("environment.services.port.range");
 
     public static final String REGISTERED_AGENT_KIND = "registeredAgent";
     public static final String AGENT_KIND = "agent";
@@ -27,4 +38,9 @@ public class AccountConstants {
     public static final String ACCOUNT_REMOVE = "account.remove";
 
     public static final String AUTH_TYPE = "authType";
+
+    public static ServicesPortRange getDefaultServicesPortRange() {
+        PortRangeSpec spec = new PortRangeSpec(ENV_PORT_RANGE.get());
+        return new ServicesPortRange(spec.getStartPort(), spec.getEndPort());
+    }
 }

--- a/code/iaas/resource-pool/src/main/java/io/cattle/platform/resource/pool/port/EnvironmentPortGeneratorFactory.java
+++ b/code/iaas/resource-pool/src/main/java/io/cattle/platform/resource/pool/port/EnvironmentPortGeneratorFactory.java
@@ -1,39 +1,32 @@
 package io.cattle.platform.resource.pool.port;
 
-import io.cattle.platform.archaius.util.ArchaiusUtil;
+import io.cattle.platform.core.addon.ServicesPortRange;
 import io.cattle.platform.core.constants.AccountConstants;
 import io.cattle.platform.core.model.Account;
-import io.cattle.platform.core.util.PortRangeSpec;
+import io.cattle.platform.json.JsonMapper;
 import io.cattle.platform.object.util.DataAccessor;
 import io.cattle.platform.resource.pool.PooledResourceItemGenerator;
 import io.cattle.platform.resource.pool.PooledResourceItemGeneratorFactory;
 import io.cattle.platform.resource.pool.impl.StringRangeGenerator;
 import io.cattle.platform.resource.pool.util.ResourcePoolConstants;
 
-import org.apache.commons.lang3.StringUtils;
-
-import com.netflix.config.DynamicStringProperty;
+import javax.inject.Inject;
 
 public class EnvironmentPortGeneratorFactory implements PooledResourceItemGeneratorFactory {
 
-    /*
-     * Read from config file to support upgrade scenario when default port range is not set on account
-     */
-    private static final DynamicStringProperty ENV_PORT_RANGE = ArchaiusUtil
-            .getString("environment.services.port.range");
+    @Inject
+    JsonMapper jsonMapper;
 
     @Override
     public PooledResourceItemGenerator getGenerator(Object pool, String qualifier) {
         if ((pool instanceof Account) && ResourcePoolConstants.ENVIRONMENT_PORT.equals(qualifier)) {
             Account env = (Account) pool;
-            PortRangeSpec spec = null;
-            String portRange = DataAccessor.fieldString(env, AccountConstants.FIELD_PORT_RANGE);
-            if (StringUtils.isEmpty(portRange)) {
-                spec = new PortRangeSpec(ENV_PORT_RANGE.get());
-            } else {
-                spec = new PortRangeSpec(portRange);
+            ServicesPortRange portRange = DataAccessor.field(env, AccountConstants.FIELD_PORT_RANGE, jsonMapper,
+                    ServicesPortRange.class);
+            if (portRange == null) {
+                portRange = AccountConstants.getDefaultServicesPortRange();
             }
-            return new StringRangeGenerator(String.valueOf(spec.getStartPort()), String.valueOf(spec.getEndPort()));
+            return new StringRangeGenerator(portRange.getStartPort().toString(), portRange.getEndPort().toString());
         }
         return null;
     }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceCreateValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceCreateValidationFilter.java
@@ -83,6 +83,7 @@ public class ServiceCreateValidationFilter extends AbstractDefaultResourceManage
         return super.create(type, request, next);
     }
 
+
     @SuppressWarnings("unchecked")
     public ApiRequest setHealthCheck(String type, ApiRequest request) {
         if (!type.equalsIgnoreCase(ServiceDiscoveryConstants.KIND.LOADBALANCERSERVICE.name())) {

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/core-model/spring-core-model-context.xml
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/core-model/spring-core-model-context.xml
@@ -34,6 +34,7 @@
                 <value>io.cattle.platform.core.addon.HaproxyConfig</value>
                 <value>io.cattle.platform.core.addon.RollingRestartStrategy</value>
                 <value>io.cattle.platform.core.addon.ServiceRestart</value>
+                <value>io.cattle.platform.core.addon.ServicesPortRange</value>
             </set>
         </property>
     </bean>

--- a/resources/content/schema/base/project.json
+++ b/resources/content/schema/base/project.json
@@ -63,8 +63,7 @@
       }
     },
     "servicesPortRange": {
-        "type" : "string",
-        "default" : "49153-65535",
+        "type" : "servicesPortRange",
         "nullable" : true,
         "attributes" : {
         "scheduleUpdate" : true

--- a/resources/content/schema/project/project-auth.json
+++ b/resources/content/schema/project/project-auth.json
@@ -57,6 +57,7 @@
         "publicEndpoint" : "r",
         "haproxyConfig" : "cru",
         "rollingRestartStrategy" : "cr",
+        "servicesPortRange" : "cru",
         "end" : ""
     }
 }

--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -277,6 +277,10 @@
         "projectMember.profilePicture" : "r",
         "projectMember.projectId" : "r",
 
+        "servicesPortRange": "cru",
+        "servicesPortRange.startPort": "cru",
+        "servicesPortRange.endPort": "cru",
+
         "pullTask": "r",
         "pullTask.labels": "cr",
         "pullTask.mode": "cr",

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -150,6 +150,7 @@ def test_user_types(user_client, adds=set(), removes=set()):
         'haproxyConfig',
         'serviceRestart',
         'rollingRestartStrategy',
+        'servicesPortRange'
     }
     types.update(adds)
     types.difference_update(removes)
@@ -359,6 +360,7 @@ def test_admin_types(admin_user_client, adds=set(), removes=set()):
         'haproxyConfig',
         'serviceRestart',
         'rollingRestartStrategy',
+        'servicesPortRange'
     }
     types.update(adds)
     types.difference_update(removes)


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/3107
https://github.com/rancher/rancher/issues/3110

Also changed the API for servicesPortRange field. Instead of string "startPort-endPort", it has a custom type: servicesPortRange. servicesPortRange type has 2 embedded fields - startPort and endPort (integers)

Also added more tests