### PR TITLE
Don't accept NULL uuid on account.create

### DIFF
--- a/resources/content/schema/base/project.json
+++ b/resources/content/schema/base/project.json
@@ -68,6 +68,10 @@
         "attributes" : {
         "scheduleUpdate" : true
       }
+    },
+    "uuid": {
+      "type": "string",
+      "nullable": "false"
     }
   }
 }


### PR DESCRIPTION
As apparently we allow this field to be set on account.create:

https://github.com/rancher/cattle/blob/a510a46f460b164348b04ec809ea83de28764e76/resources/content/schema/admin/admin-auth.json#L14


https://github.com/rancher/rancher/issues/3119

@ibuildthecloud 