### PR TITLE
Added bindmount for conf/state dir to docker command.

### DIFF
--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/process-server/defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/process-server/defaults.properties
@@ -8,7 +8,7 @@ ha.host.id.cache.millis=3600000
 # 10 years
 registration.token.period.millis=315360000000
 process.account.create.register.token.account.kinds=admin,user
-docker.register.command=sudo docker run -d --privileged -v /var/run/docker.sock:/var/run/docker.sock %s %s
+docker.register.command=sudo docker run -d --privileged -v /var/run/docker.sock:/var/run/docker.sock -v /var/lib/rancher:/var/lib/rancher %s %s
 
 agent.image=cattle/agent:latest
 agent.instance.register.script=registration/registration.sh


### PR DESCRIPTION
In some circumstances, like adding a self signed CA pem, the first
instance of Rancher agent image needs to have access to the config
in the state directory to startup.