### PR TITLE
Revert "Default secondary launch config mode to "container""

### DIFF
--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
@@ -11,6 +11,7 @@ public class ServiceDiscoveryConstants {
 
     public static final String TYPE_ENVIRONMENT = "environment";
     public static final String FIELD_SCALE = "scale";
+    public static final String FIELD_NETWORK_ID = "networkId";
     public static final String FIELD_SERVICE_ID = "serviceId";
     public static final String FIELD_SERVICE_IDS = "serviceIds";
     public static final String FIELD_UPGRADE = "upgrade";

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceCreateValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceCreateValidationFilter.java
@@ -8,8 +8,6 @@ import io.cattle.platform.core.dao.NetworkDao;
 import io.cattle.platform.core.model.Environment;
 import io.cattle.platform.core.model.Service;
 import io.cattle.platform.core.util.PortSpec;
-import io.cattle.platform.docker.constants.DockerInstanceConstants;
-import io.cattle.platform.docker.constants.DockerNetworkConstants;
 import io.cattle.platform.iaas.api.filter.common.AbstractDefaultResourceManagerFilter;
 import io.cattle.platform.json.JsonMapper;
 import io.cattle.platform.object.ObjectManager;
@@ -74,8 +72,6 @@ public class ServiceCreateValidationFilter extends AbstractDefaultResourceManage
 
         validateMetadata(request);
 
-        request = setNetworkMode(type, service.getName(), request);
-
         validateLaunchConfigs(service, request);
 
         validateIpsHostName(request);
@@ -105,39 +101,6 @@ public class ServiceCreateValidationFilter extends AbstractDefaultResourceManage
                 }
             }
         }
-    }
-
-    @SuppressWarnings("unchecked")
-    public ApiRequest setNetworkMode(String type, String serviceName, ApiRequest request) {
-        if (!type.equalsIgnoreCase(ServiceDiscoveryConstants.KIND.SERVICE.name())) {
-            return request;
-        }
-        Map<String, Object> data = CollectionUtils.toMap(request.getRequestObject());
-
-        if (data.get(ServiceDiscoveryConstants.FIELD_LAUNCH_CONFIG) != null) {
-            Map<String, Object> lc = (Map<String, Object>) data
-                    .get(ServiceDiscoveryConstants.FIELD_LAUNCH_CONFIG);
-            if (lc.get(DockerInstanceConstants.FIELD_NETWORK_MODE) != null) {
-                String ntwkMode = (String) lc.get(DockerInstanceConstants.FIELD_NETWORK_MODE);
-                if (!ntwkMode.equalsIgnoreCase(DockerInstanceConstants.FIELD_NETWORK_MODE)) {
-                    if (data.get(ServiceDiscoveryConstants.FIELD_SECONDARY_LAUNCH_CONFIGS) != null) {
-                        for (Map<String, Object> slc : (List<Map<String, Object>>) data
-                                .get(ServiceDiscoveryConstants.FIELD_SECONDARY_LAUNCH_CONFIGS)) {
-                            if (slc.get(DockerInstanceConstants.FIELD_NETWORK_MODE) == null) {
-                                slc.put(DockerInstanceConstants.FIELD_NETWORK_MODE,
-                                        DockerNetworkConstants.NETWORK_MODE_CONTAINER);
-                                slc.put(ServiceDiscoveryConstants.FIELD_NETWORK_LAUNCH_CONFIG, serviceName);
-                            }
-                        }
-                    }
-                    data.put(ServiceDiscoveryConstants.FIELD_SECONDARY_LAUNCH_CONFIGS,
-                            data.get(ServiceDiscoveryConstants.FIELD_SECONDARY_LAUNCH_CONFIGS));
-                    request.setRequestObject(data);
-                }
-            }
-        }
-
-        return request;
     }
 
 

--- a/resources/content/schema/base/secondaryLaunchConfig.json
+++ b/resources/content/schema/base/secondaryLaunchConfig.json
@@ -7,18 +7,6 @@
             "nullable": false,
             "minLength": 1,
             "maxLength": 63
-        },
-        "networkMode": {
-            "type": "enum",
-            "options": [
-                "none",
-                "bridge",
-                "host",
-                "managed",
-                "container"
-            ],
-            "default": null,
-            "nullable": true
         }
     }
 }

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -187,7 +187,6 @@ def test_activate_single_service(client, context, super_client):
     assert svc.launchConfig.healthCheck.port == 200
     assert svc.metadata == metadata
     assert svc.launchConfig.version == '0'
-    assert svc.launchConfig.networkMode == "managed"
 
     # activate the service and validate that parameters were set for instance
     service = client.wait_success(svc.activate())
