### PR TITLE
Bind to all interfaces (instead of just 10.42.x.x) on haproxy listeners

### DIFF
--- a/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
+++ b/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl
@@ -47,7 +47,7 @@ defaults
 <#if listener.sourceProtocol == "https"><#assign protocol="http"></#if>
 <#if listener.sourceProtocol == "ssl"><#assign protocol="tcp"></#if>
 frontend ${listener.uuid}_frontend
-        bind ${publicIp}:${sourcePort}<#if (listener.sourceProtocol == "https" || listener.sourceProtocol == "ssl") && certs?has_content> ssl crt /etc/haproxy/certs/<#if !defaultCert??> strict-sni</#if></#if>
+        bind *:${sourcePort}<#if (listener.sourceProtocol == "https" || listener.sourceProtocol == "ssl") && certs?has_content> ssl crt /etc/haproxy/certs/<#if !defaultCert??> strict-sni</#if></#if>
         mode ${protocol}
 
         <#list backends[listener.uuid] as backend >
@@ -99,5 +99,5 @@ backend ${listener.uuid}_${backend.uuid}_backend
 
 listen default
 <#if lbHealthCheck??><#assign defaultPort = lbHealthCheck.port><#else><#assign defaultPort = 42></#if>
-	bind 0.0.0.0:${defaultPort}
+	bind *:${defaultPort}
 


### PR DESCRIPTION
instead of just binding to 10.42.x.x. To solve hairpin nat use case


https://github.com/rancher/rancher/issues/3618


@ibuildthecloud let me know if you see any potential problems with this fix.