### PR TITLE
Fix volume create race condition

### DIFF
--- a/code/iaas/logic/pom.xml
+++ b/code/iaas/logic/pom.xml
@@ -93,5 +93,10 @@
             <artifactId>cattle-iaas-labels</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.cattle</groupId>
+            <artifactId>cattle-docker-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/code/iaas/storage-service/pom.xml
+++ b/code/iaas/storage-service/pom.xml
@@ -29,9 +29,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-        	<groupId>io.cattle</groupId>
-        	<artifactId>cattle-docker-common</artifactId>
-        	<version>0.5.0-SNAPSHOT</version>
+            <groupId>io.cattle</groupId>
+            <artifactId>cattle-docker-common</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/code/implementation/docker/common/src/main/java/io/cattle/platform/docker/process/lock/DockerStoragePoolVolumeCreateLock.java
+++ b/code/implementation/docker/common/src/main/java/io/cattle/platform/docker/process/lock/DockerStoragePoolVolumeCreateLock.java
@@ -5,8 +5,7 @@ import io.cattle.platform.lock.definition.AbstractBlockingLockDefintion;
 
 public class DockerStoragePoolVolumeCreateLock extends AbstractBlockingLockDefintion {
 
-    public DockerStoragePoolVolumeCreateLock(StoragePool storagePool, String volumeUri) {
-        super(String.format("DOCKER.STORAGE_POOL.VOLUME.CREATE.%s.%s", storagePool.getId(), volumeUri == null ? 0 : volumeUri.hashCode()));
+    public DockerStoragePoolVolumeCreateLock(StoragePool storagePool, String externalId) {
+        super(String.format("DOCKER.STORAGE_POOL.VOLUME.CREATE.%s.%s", storagePool.getId(), externalId == null ? 0 : externalId.hashCode()));
     }
-
 }

--- a/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/instancehostmap/DockerPostInstanceHostMapActivate.java
+++ b/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/instancehostmap/DockerPostInstanceHostMapActivate.java
@@ -204,7 +204,7 @@ public class DockerPostInstanceHostMapActivate extends AbstractObjectProcessLogi
         if (volume != null)
             return volume;
 
-        return lockManager.lock(new DockerStoragePoolVolumeCreateLock(storagePool, dVol.getUri()), new LockCallback<Volume>() {
+        return lockManager.lock(new DockerStoragePoolVolumeCreateLock(storagePool, dVol.getExternalId()), new LockCallback<Volume>() {
             @Override
             public Volume doWithLock() {
                 Volume volume = dockerDao.createDockerVolumeInPool(instance.getAccountId(), dVol.getName(), dVol.getUri(), dVol.getExternalId(),

--- a/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/instancehostmap/DockerPostInstanceHostMapActivate.java
+++ b/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/instancehostmap/DockerPostInstanceHostMapActivate.java
@@ -187,9 +187,11 @@ public class DockerPostInstanceHostMapActivate extends AbstractObjectProcessLogi
             if (CommonStatesConstants.REMOVED.equals(volume.getState())) {
                 restore(volume, state.getData());
                 action = "Restored";
-            } else {
+            } else if (CommonStatesConstants.REQUESTED.equals(volume.getState())) {
                 action = "Created";
                 createIgnoreCancel(volume, state.getData());
+            } else {
+                action = "Using existing";
             }
             log.debug("{} volume [{}] in storage pool [{}].", action, volume.getId(), pool.getId());
 


### PR DESCRIPTION
There are two ways volumes can be backpopulated into Rancher: from a
volume create event being sent by convoy-agent or from container
backpopulation. These two methods were not using the same lock to check
if the volume existed and thus could run into a race condition where
both created the volume.


Addresses https://github.com/rancher/rancher/issues/3446

I couldn't add a test for this because reproducing relies on hitting a race
condition that would be too hard to hit reliably. It also relies on an
active convoy stack, which we don't have or want in the cattle tests.