### PR TITLE
Changes to generate a random token per Service for public dns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ code/packaging/app/keys.properties
 .classpath
 .project
 .settings
-
 code/packaging/app/keys.properties
+code/framework/encryption/keys.properties
 dist
 docs/build
 resources/content/db/mysql/cattle_dump*.sql

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/metadata/common/ServiceMetaData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/metadata/common/ServiceMetaData.java
@@ -35,6 +35,7 @@ public class ServiceMetaData {
     protected Integer scale;
     protected String fqdn;
     protected List<String> expose = new ArrayList<>();
+    protected String token;
 
     public ServiceMetaData(ServiceMetaData that) {
         this.name = that.name;
@@ -58,6 +59,7 @@ public class ServiceMetaData {
         this.isPrimaryConfig = that.isPrimaryConfig;
         this.launchConfigName = that.launchConfigName;
         this.stackId = that.stackId;
+        this.token = that.token;
     }
 
     public ServiceMetaData(Service service, String serviceName, Environment env, List<String> sidekicks,
@@ -82,6 +84,7 @@ public class ServiceMetaData {
         this.scale = DataAccessor.fieldInteger(service, ServiceDiscoveryConstants.FIELD_SCALE);
         this.fqdn = DataAccessor.fieldString(service, ServiceDiscoveryConstants.FIELD_FQDN);
         this.stackId = env.getId();
+        this.token = DataAccessor.fieldString(service, ServiceDiscoveryConstants.FIELD_TOKEN);
     }
 
     @SuppressWarnings("unchecked")
@@ -247,5 +250,13 @@ public class ServiceMetaData {
 
     public Long getStackId() {
         return stackId;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public String getToken() {
+        return token;
     }
 }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
@@ -40,6 +40,7 @@ public class ServiceDiscoveryConstants {
     public static final String FIELD_OUTPUTS = "outputs";
     public static final String FIELD_PUBLIC_ENDPOINTS = "publicEndpoints";
     public static final String FIELD_RESTART = "restart";
+    public static final String FIELD_TOKEN = "token";
 
     public static final String STACK_FIELD_DOCKER_COMPOSE = "dockerCompose";
     public static final String STACK_FIELD_RANCHER_COMPOSE = "rancherCompose";

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceCreate.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceCreate.java
@@ -34,6 +34,7 @@ public class ServiceCreate extends AbstractObjectProcessHandler {
         Service service = (Service) state.getResource();
         sdService.setVIP(service);
         sdService.setPorts(service);
+        sdService.setToken(service);
         return null;
     }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
@@ -38,4 +38,6 @@ public interface ServiceDiscoveryService {
     void setPorts(Service service);
 
     void releasePorts(Service service);
+
+    void setToken(Service service);
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
@@ -26,6 +26,7 @@ import io.cattle.platform.core.util.PortSpec;
 import io.cattle.platform.deferred.util.DeferredUtils;
 import io.cattle.platform.eventing.EventService;
 import io.cattle.platform.framework.event.util.EventUtils;
+import io.cattle.platform.iaas.api.filter.apikey.ApiKeyFilter;
 import io.cattle.platform.json.JsonMapper;
 import io.cattle.platform.lock.LockCallbackNoReturn;
 import io.cattle.platform.lock.LockManager;
@@ -469,5 +470,12 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
                 updateObjectEndPoint(service, service.getKind(), service.getId(), publicEndpoint, add);
             }
         });
+    }
+
+    @Override
+    public void setToken(Service service) {
+        String token = ApiKeyFilter.generateKeys()[1];
+        DataAccessor.fields(service).withKey(ServiceDiscoveryConstants.FIELD_TOKEN).set(token);
+        objectManager.persist(service);
     }
 }


### PR DESCRIPTION
A cryptographically secure random token is generated during Service create and exposes in the rancher-metadata so that it can be consumed by public dns provider