### PR TITLE
Lb instance as privileged

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/LoadBalancerDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/LoadBalancerDeploymentUnitInstance.java
@@ -34,7 +34,7 @@ public class LoadBalancerDeploymentUnitInstance extends DefaultDeploymentUnitIns
     }
 
     protected void setSystemContainer(Map<String, Object> launchConfigData) {
-        launchConfigData.put(InstanceConstants.FIELD_PRIVILEGED, "true");
+        launchConfigData.put(InstanceConstants.FIELD_PRIVILEGED, true);
         launchConfigData.put(InstanceConstants.FIELD_SYSTEM_CONTAINER, SystemContainer.LoadBalancerAgent);
     }
 


### PR DESCRIPTION
regression introduced by standalone LB removal code

@ibuildthecloud this PR along with https://github.com/rancher/cattle/pull/1304 should fix https://github.com/rancher/rancher/issues/3355 - monit not being able to kill haproxy process - more details are in the last comment to the bug.