### PR TITLE
Changes to support swarm integration: Allocate an instance during Create instead of Start

### DIFF
--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceStart.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceStart.java
@@ -63,13 +63,10 @@ public class InstanceStart extends AbstractDefaultProcessHandler {
         Map<String, Object> resultData = new ConcurrentHashMap<String, Object>();
         HandlerResult result = new HandlerResult(resultData);
 
-        progress.init(state, 5, 5, 80, 5, 5);
+        progress.init(state, 5, 80, 5, 5);
 
         try {
             try {
-                progress.checkPoint("Scheduling");
-                allocate(instance);
-
                 progress.checkPoint("Networking");
                 network(instance, state);
                 activatePorts(instance, state);

--- a/resources/content/schema/base/container.json
+++ b/resources/content/schema/base/container.json
@@ -235,6 +235,22 @@
          "startCount" : {
             "type" : "int",
             "nullable" : true
+        },
+		 "startOnCreate": {
+            "type": "boolean",
+            "nullable": false,
+            "default": "true"
+        },
+         "nativeContainer": {
+            "type": "boolean",
+            "nullable": false,
+            "default": "false"
+        },
+        "validHostIds" : {
+            "type" : "array[reference[host]",
+            "create" : true,
+            "update" : true,
+            "nullable" : true
         }
     },
     "resourceActions": {

--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -104,7 +104,7 @@
         "container.tty" : "cr",
         "container.user" : "cr",
         "container.systemContainer" : "r",
-        "container.nativeContainer" : "r",
+        "container.nativeContainer" : "cr",
         "container.labels" : "cr",
         "container.volumeDriver" : "cr",
         "container.workingDir" : "cr",
@@ -113,6 +113,7 @@
         "container.deploymentUnitUuid" : "r",
         "container.version" : "r",
         "container.startCount" : "r",
+        "container.validHostIds" : "cr",
 
         "containerExec" : "r",
         "containerExec.attachStdin" : "cr",


### PR DESCRIPTION
Made changes to call allocation during InstanceCreate instead of InstanceStart.
Exposed following fields for Container:
 "startOnCreate",  "nativeContainer","validHostIds"