### PR TITLE
Varios ipsec + retain ip fixes

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/NetworkInfoDaoImpl.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/NetworkInfoDaoImpl.java
@@ -16,7 +16,6 @@ import static io.cattle.platform.core.model.tables.PortTable.*;
 import static io.cattle.platform.core.model.tables.SubnetTable.*;
 import static io.cattle.platform.core.model.tables.VnetTable.*;
 import static io.cattle.platform.core.constants.NetworkServiceConstants.*;
-
 import io.cattle.platform.configitem.context.dao.NetworkInfoDao;
 import io.cattle.platform.configitem.context.data.ClientIpsecTunnelInfo;
 import io.cattle.platform.configitem.context.data.HostPortForwardData;
@@ -24,6 +23,7 @@ import io.cattle.platform.configitem.context.data.HostRouteData;
 import io.cattle.platform.configitem.context.data.IpAssociationData;
 import io.cattle.platform.configitem.context.data.NetworkClientData;
 import io.cattle.platform.core.constants.CommonStatesConstants;
+import io.cattle.platform.core.constants.InstanceConstants;
 import io.cattle.platform.core.constants.IpAddressConstants;
 import io.cattle.platform.core.constants.NetworkServiceConstants;
 import io.cattle.platform.core.constants.NetworkServiceProviderConstants;
@@ -61,6 +61,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import javax.inject.Inject;
 
 public class NetworkInfoDaoImpl extends AbstractJooqDao implements NetworkInfoDao {
@@ -285,7 +286,8 @@ public class NetworkInfoDaoImpl extends AbstractJooqDao implements NetworkInfoDa
                         .and(ipAddress.REMOVED.isNull())
                         .and(host.REMOVED.isNull())
                         .and(subnet.REMOVED.isNull())
-                        .and(instance.REMOVED.isNull()))
+                        .and(instance.REMOVED.isNull())
+                        .and(instance.STATE.in(InstanceConstants.STATE_RUNNING, InstanceConstants.STATE_STARTING)))
                 .fetch().map(mapper);
 
         List<ClientIpsecTunnelInfo> result = new ArrayList<ClientIpsecTunnelInfo>(tempResult.size());

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
@@ -111,4 +111,6 @@ public abstract class DeploymentUnitInstance {
     public abstract boolean isHealthCheckInitializing();
 
     public abstract Long getServiceIndex();
+
+    public abstract void waitForScheduleStop();
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/ServiceDeploymentPlanner.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/ServiceDeploymentPlanner.java
@@ -234,4 +234,15 @@ public abstract class ServiceDeploymentPlanner {
             }
         }
     }
+
+    public void scheduleUnhealthyUnitsStop() {
+        List<DeploymentUnit> watchList = new ArrayList<>();
+        for (DeploymentUnit unit : this.unhealthyUnits) {
+            unit.stop();
+            watchList.add(unit);
+        }
+        for (DeploymentUnit toWatch : watchList) {
+            toWatch.waitForScheduleStop();
+        }
+    }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentManagerImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentManagerImpl.java
@@ -22,6 +22,8 @@ import io.cattle.platform.object.ObjectManager;
 import io.cattle.platform.object.process.ObjectProcessManager;
 import io.cattle.platform.object.process.StandardProcess;
 import io.cattle.platform.object.resource.ResourceMonitor;
+import io.cattle.platform.object.util.DataAccessor;
+import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
 import io.cattle.platform.servicediscovery.api.dao.ServiceExposeMapDao;
 import io.cattle.platform.servicediscovery.api.util.ServiceDiscoveryUtil;
 import io.cattle.platform.servicediscovery.deployment.DeploymentManager;
@@ -184,6 +186,13 @@ public class DeploymentManagerImpl implements DeploymentManager {
          * Cleanup incomplete units
          */
         planner.cleanupIncompleteUnits();
+
+        /*
+         * Stop unhealthy units for service with retainIp=true
+         */
+        if (DataAccessor.fieldBool(planner.getServices().get(0), ServiceDiscoveryConstants.FIELD_SERVICE_RETAIN_IP)) {
+            planner.scheduleUnhealthyUnitsStop();
+        }
 
         /*
          * Activate all the units

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/DefaultDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/DefaultDeploymentUnitInstance.java
@@ -263,5 +263,17 @@ public class DefaultDeploymentUnitInstance extends DeploymentUnitInstance implem
         
         return serviceIndexObj;
     }
+
+    @Override
+    public void waitForScheduleStop() {
+        this.instance = context.resourceMonitor.waitFor(this.instance,
+                new ResourcePredicate<Instance>() {
+            @Override
+            public boolean evaluate(Instance obj) {
+                        return InstanceConstants.STATE_STOPPING.equals(obj.getState())
+                                || InstanceConstants.STATE_STOPPED.equals(obj.getState());
+            }
+        });
+    }
 }
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/DeploymentUnit.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/DeploymentUnit.java
@@ -235,6 +235,12 @@ public class DeploymentUnit {
         }
     }
 
+    public void waitForScheduleStop() {
+        for (DeploymentUnitInstance instance : getDeploymentUnitInstances()) {
+            instance.waitForScheduleStop();
+        }
+    }
+
     protected DeploymentUnitInstance createInstance(String launchConfigName, Service service) {
         List<Integer> volumesFromInstanceIds = getSidekickContainersId(service, launchConfigName, SidekickType.DATA);
         List<Integer> networkContainerIds = getSidekickContainersId(service, launchConfigName, SidekickType.NETWORK);

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/ExternalDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/ExternalDeploymentUnitInstance.java
@@ -130,4 +130,8 @@ public class ExternalDeploymentUnitInstance extends DeploymentUnitInstance {
     public Long getServiceIndex() {
         return null;
     }
+
+    @Override
+    public void waitForScheduleStop() {
+    }
 }


### PR DESCRIPTION
1) Program ipsec channel rules only for instances in Running/Starting
state
2) service.upgrade - startFirst option can't be used on the service
with retainIp=true
3) service.reconcile - stop unhealthy instances before starting new ones


https://github.com/rancher/rancher/issues/3458