### PR TITLE
Automatically retain ip for vm service.

### DIFF
--- a/code/implementation/vm/pom.xml
+++ b/code/implementation/vm/pom.xml
@@ -34,5 +34,10 @@
             <artifactId>cattle-iaas-metadata</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.cattle</groupId>
+            <artifactId>cattle-iaas-service-discovery-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/code/implementation/vm/src/main/java/io/cattle/platform/vm/process/ServiceVirtualMachinePreCreate.java
+++ b/code/implementation/vm/src/main/java/io/cattle/platform/vm/process/ServiceVirtualMachinePreCreate.java
@@ -1,0 +1,36 @@
+package io.cattle.platform.vm.process;
+
+import static io.cattle.platform.core.constants.InstanceConstants.*;
+import static io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants.*;
+import io.cattle.platform.core.model.Service;
+import io.cattle.platform.engine.handler.HandlerResult;
+import io.cattle.platform.engine.handler.ProcessPreListener;
+import io.cattle.platform.engine.process.ProcessInstance;
+import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.object.util.DataAccessor;
+import io.cattle.platform.process.common.handler.AbstractObjectProcessLogic;
+import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
+import io.cattle.platform.util.type.CollectionUtils;
+import io.cattle.platform.util.type.Priority;
+
+public class ServiceVirtualMachinePreCreate extends AbstractObjectProcessLogic implements ProcessPreListener, Priority {
+
+    @Override
+    public String[] getProcessNames() {
+        return new String[] { "service.create" };
+    }
+
+    @Override
+    public HandlerResult handle(ProcessState state, ProcessInstance process) {
+        Service service = (Service)state.getResource();
+        if (KIND_VIRTUAL_MACHINE.equals(CollectionUtils.getNestedValue(DataAccessor.fieldMap(service, FIELD_LAUNCH_CONFIG).get("kind")))) {
+            return new HandlerResult(ServiceDiscoveryConstants.FIELD_SERVICE_RETAIN_IP, true);
+        }
+        return null;
+    }
+
+    @Override
+    public int getPriority() {
+        return Priority.PRE;
+    }
+}

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/process/spring-process-context.xml
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/process/spring-process-context.xml
@@ -433,5 +433,6 @@
 
     <bean class="io.cattle.platform.vm.process.VirtualMachineMetadata" />
     <bean class="io.cattle.platform.vm.process.VirtualMachinePreCreate" />
+    <bean class="io.cattle.platform.vm.process.ServiceVirtualMachinePreCreate" />
 
 </beans>


### PR DESCRIPTION
If a vm is created as part of a service for VM HA reasons, we should automatically retain the IP.

This does not address a scenario where a VM is added as a sidekick to a service, but I don't think we should assume retain IP in that scenario. In that scenario, user should specify it explicitly themselves.