### PR TITLE
Rollback: fix in unit-to-rollback lookup

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/addon/InServiceUpgradeStrategy.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/addon/InServiceUpgradeStrategy.java
@@ -53,4 +53,15 @@ public class InServiceUpgradeStrategy extends ServiceUpgradeStrategy {
     public void setStartFirst(boolean startFirst) {
         this.startFirst = startFirst;
     }
+
+    public boolean isFullUpgrade() {
+        boolean primaryUpgrade = this.launchConfig != null && this.previousLaunchConfig != null;
+        boolean isEmptySec = this.secondaryLaunchConfigs == null || this.secondaryLaunchConfigs.isEmpty();
+        boolean isEmptyPrevSesc = this.previousSecondaryLaunchConfigs == null
+                || this.previousSecondaryLaunchConfigs.isEmpty();
+
+        boolean allSecondaryUpgrades = (isEmptySec == isEmptyPrevSesc)
+                && (isEmptySec || this.secondaryLaunchConfigs.size() == this.previousSecondaryLaunchConfigs.size());
+        return primaryUpgrade && allSecondaryUpgrades;
+    }
 }


### PR DESCRIPTION
When search for deployment unit to rollback, do by uuid search only when
upgrade is partial (not all primary/secondary launch config of the service gets upgraded). In other cases, make a random pick of unit-to-rollback.

https://github.com/rancher/rancher/issues/3529