### PR TITLE
Catalog name space support and refresh interval changes

### DIFF
--- a/code/iaas/logic-common/src/main/java/io/cattle/platform/service/launcher/GenericServiceLauncher.java
+++ b/code/iaas/logic-common/src/main/java/io/cattle/platform/service/launcher/GenericServiceLauncher.java
@@ -64,14 +64,18 @@ public abstract class GenericServiceLauncher extends NoExceptionRunnable impleme
     @Override
     public void start() {
         future = executor.scheduleWithFixedDelay(this, WAIT, WAIT, TimeUnit.MILLISECONDS);
-        DynamicStringProperty reload = getReloadSetting();
-        if (reload != null) {
-            reload.addCallback(new Runnable() {
-                @Override
-                public void run() {
-                    processDestroy();
+        List<DynamicStringProperty> reloadList = getReloadSettings();
+        if (reloadList != null) {
+            for(DynamicStringProperty reload : reloadList) {
+                if (reload != null) {
+                    reload.addCallback(new Runnable() {
+                        @Override
+                        public void run() {
+                            processDestroy();
+                        }
+                    });
                 }
-            });
+            }
         }
     }
 
@@ -99,7 +103,7 @@ public abstract class GenericServiceLauncher extends NoExceptionRunnable impleme
         return SERVICE_USER_NAME;
     }
 
-    protected DynamicStringProperty getReloadSetting() {
+    protected List<DynamicStringProperty> getReloadSettings() {
         return null;
     }
 

--- a/code/iaas/logic-common/src/main/java/io/cattle/platform/service/launcher/ServiceAccountCreateStartup.java
+++ b/code/iaas/logic-common/src/main/java/io/cattle/platform/service/launcher/ServiceAccountCreateStartup.java
@@ -3,6 +3,7 @@ package io.cattle.platform.service.launcher;
 import io.cattle.platform.lock.definition.LockDefinition;
 import io.cattle.platform.util.type.InitializationTask;
 
+import java.util.List;
 import java.util.Map;
 
 import com.netflix.config.DynamicStringProperty;
@@ -25,7 +26,7 @@ public class ServiceAccountCreateStartup extends GenericServiceLauncher implemen
     }
 
     @Override
-    protected DynamicStringProperty getReloadSetting() {
+    protected List<DynamicStringProperty> getReloadSettings() {
         throw new UnsupportedOperationException();
     }
 

--- a/code/implementation/docker/machine/src/main/java/io/cattle/platform/docker/machine/launch/CatalogLauncher.java
+++ b/code/implementation/docker/machine/src/main/java/io/cattle/platform/docker/machine/launch/CatalogLauncher.java
@@ -5,6 +5,7 @@ import io.cattle.platform.lock.definition.LockDefinition;
 import io.cattle.platform.service.launcher.GenericServiceLauncher;
 import io.cattle.platform.util.type.InitializationTask;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -29,8 +30,11 @@ public class CatalogLauncher extends GenericServiceLauncher implements Initializ
     }
 
     @Override
-    protected DynamicStringProperty getReloadSetting() {
-        return CATALOG_URL;
+    protected List<DynamicStringProperty> getReloadSettings() {
+        List<DynamicStringProperty> list = new ArrayList<DynamicStringProperty>();
+        list.add(CATALOG_URL);
+        list.add(CATALOG_REFRESH_INTERVAL);
+        return list;
     }
 
     @Override


### PR DESCRIPTION
Changes:
- Pass the catalogUrl argument enclosed in quotes "", so that the catalog service can parse the catalog names containing spaces without issues.
- Restart the catalog service when "catalog.refresh.interval.seconds" setting is changed

Tested manually.

https://github.com/rancher/rancher/issues/3124
https://github.com/rancher/rancher/issues/2947