### PR TITLE
Adds library name to Rancher catalog and add community.

### DIFF
--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/process/machine-defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/process/machine-defaults.properties
@@ -7,5 +7,5 @@ compose.executor.execute=false
 catalog.service.executable=rancher-catalog-service
 catalog.execute=false
 
-catalog.url=https://github.com/rancher/rancher-catalog.git
+catalog.url=library=https://github.com/rancher/rancher-catalog.git,community=https://github.com/rancher/community-catalog.git
 catalog.refresh.interval.seconds=300


### PR DESCRIPTION
Community catalog will be the location that our community members can
easily add templates.

This will set the defaults for new installations. The UI will make it easy to enable the community catalog. 

Having a separate catalog will allow organizations to enable / disable contributed templates on their infrastructure.