### PR TITLE
Scale policy

### DIFF
--- a/code/framework/object/src/main/java/io/cattle/platform/object/purge/impl/RemoveMonitorImpl.java
+++ b/code/framework/object/src/main/java/io/cattle/platform/object/purge/impl/RemoveMonitorImpl.java
@@ -19,8 +19,10 @@ import io.github.ibuildthecloud.gdapi.factory.SchemaFactory;
 import io.github.ibuildthecloud.gdapi.model.Schema;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -71,7 +73,9 @@ public class RemoveMonitorImpl implements RemoveMonitor, Task {
 
             for (Object obj : objects) {
                 try {
-                    objectProcessManager.scheduleStandardProcess(StandardProcess.REMOVE, obj, null);
+                    Map<String, Object> data = new HashMap<>();
+                    data.put("errorState", true);
+                    objectProcessManager.scheduleStandardProcess(StandardProcess.REMOVE, obj, data);
                     log.info("Scheduling remove for [{}] id [{}]", type, ObjectUtils.getId(obj));
                 } catch (ProcessNotFoundException e) {
                 } catch (ProcessInstanceException e) {

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/addon/ScalePolicy.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/addon/ScalePolicy.java
@@ -1,0 +1,36 @@
+package io.cattle.platform.core.addon;
+
+import io.github.ibuildthecloud.gdapi.annotation.Field;
+
+public class ScalePolicy {
+    Integer increment;
+    Integer min;
+    Integer max;
+
+    @Field(required = false, nullable = true, defaultValue = "1", min = 1)
+    public Integer getIncrement() {
+        return increment;
+    }
+
+    public void setIncrement(Integer increment) {
+        this.increment = increment;
+    }
+
+    @Field(required = true, nullable = true, defaultValue = "1", min = 1)
+    public Integer getMin() {
+        return min;
+    }
+
+    public void setMin(Integer minScale) {
+        this.min = minScale;
+    }
+
+    @Field(required = false, nullable = true, defaultValue = "1", min = 1)
+    public Integer getMax() {
+        return max;
+    }
+
+    public void setMax(Integer maxScale) {
+        this.max = maxScale;
+    }
+}

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
@@ -44,6 +44,9 @@ public class ServiceDiscoveryConstants {
     public static final String STACK_FIELD_RANCHER_COMPOSE = "rancherCompose";
     public static final String STACK_FIELD_START_ON_CREATE = "startOnCreate";
     public static final String FIELD_SET_VIP = "assignServiceIpAddress";
+    public static final String FIELD_SCALE_POLICY = "scalePolicy";
+    public static final String FIELD_DESIRED_SCALE_INTERNAL = "desiredScaleInternal";
+    public static final String FIELD_CURRENT_SCALE = "currentScale";
 
     public static final String ACTION_SERVICE_ACTIVATE = "activate";
     public static final String ACTION_SERVICE_CREATE = "create";

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/dao/ServiceExposeMapDao.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/dao/ServiceExposeMapDao.java
@@ -60,4 +60,6 @@ public interface ServiceExposeMapDao {
 
     List<? extends Instance> getUpgradedInstances(Service service, String launchConfigName, String toVersion, boolean managed);
 
+    List<? extends Instance> listServiceInstances(long serviceId);
+
 }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/resource/ServiceDiscoveryConfigItem.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/resource/ServiceDiscoveryConfigItem.java
@@ -98,6 +98,9 @@ public class ServiceDiscoveryConfigItem {
     public static final ServiceDiscoveryConfigItem RETAIN_IP = new ServiceDiscoveryConfigItem(
             ServiceDiscoveryConstants.FIELD_SERVICE_RETAIN_IP,
             "retain_ip", false, false);
+    public static final ServiceDiscoveryConfigItem SCALE_POLICY = new ServiceDiscoveryConfigItem(
+            ServiceDiscoveryConstants.FIELD_SCALE_POLICY,
+            "scale_policy", false, false);
 
     /**
      * Name as it appears in docker-compose file

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/dao/impl/ServiceExposeMapDaoImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/dao/impl/ServiceExposeMapDaoImpl.java
@@ -108,7 +108,24 @@ public class ServiceExposeMapDaoImpl extends AbstractJooqDao implements ServiceE
                         .and(SERVICE_EXPOSE_MAP.STATE.in(CommonStatesConstants.ACTIVATING,
                                 CommonStatesConstants.ACTIVE, CommonStatesConstants.REQUESTED))
                         .and(INSTANCE.STATE.notIn(CommonStatesConstants.PURGING, CommonStatesConstants.PURGED,
-                                CommonStatesConstants.REMOVED, CommonStatesConstants.REMOVING)))
+                                CommonStatesConstants.REMOVED, CommonStatesConstants.REMOVING,
+                                InstanceConstants.STATE_ERROR, InstanceConstants.STATE_ERRORING)))
+                .fetchInto(InstanceRecord.class);
+    }
+
+    @Override
+    public List<? extends Instance> listServiceInstances(long serviceId) {
+        return create()
+                .select(INSTANCE.fields())
+                .from(INSTANCE)
+                .join(SERVICE_EXPOSE_MAP)
+                .on(SERVICE_EXPOSE_MAP.INSTANCE_ID.eq(INSTANCE.ID)
+                        .and(SERVICE_EXPOSE_MAP.SERVICE_ID.eq(serviceId))
+                        .and(SERVICE_EXPOSE_MAP.STATE.in(CommonStatesConstants.ACTIVATING,
+                                CommonStatesConstants.ACTIVE, CommonStatesConstants.REQUESTED))
+                        .and(INSTANCE.STATE.notIn(CommonStatesConstants.PURGING, CommonStatesConstants.PURGED,
+                                CommonStatesConstants.REMOVED, CommonStatesConstants.REMOVING,
+                                InstanceConstants.STATE_ERROR, InstanceConstants.STATE_ERRORING)))
                 .fetchInto(InstanceRecord.class);
     }
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/planner/DefaultServiceDeploymentPlanner.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/planner/DefaultServiceDeploymentPlanner.java
@@ -18,8 +18,17 @@ public class DefaultServiceDeploymentPlanner extends ServiceDeploymentPlanner {
             DeploymentServiceContext context) {
         super(services, units, context);
         for (Service service : services) {
-            int scale = DataAccessor.fieldInteger(service,
-                    ServiceDiscoveryConstants.FIELD_SCALE);
+            int scale;
+            // internal desired scale populated by scale policy driven deployment
+            Integer scaleInternal = DataAccessor.fieldInteger(service,
+                    ServiceDiscoveryConstants.FIELD_DESIRED_SCALE_INTERNAL);
+            if (scaleInternal != null) {
+                scale = scaleInternal;
+            } else {
+                scale = DataAccessor.fieldInteger(service,
+                        ServiceDiscoveryConstants.FIELD_SCALE);
+            }
+
             if (scale > this.requestedScale) {
                 this.requestedScale = scale;
             }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceUpdateActivate.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceUpdateActivate.java
@@ -17,6 +17,7 @@ import io.cattle.platform.object.util.DataAccessor;
 import io.cattle.platform.process.common.handler.AbstractObjectProcessHandler;
 import io.cattle.platform.process.progress.ProcessProgress;
 import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
+import io.cattle.platform.servicediscovery.api.dao.ServiceExposeMapDao;
 import io.cattle.platform.servicediscovery.deployment.DeploymentManager;
 import io.github.ibuildthecloud.gdapi.id.IdFormatter;
 
@@ -52,6 +53,9 @@ public class ServiceUpdateActivate extends AbstractObjectProcessHandler {
 
     @Inject
     AuditService auditSvc;
+
+    @Inject
+    ServiceExposeMapDao exposeDao;
 
     @Override
     public String[] getProcessNames() {
@@ -98,7 +102,8 @@ public class ServiceUpdateActivate extends AbstractObjectProcessHandler {
             }
         }
 
-        return null;
+        int currentScale = exposeDao.listServiceInstances(service.getId()).size();
+        return new HandlerResult(ServiceDiscoveryConstants.FIELD_CURRENT_SCALE, currentScale);
     }
 
     protected String obfuscateId(TimeoutException ex) {

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServicesReconcileTrigger.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServicesReconcileTrigger.java
@@ -2,6 +2,7 @@ package io.cattle.platform.servicediscovery.process;
 
 import io.cattle.platform.core.constants.HealthcheckConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
+import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.Service;
 import io.cattle.platform.engine.handler.HandlerResult;
 import io.cattle.platform.engine.process.ProcessInstance;
@@ -38,6 +39,11 @@ public class ServicesReconcileTrigger extends AbstractObjectProcessHandler {
         if (state.getResource() instanceof Service) {
             services.add((Service) state.getResource());
         } else {
+            if (state.getResource() instanceof Instance) {
+                if (state.getData().containsKey("errorState")) {
+                    return null;
+                }
+            }
             for (ServiceLookup lookup : serviceLookups) {
                 Collection<? extends Service> lookupSvs = lookup.getServices(state.getResource());
                 if (lookupSvs != null) {

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/HostServiceLookup.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/HostServiceLookup.java
@@ -1,11 +1,19 @@
 package io.cattle.platform.servicediscovery.service.impl;
 
+import static io.cattle.platform.core.model.tables.ServiceTable.*;
+import io.cattle.platform.core.addon.ScalePolicy;
 import io.cattle.platform.core.model.Host;
 import io.cattle.platform.core.model.Service;
+import io.cattle.platform.json.JsonMapper;
+import io.cattle.platform.object.ObjectManager;
+import io.cattle.platform.object.util.DataAccessor;
+import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
 import io.cattle.platform.servicediscovery.api.dao.ServiceDao;
 import io.cattle.platform.servicediscovery.service.ServiceLookup;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import javax.inject.Inject;
 
@@ -14,13 +22,34 @@ public class HostServiceLookup implements ServiceLookup {
     @Inject
     ServiceDao svcDao;
 
+    @Inject
+    ObjectManager objMgr;
+
+    @Inject
+    JsonMapper mapper;
+
     @Override
     public Collection<? extends Service> getServices(Object obj) {
         if (!(obj instanceof Host)) {
             return null;
         }
         Host host = (Host) obj;
-        return svcDao.getServicesOnHost(host.getId());
+        List<Service> services = new ArrayList<>();
+        // add all services on host
+        services.addAll(svcDao.getServicesOnHost(host.getId()));
+
+        // add all services with scale policy
+        List<? extends Service> allServices = objMgr.find(Service.class, SERVICE.ACCOUNT_ID, host.getAccountId(),
+                SERVICE.REMOVED, null);
+        for (Service service : allServices) {
+            ScalePolicy policy = DataAccessor.field(service,
+                    ServiceDiscoveryConstants.FIELD_SCALE_POLICY, mapper, ScalePolicy.class);
+            if (policy != null) {
+                services.add(service);
+            }
+        }
+
+        return services;
     }
 
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
@@ -7,6 +7,7 @@ import static io.cattle.platform.core.model.tables.SubnetTable.*;
 import io.cattle.platform.allocator.service.AllocatorService;
 import io.cattle.platform.core.addon.LoadBalancerServiceLink;
 import io.cattle.platform.core.addon.PublicEndpoint;
+import io.cattle.platform.core.addon.ScalePolicy;
 import io.cattle.platform.core.addon.ServiceLink;
 import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.constants.HealthcheckConstants;
@@ -649,6 +650,12 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
             if (scale == null || ServiceDiscoveryUtil.isNoopService(service, allocatorService)) {
                 scale = 0;
             }
+            ScalePolicy policy = DataAccessor.field(service,
+                    ServiceDiscoveryConstants.FIELD_SCALE_POLICY, jsonMapper, ScalePolicy.class);
+            if (policy != null) {
+                scale = policy.getMin();
+            }
+
             List<String> lcs = ServiceDiscoveryUtil.getServiceLaunchConfigNames(service);
             Integer expectedScale = scale * lcs.size();
             boolean isGlobal = isGlobalService(service);

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/core-model/spring-core-model-context.xml
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/core-model/spring-core-model-context.xml
@@ -31,6 +31,7 @@
                 <value>io.cattle.platform.core.addon.RecreateOnQuorumStrategyConfig</value>
                 <value>io.cattle.platform.core.addon.HaConfigInput</value>
                 <value>io.cattle.platform.core.addon.BlkioDeviceOption</value>
+                <value>io.cattle.platform.core.addon.ScalePolicy</value>
             </set>
         </property>
     </bean>

--- a/resources/content/schema/base/service.json
+++ b/resources/content/schema/base/service.json
@@ -14,6 +14,24 @@
                 "scheduleUpdate" : true
             }
         },
+        "desiredScaleInternal": {
+            "type": "int",
+            "required": false,
+            "nullable": false
+        },
+        "currentScale": {
+            "type": "int",
+            "required": false,
+            "nullable": false
+        },
+        "scalePolicy": {
+            "type": "scalePolicy",
+            "required": false,
+            "nullable": true,
+            "attributes" : {
+                "scheduleUpdate" : true
+            }
+        },
         "name":{
             "required": true,
             "validChars": "a-zA-Z0-9-",

--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -535,6 +535,8 @@
         "service.healthState": "r",
         "service.startOnCreate": "cr",
         "service.resourceActions.certificate": "",
+        "service.scalePolicy" : "cru",
+        "service.currentScale" : "r",
 
         "addRemoveServiceLinkInput" : "r",
         "addRemoveServiceLinkInput.serviceLink" : "cr",
@@ -611,7 +613,8 @@
         "externalService.resourceActions.setservicelinks" : "",
         "externalService.retainIp" : "",
         "externalService.assignServiceIpAddress" : "",
-
+        "externalService.scalePolicy" : "",
+        "externalService.currentScale" : "",
 
         "dnsService" : "r",
         "dnsService.scale" : "",
@@ -620,6 +623,8 @@
         "dnsService.createIndex" : "",
         "dnsService.selectorContainer" : "",
         "dnsService.publicEndpoints" : "",
+        "dnsService.scalePolicy" : "",
+        "dnsService.currentScale" : "",
 
         "kubernetesService" : "r",
         "kubernetesService.assignServiceIpAddress" : "",
@@ -637,6 +642,8 @@
         "kubernetesService.upgrade" : "",
         "kubernetesService.vip" : "r",
         "kubernetesService.startOnCreate" : "",
+        "kubernetesService.scalePolicy" : "",
+        "kubernetesService.currentScale" : "",
 
         "serviceEvent" : "r",
         "serviceEvent.instanceId" : "r",
@@ -772,6 +779,11 @@
         "healthcheckInstanceHostMap.instanceId" : "r",
         "healthcheckInstanceHostMap.hostId" : "r",
         "healthcheckInstanceHostMap.healthState" : "r",
+
+        "scalePolicy" : "r",
+        "scalePolicy.min" : "cr",
+        "scalePolicy.max" : "cr",
+        "scalePolicy.increment" : "cr",
 
         "end" : ""
     }

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -188,6 +188,7 @@ def test_user_types(user_client, adds=set(), removes=set()):
         'volumeSnapshotInput',
         'nfsConfig',
         'blkioDeviceOption',
+        'scalePolicy',
     }
     types.update(adds)
     types.difference_update(removes)
@@ -407,6 +408,7 @@ def test_admin_types(admin_user_client, adds=set(), removes=set()):
         'volumeSnapshotInput',
         'nfsConfig',
         'blkioDeviceOption',
+        'scalePolicy'
     }
     types.update(adds)
     types.difference_update(removes)
@@ -1656,6 +1658,8 @@ def test_svc_discovery_service(admin_user_client, user_client, project_client,
         'assignServiceIpAddress': 'r',
         'healthState': 'r',
         'startOnCreate': 'r',
+        'scalePolicy': 'r',
+        'currentScale': 'r',
     })
 
     auth_check(user_client.schema, 'service', 'r', {
@@ -1678,6 +1682,8 @@ def test_svc_discovery_service(admin_user_client, user_client, project_client,
         'assignServiceIpAddress': 'r',
         'healthState': 'r',
         'startOnCreate': 'r',
+        'scalePolicy': 'r',
+        'currentScale': 'r',
     })
 
     auth_check(project_client.schema, 'service', 'crud', {
@@ -1700,6 +1706,8 @@ def test_svc_discovery_service(admin_user_client, user_client, project_client,
         'assignServiceIpAddress': 'cr',
         'healthState': 'r',
         'startOnCreate': 'cr',
+        'scalePolicy': 'cru',
+        'currentScale': 'r',
     })
 
     resource_action_check(user_client.schema, 'service', [
@@ -1877,6 +1885,8 @@ def test_svc_discovery_lb_service(admin_user_client, user_client,
         'assignServiceIpAddress': 'r',
         'healthState': 'r',
         'startOnCreate': 'r',
+        'scalePolicy': 'r',
+        'currentScale': 'r',
     })
 
     auth_check(user_client.schema, 'loadBalancerService', 'r', {
@@ -1899,6 +1909,8 @@ def test_svc_discovery_lb_service(admin_user_client, user_client,
         'assignServiceIpAddress': 'r',
         'healthState': 'r',
         'startOnCreate': 'r',
+        'scalePolicy': 'r',
+        'currentScale': 'r',
     })
 
     auth_check(project_client.schema, 'loadBalancerService', 'crud', {
@@ -1921,6 +1933,8 @@ def test_svc_discovery_lb_service(admin_user_client, user_client,
         'assignServiceIpAddress': 'cr',
         'healthState': 'r',
         'startOnCreate': 'cr',
+        'scalePolicy': 'cru',
+        'currentScale': 'r',
     })
 
 
@@ -2592,6 +2606,8 @@ def test_compose_service(admin_user_client, user_client, project_client):
         'selectorLink': 'r',
         'scale': 'r',
         'publicEndpoints': 'r',
+        'scalePolicy': 'r',
+        'currentScale': 'r',
     })
 
     auth_check(user_client.schema, 'composeService', 'r', {
@@ -2608,6 +2624,8 @@ def test_compose_service(admin_user_client, user_client, project_client):
         'selectorLink': 'r',
         'scale': 'r',
         'publicEndpoints': 'r',
+        'scalePolicy': 'r',
+        'currentScale': 'r',
     })
 
     auth_check(project_client.schema, 'composeService', 'rd', {
@@ -2624,6 +2642,8 @@ def test_compose_service(admin_user_client, user_client, project_client):
         'selectorLink': 'r',
         'scale': 'r',
         'publicEndpoints': 'r',
+        'scalePolicy': 'r',
+        'currentScale': 'r',
     })
 
 

--- a/tests/integration/cattletest/core/test_svc_scale_policy.py
+++ b/tests/integration/cattletest/core/test_svc_scale_policy.py
@@ -1,0 +1,194 @@
+from common_fixtures import *  # NOQA
+from cattle import ApiError
+
+
+def _create_stack(client):
+    env = client.create_environment(name=random_str())
+    env = client.wait_success(env)
+    assert env.state == "active"
+    return env
+
+
+def test_activate_svc(client, context, super_client):
+    env = _create_stack(client)
+
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": image_uuid}
+    scale_policy = {"min": 2, "max": 4, "increment": 2}
+
+    svc = client.create_service(name=random_str(),
+                                environmentId=env.id,
+                                launchConfig=launch_config,
+                                scalePolicy=scale_policy,
+                                scale=6)
+    svc = client.wait_success(svc)
+    assert svc.state == "inactive"
+    assert svc.scalePolicy is not None
+    assert svc.scalePolicy.min == 2
+    assert svc.scalePolicy.max == 4
+    assert svc.scalePolicy.increment == 2
+
+    client.wait_success(svc.activate())
+    wait_for(lambda: super_client.reload(svc).currentScale >= 2)
+    wait_for(lambda: client.reload(svc).healthState == 'healthy')
+
+
+def test_activate_services_fail(super_client, new_context):
+    client = new_context.client
+    env = _create_stack(client)
+    host = super_client.reload(register_simulated_host(new_context))
+    wait_for(lambda: super_client.reload(host).state == 'active',
+             timeout=5)
+
+    image_uuid = new_context.image_uuid
+    launch_config = {"imageUuid": image_uuid, 'ports': "5419"}
+    scale_policy = {"min": 2, "max": 4}
+
+    svc = client.create_service(name=random_str(),
+                                environmentId=env.id,
+                                launchConfig=launch_config,
+                                scalePolicy=scale_policy)
+    svc = client.wait_success(svc)
+    assert svc.state == "inactive"
+
+    # as we have only 2 hosts available,
+    # service's final scale should be 2
+    svc = client.wait_success(svc.activate())
+    assert svc.state == "active"
+    wait_for(lambda: super_client.reload(svc).currentScale >= 2)
+
+
+def test_scale_update(client, context, super_client):
+    env = _create_stack(client)
+
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": image_uuid}
+    scale_policy = {"min": 1, "max": 3}
+
+    svc = client.create_service(name=random_str(),
+                                environmentId=env.id,
+                                launchConfig=launch_config,
+                                scalePolicy=scale_policy)
+    svc = client.wait_success(svc)
+    assert svc.state == "inactive"
+
+    svc = client.wait_success(svc.activate())
+    assert svc.state == "active"
+    wait_for(lambda: super_client.reload(svc).currentScale >= 1)
+
+
+def test_validate_scale_policy_create(client, context):
+    env = _create_stack(client)
+
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": image_uuid}
+
+    scale_policy = {"min": 2, "max": 1, "increment": 2}
+    with pytest.raises(ApiError) as e:
+        client.create_service(name=random_str(),
+                              environmentId=env.id,
+                              launchConfig=launch_config,
+                              scalePolicy=scale_policy)
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'MaxLimitExceeded'
+
+
+def test_validate_scale_policy_update(client, context):
+    env = _create_stack(client)
+
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": image_uuid}
+    scale_policy = {"min": 1, "max": 4, "increment": 2}
+
+    svc = client.create_service(name=random_str(),
+                                environmentId=env.id,
+                                launchConfig=launch_config,
+                                scalePolicy=scale_policy)
+    svc = client.wait_success(svc)
+    assert svc.state == "inactive"
+
+    # update with max scale < min scale
+    scale_policy = {"max": 3, "min": 5,
+                    "increment": 2}
+    with pytest.raises(ApiError) as e:
+        client.update(svc, scalePolicy=scale_policy)
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'MaxLimitExceeded'
+
+
+def test_policy_update(client, context, super_client):
+    env = _create_stack(client)
+
+    image_uuid = context.image_uuid
+    launch_config = {"imageUuid": image_uuid}
+    scale_policy = {"min": 1, "max": 4, "increment": 2}
+
+    svc = client.create_service(name=random_str(),
+                                environmentId=env.id,
+                                launchConfig=launch_config,
+                                scalePolicy=scale_policy)
+    svc = client.wait_success(svc)
+    assert svc.state == "inactive"
+
+    svc.activate()
+    svc = client.wait_success(svc, 120)
+    wait_for(lambda: super_client.reload(svc).currentScale >= 1)
+
+    # reduce the max
+    scale_policy = {"min": 2, "max": 2,
+                    "increment": 1}
+    client.update(svc, scalePolicy=scale_policy)
+    svc = client.wait_success(svc)
+    wait_for(lambda: super_client.reload(svc).currentScale <= 2)
+
+
+def test_service_affinity_rules_w_policy(super_client, new_context):
+    client = new_context.client
+    env = _create_stack(client)
+
+    image_uuid = new_context.image_uuid
+    name = random_str()
+    service_name = "service" + name
+    scale_policy = {"min": 1, "max": 3, "increment": 1}
+    # test anti-affinity
+    launch_config = {
+        "imageUuid": image_uuid,
+        "labels": {
+            "io.rancher.scheduler.affinity:container_label_ne":
+                "io.rancher.stack_service.name=" +
+                env.name + '/' + service_name
+        }
+    }
+
+    svc = client.create_service(name=service_name,
+                                environmentId=env.id,
+                                launchConfig=launch_config,
+                                scalePolicy=scale_policy)
+    svc = client.wait_success(svc)
+    assert svc.state == "inactive"
+
+    svc = client.wait_success(svc.activate(), 120)
+    assert svc.state == "active"
+
+    assert svc.currentScale == 1
+
+    # add extra host 1
+    register_simulated_host(new_context)
+
+    # wait for service instances to be 2
+    wait_for(lambda: super_client.reload(svc).currentScale >= 2)
+
+    # add extra host 2
+    register_simulated_host(new_context)
+
+    # wait for service instances to be 3
+    wait_for(lambda: super_client.reload(svc).currentScale >= 3)
+
+
+def _get_instance_for_service(super_client, serviceId):
+    instances = []
+    instance_service_maps = super_client. \
+        list_serviceExposeMap(serviceId=serviceId)
+    for mapping in instance_service_maps:
+        instances.append(mapping.instance())
+    return instances


### PR DESCRIPTION
1) Scale policy parameter was added to the service object (updatable). Fields:

* minScale - minimum number of instances required to be running for the service
* maxScale - maximum allowed service scale. 
* increment - reflects a number of containers being deployed simultaneously as we move from minScale to scale.

Example: 

1) service created with scale=4, and policy {minScale:2, maxScale:5, increment:2}.
2) Durning activate, we try to deploy 2 (=minScale) containers. If it fails, service activation fails as we don't match minScale. If succeeds, move to 3)
3) We increment scale by 2 (=interval), and wait for these instances to deploy. If at least one of them fails to deploy, we roll back to 2, and reconcile finishes with currentScale=2. If deployment of 2 extra instances is successful, reconcile finishes with currentScale=scale=4

2) New field for the service (readable only) - "currentScale" - number of service's instances.