### PR TITLE
Validate state in addition to Removed field check

### DIFF
--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/dao/impl/AgentInstanceDaoImpl.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/dao/impl/AgentInstanceDaoImpl.java
@@ -62,7 +62,9 @@ public class AgentInstanceDaoImpl extends AbstractJooqDao implements AgentInstan
         return create()
                 .selectFrom(INSTANCE)
                 .where(INSTANCE.AGENT_ID.eq(agent.getId())
-                        .and(INSTANCE.REMOVED.isNull()))
+                        .and(INSTANCE.REMOVED.isNull())
+                        .and(INSTANCE.STATE.notIn(CommonStatesConstants.ERROR, CommonStatesConstants.ERRORING,
+                                CommonStatesConstants.REMOVING)))
                 .fetchAny();
     }
 
@@ -97,7 +99,9 @@ public class AgentInstanceDaoImpl extends AbstractJooqDao implements AgentInstan
                         .on(NIC.INSTANCE_ID.eq(INSTANCE.ID))
                     .where(NIC.VNET_ID.eq(nic.getVnetId())
                             .and(NETWORK_SERVICE_PROVIDER_INSTANCE_MAP.NETWORK_SERVICE_PROVIDER_ID.eq(provider.getId()))
-                            .and(INSTANCE.REMOVED.isNull()))
+                        .and(INSTANCE.REMOVED.isNull())
+                        .and(INSTANCE.STATE.notIn(CommonStatesConstants.ERROR, CommonStatesConstants.ERRORING,
+                                CommonStatesConstants.REMOVING)))
                     .fetchInto(InstanceRecord.class);
 
         return records.size() > 0 ? records.get(0) : null;
@@ -126,7 +130,9 @@ public class AgentInstanceDaoImpl extends AbstractJooqDao implements AgentInstan
                 .join(NETWORK_SERVICE_PROVIDER_INSTANCE_MAP)
                     .on(NETWORK_SERVICE_PROVIDER_INSTANCE_MAP.INSTANCE_ID.eq(INSTANCE.ID))
                 .where(INSTANCE.REMOVED.isNull()
-                        .and(NETWORK_SERVICE_PROVIDER_INSTANCE_MAP.NETWORK_SERVICE_PROVIDER_ID.eq(provider.getId())))
+                        .and(NETWORK_SERVICE_PROVIDER_INSTANCE_MAP.NETWORK_SERVICE_PROVIDER_ID.eq(provider.getId()))
+                        .and(INSTANCE.STATE.notIn(CommonStatesConstants.ERROR, CommonStatesConstants.ERRORING,
+                                CommonStatesConstants.REMOVING)))
                 .fetchInto(AgentRecord.class);
     }
 

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/InstanceDaoImpl.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/InstanceDaoImpl.java
@@ -73,7 +73,9 @@ public class InstanceDaoImpl extends AbstractJooqDao implements InstanceDao {
                 .join(INSTANCE_HOST_MAP)
                     .on(INSTANCE_HOST_MAP.HOST_ID.eq(hostId)
                             .and(INSTANCE_HOST_MAP.INSTANCE_ID.eq(INSTANCE.ID)))
-                .where(INSTANCE.REMOVED.isNull())
+                .where(INSTANCE.REMOVED.isNull().and(
+                        INSTANCE.STATE.notIn(CommonStatesConstants.ERROR, CommonStatesConstants.ERRORING,
+                                CommonStatesConstants.REMOVING)))
                 .fetchInto(InstanceRecord.class);
     }
 

--- a/code/implementation/agent-connection-delegate/src/main/java/io/cattle/platform/agent/connection/delegate/dao/impl/AgentDelegateDaoImpl.java
+++ b/code/implementation/agent-connection-delegate/src/main/java/io/cattle/platform/agent/connection/delegate/dao/impl/AgentDelegateDaoImpl.java
@@ -4,6 +4,7 @@ import static io.cattle.platform.core.model.tables.HostTable.*;
 import static io.cattle.platform.core.model.tables.InstanceHostMapTable.*;
 import static io.cattle.platform.core.model.tables.InstanceTable.*;
 import io.cattle.platform.agent.connection.delegate.dao.AgentDelegateDao;
+import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.model.Agent;
 import io.cattle.platform.core.model.Host;
 import io.cattle.platform.core.model.Instance;
@@ -24,7 +25,9 @@ public class AgentDelegateDaoImpl extends AbstractJooqDao implements AgentDelega
                     .join(HOST)
                         .on(INSTANCE_HOST_MAP.HOST_ID.eq(HOST.ID))
                     .where(INSTANCE.AGENT_ID.eq(agent.getId())
-                            .and(INSTANCE.REMOVED.isNull())
+                        .and(INSTANCE.REMOVED.isNull().and(
+                                INSTANCE.STATE.notIn(CommonStatesConstants.ERROR, CommonStatesConstants.ERRORING,
+                                        CommonStatesConstants.REMOVING)))
                             .and(HOST.REMOVED.isNull()))
                     .fetchAny();
 
@@ -36,7 +39,9 @@ public class AgentDelegateDaoImpl extends AbstractJooqDao implements AgentDelega
         return create()
                 .selectFrom(INSTANCE)
                 .where(INSTANCE.AGENT_ID.eq(agent.getId())
-                        .and(INSTANCE.REMOVED.isNull()))
+                        .and(INSTANCE.REMOVED.isNull())
+                        .and(INSTANCE.STATE.notIn(CommonStatesConstants.ERROR, CommonStatesConstants.ERRORING,
+                                CommonStatesConstants.REMOVING)))
                 .fetchOne();
     }
 


### PR DESCRIPTION
When search for valid network agents, check that the state is not
Error/Erroring in addition to validating Removed field != null

@ibuildthecloud hit this bug today while testing host-api changes. Network-agent failed to deploy, and went to Error state. This state wasn't blacklisted, so we were trying to start/send config updates to this "dead" network-instance.

