### PR TITLE
Don't look for instances on every agent ping

### DIFF
--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/agent-server/defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/agent-server/defaults.properties
@@ -7,8 +7,8 @@ agent.ping.unmanaged.every=12
 agent.ping.stats.every=60
 # 1 minute
 agent.ping.resources.every=12
-# 5 seconds
-agent.ping.instances.every=1
+# 15 seconds
+agent.ping.instances.every=3
 
 agent.ping.reconnect.after.failed.count=6
 agent.ping.timeout.seconds=15


### PR DESCRIPTION
In the past we have had issues in which `docker ps` is not as fast as it
should be.  This causes agents to disconnect because they get hung on
`docker ps`.  By decreasing the amount of times we call `docker ps` will
allow some pings to go through which should hopefully allow the agents
to stay connected.