@@ -451,8 +450,7 @@ def test_link_volumes(client, context):
 
     labels = {"io.rancher.container.start_once": "true"}
     secondary_lc = {"imageUuid": image_uuid,
-                    "name": "secondary", "labels": labels,
-                    "networkMode": "managed"}
+                    "name": "secondary", "labels": labels}
 
     service = client.create_service(name=random_str(),
                                     environmentId=env.id,
@@ -478,12 +476,10 @@ def test_volumes_service_links_scale_one(client, context):
     image_uuid = context.image_uuid
     launch_config = {"imageUuid": image_uuid}
     sec_lc_1 = {"imageUuid": image_uuid, "name": "secondary1",
-                "dataVolumesFromLaunchConfigs": ["primary"],
-                "networkMode": "managed"}
+                "dataVolumesFromLaunchConfigs": ["primary"]}
     sec_lc_2 = {"imageUuid": image_uuid, "name": "secondary2",
                 "dataVolumesFromLaunchConfigs":
-                    ["primary", "secondary1"],
-                    "networkMode": "managed"}
+                    ["primary", "secondary1"]}
     service = client. \
         create_service(name="primary",
                        environmentId=env.id,
@@ -516,8 +512,7 @@ def test_volumes_service_links_scale_two(client, context):
     image_uuid = context.image_uuid
     launch_config = {"imageUuid": image_uuid,
                      "dataVolumesFromLaunchConfigs": ["secondary"]}
-    secondary_lc = {"imageUuid": image_uuid, "name": "secondary",
-                    "networkMode": "managed"}
+    secondary_lc = {"imageUuid": image_uuid, "name": "secondary"}
     service = client.create_service(name=random_str(),
                                     environmentId=env.id,
                                     launchConfig=launch_config,
@@ -949,8 +944,7 @@ def test_sidekick_destroy_instance(client, context):
     image_uuid = context.image_uuid
     launch_config = {"imageUuid": image_uuid,
                      "dataVolumesFromLaunchConfigs": ['secondary']}
-    secondary_lc = {"imageUuid": image_uuid, "name": "secondary",
-                    "networkMode": "managed"}
+    secondary_lc = {"imageUuid": image_uuid, "name": "secondary"}
 
     service = client.create_service(name=random_str(),
                                     environmentId=env.id,
@@ -995,8 +989,7 @@ def test_sidekick_restart_instances(client, context):
     env = _create_stack(client)
     image_uuid = context.image_uuid
     launch_config = {"imageUuid": image_uuid}
-    secondary_lc = {"imageUuid": image_uuid, "name": "secondary",
-                    "networkMode": "managed"}
+    secondary_lc = {"imageUuid": image_uuid, "name": "secondary"}
 
     service = client.create_service(name=random_str(),
                                     environmentId=env.id,
@@ -1038,8 +1031,7 @@ def test_sidekick_scaleup(client, context):
 
     image_uuid = context.image_uuid
     launch_config = {"imageUuid": image_uuid}
-    secondary_lc = {"imageUuid": image_uuid, "name": "secondary",
-                    "networkMode": "managed"}
+    secondary_lc = {"imageUuid": image_uuid, "name": "secondary"}
 
     service = client.create_service(name=random_str(),
                                     environmentId=env.id,
@@ -1453,8 +1445,7 @@ def test_network_from_service(client, context):
     image_uuid = context.image_uuid
     launch_config = {"imageUuid": image_uuid, "networkMode": 'container',
                      "networkLaunchConfig": "secondary"}
-    secondary_lc = {"imageUuid": image_uuid, "name": "secondary",
-                    "networkMode": "managed"}
+    secondary_lc = {"imageUuid": image_uuid, "name": "secondary"}
 
     service = client.create_service(name=random_str(),
                                     environmentId=env.id,
@@ -1694,8 +1685,7 @@ def test_anti_affinity_sidekick(new_context):
     }
     secondary_lc = {
         "imageUuid": image_uuid,
-        "name": "secondary",
-        "networkMode": "managed"
+        "name": "secondary"
     }
 
     service = client.create_service(name=service_name,
@@ -1883,10 +1873,8 @@ def test_indirect_ref_sidekick_destroy_instance(client, context):
     launch_config = {"imageUuid": image_uuid,
                      "dataVolumesFromLaunchConfigs": ['secondary']}
     secondary_lc = {"imageUuid": image_uuid, "name": "secondary",
-                    "dataVolumesFromLaunchConfigs": ['secondary1'],
-                    "networkMode": "managed"}
-    secondary_lc1 = {"imageUuid": image_uuid, "name": "secondary1",
-                     "networkMode": "managed"}
+                    "dataVolumesFromLaunchConfigs": ['secondary1']}
+    secondary_lc1 = {"imageUuid": image_uuid, "name": "secondary1"}
 
     service = client.create_service(name=random_str(),
                                     environmentId=env.id,
@@ -2144,8 +2132,7 @@ def test_stop_network_from_container(client, context, super_client):
     image_uuid = context.image_uuid
     launch_config = {"imageUuid": image_uuid, "networkMode": 'container',
                      "networkLaunchConfig": "secondary"}
-    secondary_lc = {"imageUuid": image_uuid, "name": "secondary",
-                    "networkMode": "managed"}
+    secondary_lc = {"imageUuid": image_uuid, "name": "secondary"}
 
     service = client.create_service(name=random_str(),
                                     environmentId=env.id,
@@ -2195,10 +2182,9 @@ def test_remove_network_from_container(client, context, super_client):
     env = _create_stack(client)
     svc_name = random_str()
     image_uuid = context.image_uuid
-    launch_config = {"imageUuid": image_uuid, "networkMode": 'managed'}
+    launch_config = {"imageUuid": image_uuid, "networkMode": 'container'}
     secondary_lc = {"imageUuid": image_uuid, "name": "secondary",
-                    "networkLaunchConfig": svc_name,
-                    "networkMode": "container"}
+                    "networkLaunchConfig": svc_name}
 
     service = client.create_service(name=svc_name,
                                     environmentId=env.id,
@@ -2207,8 +2193,8 @@ def test_remove_network_from_container(client, context, super_client):
                                     secondaryLaunchConfigs=[secondary_lc])
     service = client.wait_success(service)
     assert len(service.secondaryLaunchConfigs) == 1
-    assert service.launchConfig.networkMode == 'managed'
-    assert service.secondaryLaunchConfigs[0].networkMode == 'container'
+    assert service.launchConfig.networkMode == 'container'
+    assert service.secondaryLaunchConfigs[0].networkMode == 'managed'
 
     service = client.wait_success(service.activate(), 120)
 
@@ -2300,8 +2286,7 @@ def test_service_restart(client, context):
 
     image_uuid = context.image_uuid
     launch_config = {"imageUuid": image_uuid}
-    secondary_lc = {"imageUuid": image_uuid, "name": "secondary",
-                    "networkMode": "managed"}
+    secondary_lc = {"imageUuid": image_uuid, "name": "secondary"}
     service = client.create_service(name=random_str(),
                                     environmentId=env.id,
                                     launchConfig=launch_config,
@@ -2453,8 +2438,7 @@ def test_random_ports_sidekicks(new_context):
     image_uuid = new_context.image_uuid
     launch_config = {"imageUuid": image_uuid, "ports": ['6666', '7775']}
     secondary_lc = {"imageUuid": image_uuid,
-                    "name": "secondary", "ports": ['6666'],
-                    "networkMode": "managed"}
+                    "name": "secondary", "ports": ['6666']}
 
     svc = client.create_service(name=random_str(),
                                 environmentId=env.id,
@@ -2715,25 +2699,6 @@ def _wait_for_compose_instance_start(client, service, env,
         lambda: len(client.list_container(name=name, state='running')) > 0
     )
     return client.list_container(name=name, state='running')[0]
-
-
-def test_sidekick_network_mode(client, context):
-    env = _create_stack(client)
-    image_uuid = context.image_uuid
-    launch_config = {"imageUuid": image_uuid}
-    secondary_lc = {"imageUuid": image_uuid, "name": "secondary"}
-
-    service = client.create_service(name=random_str(),
-                                    environmentId=env.id,
-                                    launchConfig=launch_config,
-                                    scale=2,
-                                    secondaryLaunchConfigs=[secondary_lc])
-    service = client.wait_success(service)
-
-    assert service.launchConfig.networkMode == 'managed'
-    slc = service.secondaryLaunchConfigs[0]
-    assert slc.networkMode == 'container'
-    assert slc.networkLaunchConfig == service.name
 
 
 def test_host_dns(client, context, super_client):

--- a/tests/integration/cattletest/core/test_svc_upgrade.py
+++ b/tests/integration/cattletest/core/test_svc_upgrade.py
@@ -299,10 +299,8 @@ def test_in_service_upgrade_networks_from(context, client, super_client):
     image_uuid = context.image_uuid
     launch_config = {"imageUuid": image_uuid, "networkMode": 'container',
                      "networkLaunchConfig": "secondary1"}
-    secondary1 = {"imageUuid": image_uuid, "name": "secondary1",
-                  "networkMode": "managed"}
-    secondary2 = {"imageUuid": image_uuid, "name": "secondary2",
-                  "networkMode": "managed"}
+    secondary1 = {"imageUuid": image_uuid, "name": "secondary1"}
+    secondary2 = {"imageUuid": image_uuid, "name": "secondary2"}
     svc = client.create_service(name=random_str(),
                                 environmentId=env.id,
                                 scale=2,
@@ -693,10 +691,8 @@ def _create_multi_lc_svc(super_client, client, context, activate=True):
     launch_config = {'imageUuid': image_uuid,
                      'networkMode': None}
     secondary_lc1 = {"imageUuid": image_uuid, "name": "secondary1",
-                     "dataVolumesFromLaunchConfigs": ['secondary2'],
-                     "networkMode": "managed"}
-    secondary_lc2 = {"imageUuid": image_uuid, "name": "secondary2",
-                     "networkMode": "managed"}
+                     "dataVolumesFromLaunchConfigs": ['secondary2']}
+    secondary_lc2 = {"imageUuid": image_uuid, "name": "secondary2"}
     secondary = [secondary_lc1, secondary_lc2]
     svc = client.create_service(name=random_str(),
                                 environmentId=env.id,


### PR DESCRIPTION
This reverts commit 32f2c6421d2dcff0209aff743734faafa736d68a.

Conflicts:
	tests/integration/cattletest/core/test_svc_discovery.py