### PR TITLE
User friendly message on service reconcile failure

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceUpdateActivate.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceUpdateActivate.java
@@ -107,15 +107,20 @@ public class ServiceUpdateActivate extends AbstractObjectProcessHandler {
             String resourceId = splittedForId[1];
             String resourceType = splittedForResourceType[1];
             Object obfuscatedId = idFormatter.formatId(resourceType, resourceId);
-            error = error.replace(resourceId + "]", obfuscatedId + "]");
 
-            // append predicated resource's transitioninig message to an error
+
+            // append predicated resource's transitioning message to an error
             Object predicateResource = objectManager.loadResource(resourceType, resourceId);
+            error = "Waiting for [" + resourceType + ":" + obfuscatedId + "]";
             if (predicateResource != null) {
                 String transitioningMsg = DataAccessor.fieldString(predicateResource,
                         "transitioningMessage");
-                if (!StringUtils.isEmpty(transitioningMsg)) {
-                    error = error + ". " + resourceType + " status: " + transitioningMsg;
+                // Upper case first letter in resourceType
+                StringBuffer sb = new StringBuffer(resourceType);
+                sb.replace(0, 1, resourceType.substring(0, 1).toUpperCase());
+
+                if (!StringUtils.isEmpty(sb)) {
+                    error = error + ". " + sb + " status: " + transitioningMsg;
                 }
             }
         }


### PR DESCRIPTION
@deniseschannon @ibuildthecloud The message on failed service.reconcile would look like this;

```
Waiting for [instance:1i8]. Instance status: Scheduling failed: host needs ports 100/tcp available
```

Just to clarify why "waiting" not "waiting for start". During service reconcile we wait not only for start, but for other operations like stop/remove. This detail is not available at the point the exception is caught. I think appending the instance transitioning message in form of "Instance status: Scheduling failed: host needs ports 100/tcp available" as well as instance id, should be descriptive enough. 


https://github.com/rancher/rancher/issues/3926