### PR TITLE
volume delete

### DIFF
--- a/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/condition/ConditionType.java
+++ b/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/condition/ConditionType.java
@@ -1,7 +1,7 @@
 package io.github.ibuildthecloud.gdapi.condition;
 
 public enum ConditionType {
-    EQ, NE, LT, LTE, GT, GTE, PREFIX, LIKE, NOTLIKE, NULL, NOTNULL, IN(true), OR(true);
+    EQ, NE, LT, LTE, GT, GTE, PREFIX, LIKE, NOTLIKE, NULL, NOTNULL, IN(true), NOTIN(true), OR(true);
 
     public static final ConditionType[] NUMBER_MODS = new ConditionType[] { ConditionType.EQ, ConditionType.NE, ConditionType.LT, ConditionType.LTE,
             ConditionType.GT, ConditionType.GTE, ConditionType.NULL, ConditionType.NOTNULL };

--- a/code/framework/object/src/main/java/io/cattle/platform/object/jooq/utils/JooqUtils.java
+++ b/code/framework/object/src/main/java/io/cattle/platform/object/jooq/utils/JooqUtils.java
@@ -188,6 +188,13 @@ public class JooqUtils {
             } else {
                 return field.in(condition.getValues());
             }
+        case NOTIN:
+            List<Object> vals = condition.getValues();
+            if (vals.size() == 1) {
+                return field.ne(vals.get(0));
+            } else {
+                return field.notIn(condition.getValues());
+            }
         case LIKE:
             return field.like(condition.getValue().toString());
         case LT:

--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/instance/InstanceVolumeCleanupStrategyValidationFilter.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/instance/InstanceVolumeCleanupStrategyValidationFilter.java
@@ -1,0 +1,42 @@
+package io.cattle.platform.iaas.api.filter.instance;
+
+import io.cattle.platform.core.constants.InstanceConstants;
+import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.util.SystemLabels;
+import io.cattle.platform.iaas.api.filter.common.AbstractDefaultResourceManagerFilter;
+import io.cattle.platform.object.util.DataUtils;
+import io.github.ibuildthecloud.gdapi.exception.ClientVisibleException;
+import io.github.ibuildthecloud.gdapi.request.ApiRequest;
+import io.github.ibuildthecloud.gdapi.request.resource.ResourceManager;
+import io.github.ibuildthecloud.gdapi.util.ResponseCodes;
+import io.github.ibuildthecloud.gdapi.validation.ValidationErrorCodes;
+
+import java.util.Map;
+
+public class InstanceVolumeCleanupStrategyValidationFilter extends AbstractDefaultResourceManagerFilter {
+
+    @Override
+    public String[] getTypes() {
+        return InstanceConstants.CONTAINER_LIKE.toArray(new String[InstanceConstants.CONTAINER_LIKE.size()]);
+    }
+
+    @Override
+    public Class<?>[] getTypeClasses() {
+        return new Class<?>[] { Instance.class };
+    }
+
+    @Override
+    public Object create(String type, ApiRequest request, ResourceManager next) {
+        Map<?, ?> labels = DataUtils.getFieldFromRequest(request, InstanceConstants.FIELD_LABELS, Map.class);
+        if (labels != null) {
+            Object l = labels.get(SystemLabels.LABEL_VOLUME_CLEANUP_STRATEGY);
+            if (l != null && !InstanceConstants.VOLUME_REMOVE_STRATEGIES.contains(l)) {
+                throw new ClientVisibleException(ResponseCodes.BAD_REQUEST, ValidationErrorCodes.INVALID_OPTION, String.format(
+                        "%s is an invalid value for the %s label.", l.toString(), SystemLabels.LABEL_VOLUME_CLEANUP_STRATEGY), null);
+            }
+        }
+        
+        return super.create(type, request, next);
+    }
+
+}

--- a/code/iaas/logic-common/src/main/java/io/cattle/platform/process/common/lock/MountVolumeLock.java
+++ b/code/iaas/logic-common/src/main/java/io/cattle/platform/process/common/lock/MountVolumeLock.java
@@ -1,0 +1,11 @@
+package io.cattle.platform.process.common.lock;
+
+import io.cattle.platform.lock.definition.AbstractBlockingLockDefintion;
+import io.cattle.platform.lock.definition.BlockingLockDefinition;
+
+public class MountVolumeLock extends AbstractBlockingLockDefintion implements BlockingLockDefinition {
+
+    public MountVolumeLock(Long volumeId) {
+        super("MOUNT.VOLUME." + volumeId);
+    }
+}

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstancePurge.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstancePurge.java
@@ -1,23 +1,36 @@
 package io.cattle.platform.process.instance;
 
+import static io.cattle.platform.core.constants.InstanceConstants.*;
 import io.cattle.platform.core.constants.InstanceLinkConstants;
+import io.cattle.platform.core.dao.VolumeDao;
 import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.InstanceLink;
-import io.cattle.platform.core.model.Mount;
 import io.cattle.platform.core.model.Port;
+import io.cattle.platform.core.model.Volume;
+import io.cattle.platform.core.util.SystemLabels;
 import io.cattle.platform.engine.handler.HandlerResult;
 import io.cattle.platform.engine.process.ProcessInstance;
 import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.object.process.StandardProcess;
+import io.cattle.platform.object.util.DataAccessor;
 import io.cattle.platform.process.base.AbstractDefaultProcessHandler;
 
+import java.util.Set;
+
+import javax.inject.Inject;
 import javax.inject.Named;
+
+import org.apache.commons.lang3.StringUtils;
 
 @Named
 public class InstancePurge extends AbstractDefaultProcessHandler {
 
+    @Inject
+    VolumeDao volumeDao;
+
     @Override
     public HandlerResult handle(ProcessState state, ProcessInstance process) {
-        Instance instance = (Instance) state.getResource();
+        Instance instance = (Instance)state.getResource();
 
         for (Port port : getObjectManager().children(instance, Port.class)) {
             deactivateThenRemove(port, state.getData());
@@ -27,12 +40,29 @@ public class InstancePurge extends AbstractDefaultProcessHandler {
             deactivateThenRemove(link, state.getData());
         }
 
-        for (Mount mount : getObjectManager().children(instance, Mount.class)) {
-            deactivateThenRemove(mount, state.getData());
-        }
+        deleteVolumes(instance, state);
 
         deallocate(instance, null);
 
         return null;
+    }
+
+    private void deleteVolumes(Instance instance, ProcessState state) {
+        Object b = DataAccessor.fieldMap(instance, FIELD_LABELS).get(SystemLabels.LABEL_VOLUME_CLEANUP_STRATEGY);
+        String behavior = b != null ? b.toString() : VOLUME_CLEANUP_STRATEGY_UNNAMED;
+
+        if (VOLUME_CLEANUP_STRATEGY_NONE.equals(behavior)
+                || (!VOLUME_CLEANUP_STRATEGY_UNNAMED.equals(behavior) && !VOLUME_CLEANUP_STRATEGY_ALL.equals(behavior))) {
+            return;
+        }
+
+        Set<? extends Volume> volumes = volumeDao.findNonremovedVolumesWithNoOtherMounts(instance.getId());
+        for (Volume v : volumes) {
+            if (VOLUME_CLEANUP_STRATEGY_UNNAMED.equals(behavior) &&
+                    ((StringUtils.length(v.getName()) != 64 || !StringUtils.isAlphanumeric(v.getName()))) && !StringUtils.startsWith(v.getName(), "/")) {
+                continue;
+            }
+            objectProcessManager.scheduleStandardProcess(StandardProcess.REMOVE, v, state.getData());
+        }
     }
 }

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceRemove.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceRemove.java
@@ -8,6 +8,7 @@ import io.cattle.platform.core.model.Volume;
 import io.cattle.platform.engine.handler.HandlerResult;
 import io.cattle.platform.engine.process.ProcessInstance;
 import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.object.process.StandardProcess;
 import io.cattle.platform.process.base.AbstractDefaultProcessHandler;
 
 import java.util.HashMap;
@@ -49,7 +50,7 @@ public class InstanceRemove extends AbstractDefaultProcessHandler {
 
         List<Mount> mounts = getObjectManager().children(instance, Mount.class);
         for (Mount mount : mounts) {
-            execute("mount.deactivate", mount, data);
+            objectProcessManager.scheduleStandardProcess(StandardProcess.DEACTIVATE, mount, data);
         }
     }
 

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceRestore.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceRestore.java
@@ -1,7 +1,6 @@
 package io.cattle.platform.process.instance;
 
 import io.cattle.platform.core.model.Instance;
-import io.cattle.platform.core.model.Mount;
 import io.cattle.platform.core.model.Nic;
 import io.cattle.platform.core.model.Volume;
 import io.cattle.platform.engine.handler.HandlerResult;
@@ -36,11 +35,6 @@ public class InstanceRestore extends AbstractDefaultProcessHandler {
 
         for (Volume volume : volumes) {
             restore(volume, data);
-        }
-
-        List<Mount> mounts = getObjectManager().children(instance, Mount.class);
-        for (Mount mount : mounts) {
-            restore(mount, data);
         }
     }
 

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceStart.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceStart.java
@@ -18,7 +18,6 @@ import io.cattle.platform.core.model.IpAddress;
 import io.cattle.platform.core.model.Nic;
 import io.cattle.platform.core.model.Port;
 import io.cattle.platform.core.model.Volume;
-import io.cattle.platform.core.util.InstanceHelpers;
 import io.cattle.platform.engine.handler.HandlerResult;
 import io.cattle.platform.engine.process.ProcessInstance;
 import io.cattle.platform.engine.process.ProcessState;
@@ -207,9 +206,6 @@ public class InstanceStart extends AbstractDefaultProcessHandler {
 
     protected void storage(Instance instance, ProcessState state) {
         List<Volume> volumes = getObjectManager().children(instance, Volume.class);
-
-        volumes.addAll(InstanceHelpers.extractVolumesFromMounts(instance, objectManager));
-
         for (Volume volume : volumes) {
             activate(volume, state.getData());
         }

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/mount/MountCreate.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/mount/MountCreate.java
@@ -1,0 +1,34 @@
+package io.cattle.platform.process.mount;
+
+import io.cattle.platform.core.constants.CommonStatesConstants;
+import io.cattle.platform.core.dao.GenericMapDao;
+import io.cattle.platform.core.model.Mount;
+import io.cattle.platform.core.model.Volume;
+import io.cattle.platform.engine.handler.HandlerResult;
+import io.cattle.platform.engine.process.ProcessInstance;
+import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.lock.LockManager;
+import io.cattle.platform.object.process.StandardProcess;
+import io.cattle.platform.process.base.AbstractDefaultProcessHandler;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named
+public class MountCreate extends AbstractDefaultProcessHandler {
+
+    @Inject
+    GenericMapDao mapDao;
+    @Inject
+    LockManager lockManager;
+
+    @Override
+    public HandlerResult handle(final ProcessState state, ProcessInstance process) {
+        Mount mount = (Mount)state.getResource();
+        Volume volume = objectManager.loadResource(Volume.class, mount.getVolumeId());
+        if (!CommonStatesConstants.ACTIVE.equals(volume.getState()) && !CommonStatesConstants.ACTIVATING.equals(volume.getState())) {
+            objectProcessManager.scheduleStandardProcess(StandardProcess.ACTIVATE, volume, state.getData());
+        }
+        return null;
+    }
+}

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/mount/MountDeactivate.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/mount/MountDeactivate.java
@@ -1,0 +1,55 @@
+package io.cattle.platform.process.mount;
+
+import static io.cattle.platform.core.model.tables.MountTable.*;
+import io.cattle.platform.core.constants.CommonStatesConstants;
+import io.cattle.platform.core.model.Mount;
+import io.cattle.platform.core.model.Volume;
+import io.cattle.platform.engine.handler.HandlerResult;
+import io.cattle.platform.engine.process.ProcessInstance;
+import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.lock.LockCallbackNoReturn;
+import io.cattle.platform.lock.LockManager;
+import io.cattle.platform.object.process.StandardProcess;
+import io.cattle.platform.process.base.AbstractDefaultProcessHandler;
+import io.cattle.platform.process.common.lock.MountVolumeLock;
+import io.github.ibuildthecloud.gdapi.condition.Condition;
+import io.github.ibuildthecloud.gdapi.condition.ConditionType;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named
+public class MountDeactivate extends AbstractDefaultProcessHandler {
+
+    private static final List<Object> STATES = Arrays.asList(new Object[]{CommonStatesConstants.INACTIVE,
+                CommonStatesConstants.DEACTIVATING, CommonStatesConstants.REMOVED, CommonStatesConstants.REMOVING});
+    @Inject
+    LockManager lockManager;
+
+    @Override
+    public HandlerResult handle(final ProcessState state, ProcessInstance process) {
+        final Mount mount = (Mount)state.getResource();
+        lockManager.lock(new MountVolumeLock(mount.getVolumeId()), new LockCallbackNoReturn() {
+            @Override
+            public void doWithLockNoResult() {
+                Map<Object, Object> criteria = new HashMap<Object, Object>();
+                criteria.put(MOUNT.ID, new Condition(ConditionType.NE, mount.getId()));
+                criteria.put(MOUNT.STATE, new Condition(ConditionType.NOTIN, STATES));
+                criteria.put(MOUNT.VOLUME_ID, mount.getVolumeId());
+                Mount mount2 = objectManager.findAny(Mount.class, criteria);
+                if (mount2 == null) {
+                    Volume vol = objectManager.loadResource(Volume.class, mount.getVolumeId());
+                    if (CommonStatesConstants.ACTIVE.equals(vol.getState()) || CommonStatesConstants.ACTIVATING.equals(vol.getState())) {
+                        objectProcessManager.scheduleStandardProcess(StandardProcess.DEACTIVATE, vol, null);
+                    }
+                }
+            }
+        });
+        return null;
+    }
+}

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/mount/MountRemove.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/mount/MountRemove.java
@@ -1,0 +1,47 @@
+package io.cattle.platform.process.mount;
+
+import io.cattle.platform.core.dao.GenericMapDao;
+import io.cattle.platform.core.model.Host;
+import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.InstanceHostMap;
+import io.cattle.platform.core.model.Mount;
+import io.cattle.platform.core.model.Volume;
+import io.cattle.platform.core.model.VolumeStoragePoolMap;
+import io.cattle.platform.engine.handler.ProcessPostListener;
+import io.cattle.platform.engine.process.ProcessInstance;
+import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.process.common.handler.AgentBasedProcessHandler;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+public class MountRemove extends AgentBasedProcessHandler implements ProcessPostListener {
+
+    @Inject
+    GenericMapDao mapDao;
+
+    @Override
+    protected Object getAgentResource(ProcessState state, ProcessInstance process, Object dataResource) {
+        Instance instance = (Instance)getObjectByRelationship("instance", state.getResource());
+        List<? extends InstanceHostMap> maps = objectManager.children(instance, InstanceHostMap.class);
+        Host host = maps.size() > 0 ? objectManager.loadResource(Host.class, maps.get(0).getHostId()) : null;
+        return host;
+    }
+
+    @Override
+    protected Object getDataResource(ProcessState state, ProcessInstance process) {
+        Mount m = (Mount)state.getResource();
+        Volume v = objectManager.loadResource(Volume.class, m.getVolumeId());
+        List<? extends VolumeStoragePoolMap> maps = objectManager.children(v, VolumeStoragePoolMap.class);
+        return maps.size() > 0 ? maps.get(0) : null;
+    }
+
+    @Override
+    protected Object getEventResource(ProcessState state, ProcessInstance process) {
+        Mount m = (Mount)state.getResource();
+        Volume v = objectManager.loadResource(Volume.class, m.getVolumeId());
+        List<? extends VolumeStoragePoolMap> maps = objectManager.children(v, VolumeStoragePoolMap.class);
+        return maps.size() > 0 ? maps.get(0) : null;
+    }
+}

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/volume/VolumeActivate.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/volume/VolumeActivate.java
@@ -45,7 +45,7 @@ public class VolumeActivate extends AbstractDefaultProcessHandler {
         Image image = getObjectManager().loadResource(Image.class, volume.getImageId());
 
         activateImageInPool(volume, image, map.getStoragePoolId(), data);
-        activate(map, data);
+        createThenActivate(map, data);
     }
 
     protected void activateImageInPool(Volume volume, final Image image, final long poolId, Map<String, Object> data) {

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
@@ -82,4 +82,10 @@ public class InstanceConstants {
     public static final String EVENT_INSTANCE_FORCE_STOP = "compute.instance.force.stop";
 
     public static final Set<String> CONTAINER_LIKE = new HashSet<>(Arrays.asList(KIND_CONTAINER, KIND_VIRTUAL_MACHINE));
+
+    public static final String VOLUME_CLEANUP_STRATEGY_NONE = "none";
+    public static final String VOLUME_CLEANUP_STRATEGY_UNNAMED = "unnamed";
+    public static final String VOLUME_CLEANUP_STRATEGY_ALL = "all";
+    public static final Set<String> VOLUME_REMOVE_STRATEGIES = new HashSet<>(Arrays.asList(VOLUME_CLEANUP_STRATEGY_NONE, VOLUME_CLEANUP_STRATEGY_UNNAMED,
+            VOLUME_CLEANUP_STRATEGY_ALL));
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/VolumeDao.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/VolumeDao.java
@@ -5,11 +5,14 @@ import io.cattle.platform.core.model.Volume;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface VolumeDao {
     Volume findVolumeByExternalId(Long storagePoolId, String externalId);
-    
+
     void createVolumeInStoragePool(Map<String, Object> volumeData, String volumeName, StoragePool storagePool);
 
     List<? extends Volume> findSharedOrUnmappedVolumes(long accountId, String volumeName);
+
+    Set<? extends Volume> findNonremovedVolumesWithNoOtherMounts(long instanceId);
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/util/SystemLabels.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/util/SystemLabels.java
@@ -6,6 +6,7 @@ public class SystemLabels {
     public static final String LABEL_USE_RANCHER_DNS = "io.rancher.container.dns";
     public static final String LABEL_REQUESTED_IP = "io.rancher.container.requested_ip";
     public static final String LABEL_AGENT_URI_PREFIX = "io.rancher.container.agent.uri.prefix";
+    public static final String LABEL_VOLUME_CLEANUP_STRATEGY = "io.rancher.container.volume_cleanup_strategy";
 
     /**
      * Indicates an instance runs an agent that provides the labels provider service

--- a/code/implementation/docker/common/src/main/java/io/cattle/platform/docker/transform/DockerTransformerImpl.java
+++ b/code/implementation/docker/common/src/main/java/io/cattle/platform/docker/transform/DockerTransformerImpl.java
@@ -266,7 +266,7 @@ public class DockerTransformerImpl implements DockerTransformer {
     void setLabels(Instance instance, Map<String, Object> fromInspect) {
         // Labels not yet implemented in docker-java. Need to use the raw map
         Object l = CollectionUtils.getNestedValue(fromInspect, "Config", "Labels");
-        Map<String, String> cleanedLabels = new HashMap<String, String>();
+        Map<String, Object> cleanedLabels = new HashMap<String, Object>();
         if (l instanceof Map) {
             Map labels = (Map)l;
             for (Object key : labels.keySet()) {
@@ -278,7 +278,9 @@ public class DockerTransformerImpl implements DockerTransformer {
                 cleanedLabels.put(key.toString(), value.toString());
             }
         }
-        setField(instance, FIELD_LABELS, cleanedLabels);
+        Map<String, Object> labels = DataAccessor.fieldMap(instance, FIELD_LABELS);
+        labels.putAll(cleanedLabels);
+        setField(instance, FIELD_LABELS, labels);
     }
 
     void setImage(Instance instance, String image) {

--- a/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/dao/impl/DockerComputeDaoImpl.java
+++ b/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/dao/impl/DockerComputeDaoImpl.java
@@ -87,7 +87,6 @@ public class DockerComputeDaoImpl extends AbstractJooqDao implements DockerCompu
                     .where(VOLUME_STORAGE_POOL_MAP.STORAGE_POOL_ID.eq(storagePool.getId()))
                         .and(condition)
                         .and(VOLUME_STORAGE_POOL_MAP.REMOVED.isNull())
-                        .and(VOLUME.REMOVED.isNull())
                 .fetchInto(VolumeRecord.class);
 
         if ( volumes.isEmpty() )

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/iaas-api/spring-iaas-api-logic-context.xml
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/iaas-api/spring-iaas-api-logic-context.xml
@@ -20,6 +20,7 @@
     <bean class="io.cattle.platform.iaas.api.filter.instance.InstanceImageValidationFilter" />
     <bean class="io.cattle.platform.iaas.api.filter.instance.InstanceNetworkValidationFilter" />
     <bean class="io.cattle.platform.iaas.api.filter.instance.InstancePortsValidationFilter" />
+    <bean class="io.cattle.platform.iaas.api.filter.instance.InstanceVolumeCleanupStrategyValidationFilter" />
     <bean class="io.cattle.platform.iaas.api.credential.SshKeyOutputFilter" />
     <bean class="io.cattle.platform.iaas.api.filter.containerevent.ContainerEventFilter" />
     <bean class="io.cattle.platform.iaas.api.filter.externalevent.ExternalEventFilter" />

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/process/core-process-defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/process/core-process-defaults.properties
@@ -61,7 +61,6 @@ process.instancehostmap.purge.priority=-100
 process.instancelink.purge.priority=-100
 process.ipaddress.purge.priority=-100
 process.ipaddressnicmap.purge.priority=-100
-process.mount.purge.priority=-100
 process.networkserviceproviderinstancemap.purge.priority=-100
 process.nic.purge.priority=-100
 process.port.purge.priority=-100

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/process/spring-core-logic-context.xml
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/process/spring-core-logic-context.xml
@@ -80,6 +80,18 @@
         </property>
     </bean>
 
+    <bean class="io.cattle.platform.process.mount.MountRemove"
+        p:name="MountRemove"
+        p:commandName="storage.volume.remove"
+        p:dataTypeClass="io.cattle.platform.core.model.VolumeStoragePoolMap"
+        p:dataResourceRelationship="none"
+        p:processNames="mount.remove"
+        p:shortCircuitIfAgentRemoved="true" >
+        <property name="priority">
+            <util:constant static-field="io.cattle.platform.util.type.Priority.DEFAULT"/>
+        </property>
+    </bean>
+
     <bean class="io.cattle.platform.process.common.handler.AgentBasedProcessHandler"
         p:name="InstanceHostMapActivate"
         p:commandName="compute.instance.activate"

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/process/spring-core-processes-context.xml
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/process/spring-core-processes-context.xml
@@ -44,7 +44,6 @@
     <process:defaultProcesses resourceType="ipAddressNicMap" />
     <process:defaultProcesses resourceType="ipAssociation" />
     <process:defaultProcesses resourceType="ipPool" />
-    <process:defaultProcesses resourceType="mount" />
     <process:defaultProcesses resourceType="network" />
     <process:defaultProcesses resourceType="networkService" />
     <process:defaultProcesses resourceType="networkServiceProvider" />
@@ -98,9 +97,14 @@
 
     <!-- Volume -->
     <process:defaultProcesses resourceType="volume" exclude="volume.activate"/>
-    <process:process name="volume.activate" resourceType="agent" start="inactive,requested, registering" transitioning="activating" done="active" />
+    <process:process name="volume.activate" resourceType="volume" start="inactive,requested,registering" transitioning="activating" done="active" />
     <process:process name="volume.allocate" resourceType="volume" stateField="allocationState" start="inactive" transitioning="activating" done="active" />
     <process:process name="volume.deallocate" resourceType="volume" stateField="allocationState" start="activating,active" transitioning="deactivating" done="inactive" />
+
+    <!-- Mount -->
+    <process:process name="mount.create" resourceType="mount" start="requested" transitioning="activating" done="active" />
+    <process:process name="mount.deactivate" resourceType="mount" start="active,activating" transitioning="deactivating" done="inactive" />
+    <process:process name="mount.remove" resourceType="mount" start="inactive,deactivating" transitioning="removing" done="removed" />
 
     <!-- Physical Host -->  
     <process:process name="physicalhost.create" resourceType="physicalHost" start="requested" transitioning="creating" done="created" delegate="physicalhost.bootstrap" />

--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -362,6 +362,7 @@
         "volume.uri" : "r",
         "volume.driver": "cr",
         "volume.driverOpts": "cr",
+        "volume.resourceActions.deactivate" : "",
 
         "loadBalancerConfig" : "r",
         "loadBalancerConfig.appCookieStickinessPolicy" : "cru",

--- a/tests/integration/cattletest/core/test_volume.py
+++ b/tests/integration/cattletest/core/test_volume.py
@@ -1,6 +1,11 @@
+from random import choice
+from string import hexdigits
+
 from common_fixtures import *  # NOQA
 from gdapi import ApiError
 from gdapi import ClientApiError
+
+VOLUME_CLEANUP_LABEL = 'io.rancher.container.volume_cleanup_strategy'
 
 
 def test_volume_delete_active(client, context):
@@ -86,9 +91,11 @@ def test_create_container_with_volume(new_context, super_client):
 
     assert dataVol1Found and dataVol2Found
 
+    # Mounting happens in docker specific code; need to simulate
+    create_mount(v1, c, client, super_client)
+    create_mount(v2, c, client, super_client)
     v1 = client.wait_success(v1)
     v2 = client.wait_success(v2)
-
     assert v1.state == 'active'
     assert v2.state == 'active'
 
@@ -98,11 +105,8 @@ def test_create_container_with_volume(new_context, super_client):
     vsp1 = super_client.list_volumeStoragePoolMap(volumeId=v1.id)
     vsp2 = super_client.list_volumeStoragePoolMap(volumeId=v2.id)
 
-    assert vsp1 is not None
-    assert vsp2 is not None
-
-    assert len(vsp1) == 1
-    assert len(vsp2) == 1
+    assert vsp1 is not None and len(vsp1) == 1
+    assert vsp2 is not None and len(vsp2) == 1
 
     spid1 = vsp1[0].storagePoolId
     spid2 = vsp2[0].storagePoolId
@@ -123,3 +127,241 @@ def test_create_container_with_volume(new_context, super_client):
         client.wait_success(c)
 
     assert e.value.message == 'Failed to find a placement'
+
+
+def create_resources(context, client, super_client, labels={}):
+    vol = client.create_volume(name=random_str(), driver='local')
+    unnamed_vol = client.create_volume(name=random_vol_name(), driver='local')
+    data_volume_mounts = {'/con/path': vol.id, '/path2': unnamed_vol.id}
+    c = client.create_container(imageUuid=context.image_uuid,
+                                dataVolumeMounts=data_volume_mounts,
+                                labels=labels)
+    c = client.wait_success(c)
+    # Simulate volume mount (only happens with real docker)
+    create_mount(vol, c, client, super_client)
+    create_mount(unnamed_vol, c, client, super_client)
+    return c, vol, unnamed_vol
+
+
+def test_instance_volume_cleanup_strategy(new_context, super_client):
+    client = new_context.client
+
+    # Assert default strategy to delete unnamed volumes only
+    c, vol, unnamed_vol = create_resources(new_context, client, super_client)
+    c = client.wait_success(c.stop())
+    c = client.wait_success(c.remove())
+    client.wait_success(c.purge())
+    wait_for_condition(client, vol, lambda x: x.state == 'inactive')
+    wait_for_condition(client, unnamed_vol, lambda x: x.state == 'removed')
+
+    # Assert explicit 'unnamed' strategy
+    c, vol, unnamed_vol = create_resources(
+        new_context, client, super_client, labels={
+            VOLUME_CLEANUP_LABEL: 'unnamed'})
+    c = client.wait_success(c.stop())
+    c = client.wait_success(c.remove())
+    client.wait_success(c.purge())
+    wait_for_condition(client, vol, lambda x: x.state == 'inactive')
+    wait_for_condition(client, unnamed_vol, lambda x: x.state == 'removed')
+
+    # Assert 'none' strategy
+    c, vol, unnamed_vol = create_resources(
+        new_context, client, super_client, labels={
+            VOLUME_CLEANUP_LABEL: 'none'})
+    c = client.wait_success(c.stop())
+    c = client.wait_success(c.remove())
+    client.wait_success(c.purge())
+    wait_for_condition(client, vol, lambda x: x.state == 'inactive')
+    wait_for_condition(client, unnamed_vol, lambda x: x.state == 'inactive')
+
+    # Assert 'all' strategy
+    c, vol, unnamed_vol = create_resources(
+        new_context, client, super_client, labels={
+            VOLUME_CLEANUP_LABEL: 'all'})
+    c = client.wait_success(c.stop())
+    c = client.wait_success(c.remove())
+    client.wait_success(c.purge())
+    wait_for_condition(client, vol, lambda x: x.state == 'removed')
+    wait_for_condition(client, unnamed_vol, lambda x: x.state == 'removed')
+
+    # Assert invalid value for label is rejected
+    with pytest.raises(ApiError):
+        create_resources(
+            new_context, client, super_client,
+            labels={VOLUME_CLEANUP_LABEL: 'foo'})
+
+
+def create_container_and_mount(client, data_volume_mounts, new_context,
+                               super_client, vols):
+    c = client.create_container(imageUuid=new_context.image_uuid,
+                                dataVolumeMounts=data_volume_mounts,
+                                labels={VOLUME_CLEANUP_LABEL: 'all'})
+    c = client.wait_success(c)
+    for vol in vols:
+        c, m = create_mount(vol, c, client, super_client)
+    return c
+
+
+def purge_instance_and_check_volume_state(c, vols, state, client):
+    c = client.wait_success(c.stop())
+    c = client.wait_success(c.remove())
+    client.wait_success(c.purge())
+    for vol in vols:
+        wait_for_condition(client, vol,
+                           lambda x: x.state == state,
+                           lambda x: 'State: %s. Expected: %s' % (
+                               x.state, state))
+
+
+def create_volume_and_dvm(client, count):
+    dvms = {}
+    vols = []
+    for i in range(0, count):
+        v1 = client.create_volume(name=random_str(), driver='local')
+        dvms['/con/path%s' % i] = v1.id
+        vols.append(v1)
+
+    return dvms, vols
+
+
+def test_volume_remove_on_purge(new_context, super_client):
+    client = new_context.client
+
+    # Simple case: volume associated with one container that is purged
+    # volume gets removed
+    dvms, vols = create_volume_and_dvm(client, 2)
+    c = create_container_and_mount(client, dvms, new_context,
+                                   super_client, vols)
+    purge_instance_and_check_volume_state(c, vols, 'removed', client)
+
+    # Vol associated with multiple containers
+    dvms, vols = create_volume_and_dvm(client, 2)
+    c = create_container_and_mount(client, dvms, new_context,
+                                   super_client, vols)
+    c2 = create_container_and_mount(client, dvms, new_context,
+                                    super_client, vols)
+    purge_instance_and_check_volume_state(c, vols, 'active', client)
+    purge_instance_and_check_volume_state(c2, vols, 'removed', client)
+
+    # Vol associated with same container twice (because of restore)
+    dvms, vols = create_volume_and_dvm(client, 2)
+    c = create_container_and_mount(client, dvms, new_context,
+                                   super_client, vols)
+    c2 = create_container_and_mount(client, dvms, new_context,
+                                    super_client, vols)
+    c2 = client.wait_success(c2.stop())
+    c2 = client.wait_success(c2.remove())
+    c2 = client.wait_success(c2.restore())
+    c2 = client.wait_success(c2.start())
+    create_mount(vols[0], c2, client, super_client)
+    create_mount(vols[1], c2, client, super_client)
+
+    purge_instance_and_check_volume_state(c, vols, 'active', client)
+    purge_instance_and_check_volume_state(c2, vols, 'removed', client)
+
+    # 1 volume is associated with an active container and shouldn't be
+    # removed
+    dvms, vols = create_volume_and_dvm(client, 2)
+    c = create_container_and_mount(client, dvms, new_context,
+                                   super_client, vols)
+    dvms = {'/path': vols[1].id}
+    v2 = vols.pop()
+    c2_vols = [v2]
+    c2 = create_container_and_mount(client, dvms, new_context,
+                                    super_client, c2_vols)
+
+    # Since vol[1] was popped, this is asserting only vols[0] gets removed
+    purge_instance_and_check_volume_state(c, vols, 'removed', client)
+    v2 = client.wait_success(v2)
+    assert v2.state == 'active'
+    purge_instance_and_check_volume_state(c2, c2_vols, 'removed', client)
+
+
+def test_volume_mounting_and_delete(new_context, super_client):
+    client = new_context.client
+
+    v1 = client.create_volume(name=random_str(), driver='local')
+
+    data_volume_mounts = {'/con/path': v1.id}
+    c = client.create_container(imageUuid=new_context.image_uuid,
+                                dataVolumeMounts=data_volume_mounts)
+    c = client.wait_success(c)
+    assert c.state == 'running'
+
+    v1 = client.wait_success(v1)
+    assert len(v1.storagePools()) == 1
+
+    # Creating a mount that associates the volume to the container
+    # only happens when integrating with real docker, so we'll simulate it
+    c, m = create_mount(v1, c, client, super_client)
+
+    # Assert that creating the mount results in activating volume
+    check_mount_count(client, c, 1)
+    assert m.state == 'active'
+    v1 = wait_for_condition(client, v1, lambda x: x.state == 'active')
+
+    # Assert that a volume with mounts cannot be deactivated, removed or purged
+    assert 'deactivate' not in v1.actions and 'remove' not in v1.actions \
+           and 'purge' not in v1.actions
+
+    # Assert that once the container is removed, the mounts are removed and the
+    # the volume is deactivated
+    c = client.wait_success(c.stop())
+    c = client.wait_success(c.remove())
+    v1 = wait_for_condition(client, v1, lambda x: x.state == 'inactive')
+    check_mount_count(client, c, 0)
+
+    # Mount to new container to assert volume goes back to active
+    c2 = client.create_container(imageUuid=new_context.image_uuid,
+                                 dataVolumeMounts=data_volume_mounts)
+    c2 = client.wait_success(c2)
+    c2, m2 = create_mount(v1, c2, client, super_client)
+    check_mount_count(client, c2, 1)
+    v1 = wait_for_condition(client, v1, lambda x: x.state == 'active')
+
+    # Make the volume be mounted to two containers
+    c3 = client.create_container(imageUuid=new_context.image_uuid,
+                                 dataVolumeMounts=data_volume_mounts,
+                                 labels={VOLUME_CLEANUP_LABEL: 'all'})
+    c3 = client.wait_success(c3)
+    c3, m3 = create_mount(v1, c3, client, super_client)
+    check_mount_count(client, c3, 1)
+    check_mount_count(client, v1, 2)
+
+    # Remove 1 one of the containers and assert that actions are still blocked
+    c2 = client.wait_success(c2.stop())
+    c2 = client.wait_success(c2.remove())
+    check_mount_count(client, c2, 0)
+    v1 = wait_for_condition(client, v1, lambda x: x.state == 'active')
+    v1 = client.wait_success(v1)
+    check_mount_count(client, v1, 1)
+    assert 'deactivate' not in v1.actions and 'remove' not in v1.actions \
+           and 'purge' not in v1.actions
+
+    # Remove remaining container and assert the volume can be removed
+    c3 = client.wait_success(c3.stop())
+    c3 = client.wait_success(c3.remove())
+    check_mount_count(client, c3, 0)
+    v1 = wait_for_condition(client, v1, lambda x: x.state == 'inactive')
+    check_mount_count(client, v1, 0)
+
+    v1 = client.wait_success(v1.remove())
+    assert v1.state == 'removed'
+
+
+def create_mount(volume, container, client, super_client):
+    mount = super_client.create_mount(volumeId=volume.id,
+                                      instanceId=container.id,
+                                      accountId=container.accountId)
+    mount = super_client.wait_success(mount)
+    return client.reload(container), mount
+
+
+def check_mount_count(client, resource, count):
+    wait_for_condition(client, resource, lambda x: len(
+        [i for i in resource.mounts() if i.state != 'inactive']) == count)
+
+
+def random_vol_name():
+    # Emulates the random name that docker would assign to an unnamed volume
+    return ''.join(choice(hexdigits) for i in range(64))


### PR DESCRIPTION
Allows volume delete from the API, but only allows it when the volume
has no mounts and is inactive.

Sets the agentId on convoy storagePools so that the convoy-agent can
handle volume lifecycle events (like volume deleting).

Refactors the mount and volume lifecycles a bit. Simplifies mount to
just requested->active->removed. When an instance is removed, the mount
will be removed. If an instance is restored from the removed state, new
mounts will be created when the instance is started. Changes volume
lifecycle sucht that mount.create and mount.remove causes them to be
activated and deactivated.