### PR TITLE
Allow labels on host create only

### DIFF
--- a/code/iaas/agent-server/src/main/java/io/cattle/platform/agent/server/resource/impl/AgentResourcesMonitorImpl.java
+++ b/code/iaas/agent-server/src/main/java/io/cattle/platform/agent/server/resource/impl/AgentResourcesMonitorImpl.java
@@ -27,6 +27,7 @@ import io.cattle.platform.lock.definition.LockDefinition;
 import io.cattle.platform.object.ObjectManager;
 import io.cattle.platform.object.meta.ObjectMetaDataManager;
 import io.cattle.platform.object.util.DataAccessor;
+import io.cattle.platform.util.type.CollectionUtils;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -229,6 +230,11 @@ public class AgentResourcesMonitorImpl implements AgentResourcesEventListener {
             } else {
                 data = createData(agent, uuid, data);
                 data.put(HostConstants.FIELD_PHYSICAL_HOST_ID, physicalHostId);
+
+                /* Copy createLabels to labels */
+                Map<String, Object> labels = CollectionUtils.toMap(data.get(HostConstants.FIELD_LABELS));
+                labels.putAll(CollectionUtils.<String, Object>toMap(data.get(HostConstants.FIELD_CREATE_LABELS)));
+                data.put(HostConstants.FIELD_LABELS, labels);
 
                 hosts.put(uuid, resourceDao.createAndSchedule(Host.class, data));
             }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/HostConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/HostConstants.java
@@ -5,6 +5,9 @@ public class HostConstants {
     public static final String TYPE = "host";
     public static final String FIELD_PHYSICAL_HOST_ID = "physicalHostId";
 
+    /* This is not a real field in the API but passed as a field on agent ping */
+    public static final String FIELD_CREATE_LABELS = "createLabels";
+
     public static final String FIELD_REPORTED_UUID = "reportedUuid";
     public static final String FIELD_PHYSICAL_HOST_UUID = "physicalHostUuid";
     public static final String FIELD_HOST_UUID = "hostUuid";


### PR DESCRIPTION
When a host is created the labels should be assigned that were passed in
then CATTLE_HOST_LABELS environment variable.  If the user changes the
label after the fact, we should use the value the user provided and not
the value from CATTLE_HOST_LABELS.  This is accomplished by only using
CATTLE_HOST_LABELS when creating the host entry but not updating it.

https://github.com/rancher/rancher/issues/3149