### PR TITLE
Enable update operation on certificate.key

### DIFF
--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -350,7 +350,7 @@
         "certificate" : "r",
         "certificate.certChain" : "crud",
         "certificate.cert" : "crud",
-        "certificate.key" : "cro",
+        "certificate.key" : "curo",
         "certificate.certFingerprint" : "r",
         "certificate.CN" : "r",
         "certificate.expiresAt" : "r",

--- a/tests/integration/cattletest/core/test_healthcheck.py
+++ b/tests/integration/cattletest/core/test_healthcheck.py
@@ -843,7 +843,8 @@ def test_health_check_host_remove(super_client, context, client):
 def test_healtcheck(client, context, super_client):
     stack = client.create_environment(name='env-' + random_str())
     image_uuid = context.image_uuid
-    register_simulated_host(context)
+    host = register_simulated_host(context)
+    client.wait_success(host)
 
     # test that external service was set with healtcheck
     health_check = {"name": "check1", "responseTimeout": 3,

--- a/tests/integration/cattletest/core/test_svc_upgrade.py
+++ b/tests/integration/cattletest/core/test_svc_upgrade.py
@@ -159,7 +159,7 @@ def test_big_scale(context, client):
 
     svc = client.create_service(name=random_str(),
                                 environmentId=env.id,
-                                scale=15,
+                                scale=10,
                                 launchConfig=launch_config,
                                 intervalMillis=100)
     svc = client.wait_success(svc)


### PR DESCRIPTION
Made key a writable field. https://github.com/rancher/rancher/issues/3553

@ibuildthecloud tested is manually by verifying that the key was set in the DB as the key has ro permission, and returned to the API only on create.