### PR TITLE
LB support for TLS 1.0

### DIFF
--- a/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
+++ b/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
@@ -46,7 +46,7 @@ defaults
 <#if listener.sourceProtocol == "https"><#assign protocol="http"></#if>
 <#if listener.sourceProtocol == "ssl"><#assign protocol="tcp"></#if>
 frontend ${listener.uuid}_frontend
-        bind ${publicIp}:${sourcePort}<#if (listener.sourceProtocol == "https" || listener.sourceProtocol == "ssl") && certs?has_content> ssl crt /etc/haproxy/certs/<#if !defaultCert??> strict-sni</#if>  no-sslv3 no-tlsv10</#if>
+        bind ${publicIp}:${sourcePort}<#if (listener.sourceProtocol == "https" || listener.sourceProtocol == "ssl") && certs?has_content> ssl crt /etc/haproxy/certs/<#if !defaultCert??> strict-sni</#if>  no-sslv3</#if>
         mode ${protocol}
 
         <#list backends[listener.uuid] as backend >


### PR DESCRIPTION
Fix for https://github.com/rancher/rancher/issues/3097

Any reason for TLS 1.0 to be disabled in the first place assuming HAProxy has a POODLE-safe implementation?

There's still many clients that don't support TLS above 1.0.