### PR TITLE
Dont delete shared pools when an agent is removed

### DIFF
--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/agent/AgentRemove.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/agent/AgentRemove.java
@@ -1,8 +1,10 @@
 package io.cattle.platform.process.agent;
 
 import io.cattle.platform.agent.util.AgentUtils;
+import io.cattle.platform.core.constants.StoragePoolConstants;
 import io.cattle.platform.core.model.Account;
 import io.cattle.platform.core.model.Agent;
+import io.cattle.platform.core.model.StoragePool;
 import io.cattle.platform.engine.handler.HandlerResult;
 import io.cattle.platform.engine.process.ProcessInstance;
 import io.cattle.platform.engine.process.ProcessState;
@@ -40,6 +42,13 @@ public class AgentRemove extends AbstractObjectProcessHandler {
             }
 
             for (Object obj : objectManager.children(agent, clz)) {
+                if (obj instanceof StoragePool) {
+                    StoragePool sp = (StoragePool)obj;
+                    if (StoragePoolConstants.TYPE.equals(sp.getKind())) {
+                        // Don't automatically delete shared storage pools
+                        continue;
+                    }
+                }
                 deactivateThenScheduleRemove(obj, state.getData());
             }
         }

--- a/tests/integration/cattletest/core/test_shared_volumes.py
+++ b/tests/integration/cattletest/core/test_shared_volumes.py
@@ -64,6 +64,19 @@ def test_storage_pool_update(new_context, super_client):
     assert sp.state == 'active'
 
 
+def test_storage_pool_agent_delete(new_context, super_client):
+    client = new_context.client
+    sp = add_storage_pool(new_context)
+
+    original_agent = super_client.list_agent(accountId=new_context.agent.id)[0]
+
+    original_agent = super_client.wait_success(original_agent.deactivate())
+    original_agent = super_client.wait_success(original_agent.remove())
+
+    sp = client.reload(sp)
+    assert sp.state == 'active'
+
+
 def test_multiple_sp_volume_schedule(new_context):
     # Tests that when a host has more than one storage pool (one local, one
     # shared), and a container is scheduled to it, the root volume can be


### PR DESCRIPTION
If a storage pool agent container goes unhealthy, it will get removed
and replaced. This causes the associated agent to get removed and
replaced. This change prevents the storage pool assocaited with the
agent from being removed so that when the new storage pool agent
container comes online, it can be associated with the existing pool.

The logic for associating a new agent container with an existing pool
is already in place in `ExternalEventCreate.java`

Addresses: https://github.com/rancher/rancher/issues/3333