### PR TITLE
Changes to exclude the internal rancher lable 'io.rancher.service.hash'

### DIFF
--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/constants/ServiceDiscoveryConstants.java
@@ -102,6 +102,7 @@ public class ServiceDiscoveryConstants {
     public static final String LABEL_LB_SSL_PORTS = "io.rancher.loadbalancer.ssl.ports";
     public static final String LABEL_SELECTOR_CONTAINER = "io.rancher.service.selector.container";
     public static final String LABEL_SELECTOR_LINK = "io.rancher.service.selector.link";
+    public static final String LABEL_SERVICE_HASH = "io.rancher.service.hash";
 
     public static final String PRIMARY_LAUNCH_CONFIG_NAME = "io.rancher.service.primary.launch.config";
 

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/service/impl/ServiceDiscoveryApiServiceImpl.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/service/impl/ServiceDiscoveryApiServiceImpl.java
@@ -127,6 +127,7 @@ public class ServiceDiscoveryApiServiceImpl implements ServiceDiscoveryApiServic
                 Map<String, Object> cattleServiceData = ServiceDiscoveryUtil.getServiceDataAsMap(service,
                         launchConfigName, allocatorService);
                 Map<String, Object> composeServiceData = new HashMap<>();
+                excludeLables(cattleServiceData);
                 formatScale(service, cattleServiceData);
                 for (String cattleService : cattleServiceData.keySet()) {
                     translateRancherToCompose(forDockerCompose, cattleServiceData, composeServiceData, cattleService, service);
@@ -148,6 +149,19 @@ public class ServiceDiscoveryApiServiceImpl implements ServiceDiscoveryApiServic
             }
         }
         return data;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void excludeLables(Map<String, Object> composeServiceData) {
+        if (composeServiceData.get(InstanceConstants.FIELD_LABELS) != null) {
+            Map<String, String> labels = new HashMap<>();
+            labels.putAll((HashMap<String, String>) composeServiceData.get(InstanceConstants.FIELD_LABELS));
+            String serviceHash = labels.get(ServiceDiscoveryConstants.LABEL_SERVICE_HASH);
+            if (serviceHash != null) {
+                labels.remove(ServiceDiscoveryConstants.LABEL_SERVICE_HASH);
+                composeServiceData.put(InstanceConstants.FIELD_LABELS, labels);
+            }
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -1778,7 +1778,8 @@ def test_export_config(client, context):
     # cpuCet
     # global vs scale
     image_uuid = context.image_uuid
-    labels = {'io.rancher.scheduler.global': 'true'}
+    labels = {'io.rancher.scheduler.global': 'true',
+              'io.rancher.service.hash': '088b54be-2b79-99e30b3a1a24'}
     metadata = {"$bar": {"metadata": [{"$id$$foo$bar$$": "${HOSTNAME}"}]}}
     restart_policy = {"maximumRetryCount": 2, "name": "on-failure"}
     launch_config = {"imageUuid": image_uuid,
@@ -1797,6 +1798,8 @@ def test_export_config(client, context):
     service = client.wait_success(service)
 
     compose_config = env.exportconfig()
+    labels = {'io.rancher.scheduler.global': 'true'}
+
     assert compose_config is not None
     docker_yml = yaml.load(compose_config.dockerComposeConfig)
     assert docker_yml[service.name]['cpuset'] == "0,1"


### PR DESCRIPTION
Changes to exclude the internal rancher lable 'io.rancher.service.hash' from the exported config yml files.
Also changed the py test to check if the label gets excluded.

https://github.com/rancher/rancher/issues/3937