### PR TITLE
Add bind mount to NetworkAgent

### DIFF
--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/AgentInstanceManagerImpl.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/AgentInstanceManagerImpl.java
@@ -18,6 +18,7 @@ import io.cattle.platform.object.ObjectManager;
 import io.cattle.platform.object.process.ObjectProcessManager;
 import io.cattle.platform.object.resource.ResourceMonitor;
 import io.cattle.platform.object.resource.ResourcePredicate;
+import io.cattle.platform.util.type.CollectionUtils;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -79,6 +80,8 @@ public class AgentInstanceManagerImpl implements AgentInstanceManager {
                         .withAccountId(instance.getAccountId())
                         .withPrivileged(true).forVnetId(nic.getVnetId())
                         .withSystemContainerType(SystemContainer.NetworkAgent)
+                        .withParameters(CollectionUtils.asMap(InstanceConstants.FIELD_DATA_VOLUMES,
+                                Arrays.asList("/var/lib/rancher/etc:/var/lib/rancher/etc:ro")))
                         .build();
             } else {
                 start(agentInstance);

--- a/tests/integration/cattletest/core/test_docker.py
+++ b/tests/integration/cattletest/core/test_docker.py
@@ -900,6 +900,8 @@ def test_delete_network_agent(super_client, docker_client):
     networkAgent = agentNsp.instances()[0]
 
     assert networkAgent.state == 'running'
+    assert networkAgent.dataVolumes == \
+        ['/var/lib/rancher/etc:/var/lib/rancher/etc:ro']
     docker_client.delete(networkAgent)
 
     networkAgent = docker_client.wait_success(networkAgent)

--- a/tests/integration/cattletest/core/test_virtual_machine.py
+++ b/tests/integration/cattletest/core/test_virtual_machine.py
@@ -116,7 +116,8 @@ def test_virtual_machine_default_fields(super_client, client, context):
     assert c.labels['io.rancher.vm.userdata'] == 'hi'
     assert c.dataVolumes == ['/var/lib/rancher/vm:/vm',
                              '{}-00:/volumes/disk00'.format(c.uuid[0:7]),
-                             '{}-{}:/volumes/disk01'.format(c.uuid[0:7], disk_name)]
+                             '{}-{}:/volumes/disk01'.format(c.uuid[0:7],
+                                                            disk_name)]
     assert c.devices == ['/dev/kvm:/dev/kvm', '/dev/net/tun:/dev/net/tun']
     assert c.capAdd == ['NET_ADMIN']
     assert c.capabilities == ['console']


### PR DESCRIPTION
This PR adds a host bind mount of /var/lib/rancher/etc:/var/lib/rancher/etc:ro to the network agent. This will allow configuration information to be passed to the agent on startup. 

Also, this includes a fix for a Flake 8 error.