### PR TITLE
don't process init health check event

### DIFF
--- a/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/InstanceHealthcheckRegister.java
+++ b/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/InstanceHealthcheckRegister.java
@@ -53,6 +53,8 @@ public class InstanceHealthcheckRegister extends AbstractObjectProcessLogic impl
             if (instance.getHealthState() == null) {
                 objectManager.setFields(instance, INSTANCE.HEALTH_STATE,
                         HealthcheckConstants.HEALTH_STATE_INITIALIZING, INSTANCE.HEALTH_UPDATED, new Date());
+            } else if (instance.getHealthState().equalsIgnoreCase(HealthcheckConstants.HEALTH_STATE_HEALTHY)) {
+                healtcheckService.updateInstanceHealthState(instance, HealthcheckConstants.HEALTH_STATE_REINITIALIZING);
             }
             healtcheckService.registerForHealtcheck(HealthcheckInstanceType.INSTANCE, instance.getId());
         }

--- a/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/service/HealthcheckService.java
+++ b/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/service/HealthcheckService.java
@@ -1,5 +1,6 @@
 package io.cattle.iaas.healthcheck.service;
 
+import io.cattle.platform.core.model.Instance;
 
 public interface HealthcheckService {
 
@@ -12,4 +13,6 @@ public interface HealthcheckService {
     void updateHealthcheck(String healthcheckInstanceHostMapUuid, final long externalTimestamp, final String health);
 
     void registerForHealtcheck(HealthcheckInstanceType instanceType, long id);
+
+    void updateInstanceHealthState(Instance instance, String updateWithState);
 }

--- a/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/service/impl/HealthcheckServiceImpl.java
+++ b/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/service/impl/HealthcheckServiceImpl.java
@@ -98,8 +98,8 @@ public class HealthcheckServiceImpl implements HealthcheckService {
         if (updateWithState == null) {
             return;
         }
-
-        updateHealthcheckInstance(hcInstance, updateWithState);
+        Instance instance = objectManager.loadResource(Instance.class, hcInstance.getInstanceId());
+        updateInstanceHealthState(instance, updateWithState);
     }
 
     protected boolean shouldUpdate(HealthcheckInstanceHostMap hcihm, long externalTimestamp, String healthState) {
@@ -160,8 +160,8 @@ public class HealthcheckServiceImpl implements HealthcheckService {
         return instance == null ? null : instance.getHealthState();
     }
 
-    protected void updateHealthcheckInstance(HealthcheckInstance hcInstance, String updateWithState) {
-        Instance instance = objectManager.loadResource(Instance.class, hcInstance.getInstanceId());
+    @Override
+    public void updateInstanceHealthState(Instance instance, String updateWithState) {
         if (instance != null) {
             if (updateWithState.equalsIgnoreCase(HealthcheckConstants.HEALTH_STATE_HEALTHY)) {
                 objectProcessManager.scheduleProcessInstance(HealthcheckConstants.PROCESS_UPDATE_HEALTHY, instance,

--- a/tests/integration/cattletest/core/test_healthcheck.py
+++ b/tests/integration/cattletest/core/test_healthcheck.py
@@ -121,7 +121,14 @@ def test_health_check_create_service(super_client, context, client):
                                      healthcheckUuid=hcihm.uuid)
     super_client.wait_success(se)
     hcihm = super_client.wait_success(super_client.reload(hcihm))
-    assert hcihm.healthState == 'reinitializing'
+    assert hcihm.healthState == 'healthy'
+    wait_for(lambda: super_client.reload(c).healthState == 'healthy',
+             timeout=5)
+
+    # restart the instance
+    c = super_client.wait_success(c.stop())
+    wait_for(lambda: super_client.reload(c).state == 'running',
+             timeout=5)
     wait_for(lambda: super_client.reload(c).healthState == 'reinitializing',
              timeout=5)
 
@@ -132,7 +139,7 @@ def test_health_check_create_service(super_client, context, client):
                                      healthcheckUuid=hcihm.uuid)
     super_client.wait_success(se)
     hcihm = super_client.wait_success(super_client.reload(hcihm))
-    assert hcihm.healthState == 'reinitializing'
+    assert hcihm.healthState == 'healthy'
     wait_for(lambda: super_client.reload(c).healthState == 'reinitializing',
              timeout=5)
 
@@ -154,8 +161,8 @@ def test_health_check_create_service(super_client, context, client):
                                      healthcheckUuid=hcihm.uuid)
     super_client.wait_success(se)
     hcihm = super_client.wait_success(super_client.reload(hcihm))
-    assert hcihm.healthState == 'reinitializing'
-    wait_for(lambda: super_client.reload(c).healthState == 'reinitializing',
+    assert hcihm.healthState == 'healthy'
+    wait_for(lambda: super_client.reload(c).healthState == 'healthy',
              timeout=5)
 
     ts = int(time.time())
@@ -251,14 +258,10 @@ def test_health_check_reinit_timeout(super_client, context, client):
     wait_for(lambda: super_client.reload(c).healthState == 'healthy',
              timeout=5)
 
-    ts = int(time.time())
-    client = _get_agent_client(agent)
-    se = client.create_service_event(externalTimestamp=ts,
-                                     reportedHealth='INIT',
-                                     healthcheckUuid=hcihm.uuid)
-    super_client.wait_success(se)
-    hcihm = super_client.wait_success(super_client.reload(hcihm))
-    assert hcihm.healthState == 'reinitializing'
+    # restart the instance
+    c = super_client.wait_success(c.stop())
+    wait_for(lambda: super_client.reload(c).state == 'running',
+             timeout=5)
     wait_for(lambda: super_client.reload(c).healthState == 'reinitializing',
              timeout=5)
 


### PR DESCRIPTION
as its being set by cattle on instance restart.
That is done to avoid the scenario when init state is reported on
healthcheck process restart inside the agent happening around the time
when instance becomes unheatlhy. This can lead to instance being set
with reinitializing state instead of unheatlhy, and it postpones (or
even cancels, if reinitializing timeout is not set) instance recreation


https://github.com/rancher/rancher/issues/3338