### PR TITLE
Resolve to vip on dns when assignIpAddress flag is set to true

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/DnsInfoDaoImpl.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/DnsInfoDaoImpl.java
@@ -358,7 +358,9 @@ public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
         // b) for k8s services
         Map<String, Object> data = new HashMap<>();
         data.putAll(DataUtils.getFields(service));
-        if (data.containsKey(ServiceDiscoveryConstants.FIELD_SET_VIP)
+        Object vipObj = data.get(ServiceDiscoveryConstants.FIELD_SET_VIP);
+        boolean setVip = vipObj != null && Boolean.valueOf(vipObj.toString());
+        if (setVip
                 || service.getKind().equalsIgnoreCase("kubernetesservice")) {
             return vip;
         }


### PR DESCRIPTION
Instead of relying on a sole presence of the flag. It can be passed as
false to the API