### PR TITLE
Allow wildcards for whitelisted URLs for proxy

### DIFF
--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/request/handler/GenericWhitelistedProxy.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/request/handler/GenericWhitelistedProxy.java
@@ -171,7 +171,17 @@ public class GenericWhitelistedProxy extends AbstractResponseGenerator {
     }
 
     private boolean isWhitelisted(String host) {
-        return PROXY_WHITELIST.get().contains(host);
+        for (String valid : PROXY_WHITELIST.get()) {
+            if (valid.equals(host)) {
+                return true;
+            }
+
+            if (valid.startsWith("*") && host.endsWith(valid.substring(1))) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
 }

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/iaas-api/defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/iaas-api/defaults.properties
@@ -63,7 +63,7 @@ api.request.options=_plainId,_role
 console.url.format.websocket-vnc=${static}/vnc.html?path=${path}&host=${host}&port=${port}&password=${password}&autoconnect=1
 
 api.proxy.allow=true
-api.proxy.whitelist=ec2.us-east-1.amazonaws.com,ec2.us-west-2.amazonaws.com,ec2.us-west-1.amazonaws.com,ec2.eu-west-1.amazonaws.com,ec2.eu-central-1.amazonaws.com,ec2.ap-southeast-1.amazonaws.com,ec2.ap-southeast-2.amazonaws.com,ec2.ap-northeast-1.amazonaws.com,ec2.sa-east-1.amazonaws.com,api.exoscale.ch,api.ubiquityhosting.com
+api.proxy.whitelist=*.amazonaws.com,forums.rancher.com,api.exoscale.ch,api.ubiquityhosting.com
 
 api.github.scheme=https://
 

--- a/tests/integration/cattletest/core/test_proxy.py
+++ b/tests/integration/cattletest/core/test_proxy.py
@@ -26,3 +26,14 @@ def test_proxy(client, admin_user_client):
 
     assert r.status_code == 200
     assert 'Darren' in r.text
+
+
+def test_aws_proxy(client):
+    base_url = client.schema.types['schema'].links['collection']
+    base_url = base_url.replace('/schemas', '')
+
+    host = 'ec2.us-west-2.amazonaws.com'
+    r = requests.post(base_url + '/proxy/{}'.format(host),
+                      headers=auth_header_map(client))
+
+    assert r.status_code == 400


### PR DESCRIPTION
Each Amazon region needs a unique URL for each region to be whitelisted.
With this change we can whitelist a wildcard such that we don't need to
add a new URL for each new region.

https://github.com/rancher/rancher/issues/3185