### PR TITLE
Switch to /var/lib/rancher/etc/machinedrivers.json

### DIFF
--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/process/defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/process/defaults.properties
@@ -95,7 +95,7 @@ docker.vip.subnet.cidr=169.254.64.0/18
 machine.service.executable=go-machine-service
 machine.execute=false
 
-machine.driver.config=file:///var/lib/rancher/server/etc/machinedrivers.json
+machine.driver.config=file:///var/lib/rancher/etc/machinedrivers.json
 
 compose.executor.service.executable=rancher-compose-executor
 compose.executor.execute=false


### PR DESCRIPTION
This is more inline with `/var/lib/rancher/etc/agent.conf` which exists today.

@cloudnautique @hibooboo2 