### PR TITLE
Removed unneeded group by clause

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/MetaDataInfoDaoImpl.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/MetaDataInfoDaoImpl.java
@@ -137,7 +137,7 @@ public class MetaDataInfoDaoImpl extends AbstractJooqDao implements MetaDataInfo
                 .and(host.STATE.notIn(CommonStatesConstants.REMOVING, CommonStatesConstants.REMOVED))
                 .and(INSTANCE_HOST_MAP.INSTANCE_ID.eq(instance.getId()))
                 .and(hostIpAddress.REMOVED.isNull())
-                .and(host.ACCOUNT_ID.eq(accountId)).groupBy(host.ID)
+                .and(host.ACCOUNT_ID.eq(accountId))
                 .fetch().map(mapper);
     }
 
@@ -166,7 +166,7 @@ public class MetaDataInfoDaoImpl extends AbstractJooqDao implements MetaDataInfo
                 .where(host.REMOVED.isNull())
                 .and(host.STATE.notIn(CommonStatesConstants.REMOVING, CommonStatesConstants.REMOVED))
                 .and(hostIpAddress.REMOVED.isNull())
-                .and(host.ACCOUNT_ID.eq(accountId)).groupBy(host.ID)
+                .and(host.ACCOUNT_ID.eq(accountId))
                 .fetch().map(mapper);
     }
 


### PR DESCRIPTION
@ibuildthecloud after you've split getting host/hostip records into 2 methods - getting it for specific instance and getting it for all - there is no need for groupBy clause. It was needed before because we had left outer join on instance_host_map table. After your fix, we either get it for specific instance with inner join, or just getting all hosts in the system.