### PR TITLE
put non-fqdn self stack records to client sections

### DIFF
--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/util/ServiceDiscoveryDnsUtil.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/util/ServiceDiscoveryDnsUtil.java
@@ -28,12 +28,18 @@ public class ServiceDiscoveryDnsUtil {
                 .append(getNamespace(service)).toString().toLowerCase();
     }
 
-    public static String getFqdn(Environment stack, Service service, String launchConfigName) {
-        return getServiceNamespace(stack, service, launchConfigName).toLowerCase() + ".";
+
+    public static String getFqdn(Environment stack, Service service, String launchConfigName, boolean forDefault) {
+        if (forDefault) {
+            return getServiceNamespace(stack, service, launchConfigName).toLowerCase() + ".";
+
+        } else {
+            return launchConfigName.toLowerCase() + ".";
+        }
     }
 
     public static String getDnsName(Service service, Environment stack, String linkName,
-            String dnsPrefix, boolean self) {
+            String dnsPrefix, boolean self, boolean forDefault) {
 
         if (!StringUtils.isEmpty(linkName)) {
             return linkName;
@@ -46,6 +52,6 @@ public class ServiceDiscoveryDnsUtil {
             dnsName = dnsPrefix == null ? service.getName() : dnsPrefix + "." + service.getName();
         }
 
-        return ServiceDiscoveryDnsUtil.getFqdn(stack, service, dnsName);
+        return ServiceDiscoveryDnsUtil.getFqdn(stack, service, dnsName, forDefault);
     }
 }


### PR DESCRIPTION
@ibuildthecloud @vincent99 

https://github.com/rancher/rancher/issues/3694

to support clients that do dns name search by always appending "." at the end of the dns-name-to-resolve, so configured search domains are not being used.