### PR TITLE
Make mount and vol sp map cleanup more robust

### DIFF
--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/volume/VolumePurge.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/volume/VolumePurge.java
@@ -7,6 +7,7 @@ import io.cattle.platform.core.model.VolumeStoragePoolMap;
 import io.cattle.platform.engine.handler.HandlerResult;
 import io.cattle.platform.engine.process.ProcessInstance;
 import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.engine.process.impl.ProcessCancelException;
 import io.cattle.platform.object.process.StandardProcess;
 import io.cattle.platform.process.base.AbstractDefaultProcessHandler;
 import io.cattle.platform.process.common.util.ProcessUtils;
@@ -21,18 +22,26 @@ public class VolumePurge extends AbstractDefaultProcessHandler {
 
     @Override
     public HandlerResult handle(ProcessState state, ProcessInstance process) {
-        Volume volume = (Volume) state.getResource();
+        Volume volume = (Volume)state.getResource();
 
         deallocate(volume, state.getData());
 
         for (VolumeStoragePoolMap map : mapDao.findToRemove(VolumeStoragePoolMap.class, Volume.class, volume.getId())) {
-            objectProcessManager.scheduleStandardProcess(StandardProcess.DEACTIVATE, map,
-                    ProcessUtils.chainInData(state.getData(), "volumestoragepoolmap.deactivate", "volumestoragepoolmap.remove"));
+            try {
+                objectProcessManager.scheduleStandardProcess(StandardProcess.DEACTIVATE, map,
+                        ProcessUtils.chainInData(state.getData(), "volumestoragepoolmap.deactivate", "volumestoragepoolmap.remove"));
+            } catch (ProcessCancelException e) {
+                objectProcessManager.scheduleStandardProcess(StandardProcess.REMOVE, map, null);
+            }
         }
 
-        for (Mount mount: mapDao.findToRemove(Mount.class, Volume.class, volume.getId())) {
-            objectProcessManager.scheduleStandardProcess(StandardProcess.DEACTIVATE, mount,
-                    ProcessUtils.chainInData(state.getData(), "mount.deactivate", "mount.remove"));
+        for (Mount mount : mapDao.findToRemove(Mount.class, Volume.class, volume.getId())) {
+            try {
+                objectProcessManager.scheduleStandardProcess(StandardProcess.DEACTIVATE, mount,
+                        ProcessUtils.chainInData(state.getData(), "mount.deactivate", "mount.remove"));
+            } catch (ProcessCancelException e) {
+                objectProcessManager.scheduleStandardProcess(StandardProcess.REMOVE, mount, null);
+            }
         }
 
         return new HandlerResult();


### PR DESCRIPTION
Fallback to scheduling a remove if deactivation failes for mounts or
volumeStoragePoolMaps during volume.purge.