### PR TITLE
Changes to add the missing Log driver/log opts to exported .yml file

### DIFF
--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
@@ -15,6 +15,7 @@ public class ServiceDiscoveryConstants {
     public static final String FIELD_SERVICE_IDS = "serviceIds";
     public static final String FIELD_UPGRADE = "upgrade";
     public static final String FIELD_LAUNCH_CONFIG = "launchConfig";
+    public static final String FIELD_LOG_CONFIG = "logConfig";
     public static final String FIELD_LOAD_BALANCER_CONFIG = "loadBalancerConfig";
     public static final String FIELD_ENVIRIONMENT_ID = "environmentId";
     public static final String FIELD_EXTERNALIPS = "externalIpAddresses";

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/service/impl/ServiceDiscoveryApiServiceImpl.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/service/impl/ServiceDiscoveryApiServiceImpl.java
@@ -27,6 +27,7 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -139,6 +140,7 @@ public class ServiceDiscoveryApiServiceImpl implements ServiceDiscoveryApiServic
                     populateSidekickLabels(service, composeServiceData, isPrimaryConfig);
                     populateLoadBalancerServiceLabels(service, launchConfigName, composeServiceData);
                     populateSelectorServiceLabels(service, launchConfigName, composeServiceData);
+                    populateLogConfig(cattleServiceData, composeServiceData);
                 }
                 if (!composeServiceData.isEmpty()) {
                     data.put(isPrimaryConfig ? service.getName() : launchConfigName, composeServiceData);
@@ -147,7 +149,7 @@ public class ServiceDiscoveryApiServiceImpl implements ServiceDiscoveryApiServic
         }
         return data;
     }
-    
+
     @SuppressWarnings("unchecked")
     protected void formatScale(Service service, Map<String, Object> composeServiceData) {
         if (composeServiceData.get(InstanceConstants.FIELD_LABELS) != null) {
@@ -155,6 +157,25 @@ public class ServiceDiscoveryApiServiceImpl implements ServiceDiscoveryApiServic
             if (labels.containsKey(ServiceDiscoveryConstants.LABEL_SERVICE_GLOBAL)
                     && labels.get(ServiceDiscoveryConstants.LABEL_SERVICE_GLOBAL).equals(String.valueOf(Boolean.TRUE))) {
                 composeServiceData.remove(ServiceDiscoveryConstants.FIELD_SCALE);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void populateLogConfig(Map<String, Object> cattleServiceData, Map<String, Object> composeServiceData) {
+        Object value = cattleServiceData.get(ServiceDiscoveryConstants.FIELD_LOG_CONFIG);
+        if (value instanceof Map) {
+            if (!((Map<?, ?>) value).isEmpty()) {
+                Map<String, Object> map = (Map<String, Object>)value;
+                Iterator<String> it = map.keySet().iterator();
+                while (it.hasNext()) {
+                    String key = it.next();
+                    if (key.equalsIgnoreCase("config")) {
+                        composeServiceData.put("log_opt", map.get(key));
+                    } else if (key.equalsIgnoreCase("driver")) {
+                        composeServiceData.put("log_driver", map.get(key));
+                    }
+                }
             }
         }
     }

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -1790,7 +1790,10 @@ def test_export_config(client, context):
     restart_policy = {"maximumRetryCount": 2, "name": "on-failure"}
     launch_config = {"imageUuid": image_uuid,
                      "cpuSet": "0,1", "labels": labels,
-                     "restartPolicy": restart_policy}
+                     "restartPolicy": restart_policy,
+                     "logConfig": {"config": {"labels": "foo"},
+                                   "driver": "json-file"}
+                     }
     service = client. \
         create_service(name="web",
                        environmentId=env.id,
@@ -1806,6 +1809,8 @@ def test_export_config(client, context):
     assert docker_yml[service.name]['cpuset'] == "0,1"
     assert docker_yml[service.name]['labels'] == labels
     assert "restart" not in docker_yml[service.name]
+    assert docker_yml[service.name]["log_driver"] == "json-file"
+    assert docker_yml[service.name]["log_opt"] is not None
 
     rancher_yml = yaml.load(compose_config.rancherComposeConfig)
     assert 'scale' not in rancher_yml[service.name]


### PR DESCRIPTION
This will add the missing log_config details to the dockerCompose file while viewing the config back on UI.

https://github.com/rancher/rancher/issues/2388