### PR TITLE
Deployment planner bug fixes

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/ServiceDeploymentPlanner.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/ServiceDeploymentPlanner.java
@@ -117,6 +117,7 @@ public abstract class ServiceDeploymentPlanner {
                     if (usedServiceIndexes.contains(serviceIndexId)) {
                         badUnits.add(healthyUnit);
                         it.remove();
+                        break;
                     }
                 }
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/planner/GlobalServiceDeploymentPlanner.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/planner/GlobalServiceDeploymentPlanner.java
@@ -55,6 +55,6 @@ public class GlobalServiceDeploymentPlanner extends ServiceDeploymentPlanner {
 
     @Override
     public boolean needToReconcileDeploymentImpl() {
-        return (healthyUnits.size() != hostIds.size());
+        return !hostToUnits.keySet().containsAll(hostIds);
     }
 }


### PR DESCRIPTION
1) Bug fix in duplicate service indexes cleanup

Break inner loop once the element of outer loop is removed


https://github.com/rancher/rancher/issues/3930

2) Bug fix in global deployment planner

reconcile when active hosts are missing instances, instead of doing blind instance.size to host.size comparison

https://github.com/rancher/rancher/issues/3922