### PR TITLE
Skip accounts in removed/removing states o config items updates.

### DIFF
--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/AgentInstanceManagerImpl.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/AgentInstanceManagerImpl.java
@@ -6,9 +6,11 @@ import io.cattle.platform.agent.instance.service.AgentInstanceManager;
 import io.cattle.platform.agent.instance.service.InstanceNicLookup;
 import io.cattle.platform.agent.instance.service.NetworkServiceInfo;
 import io.cattle.platform.core.constants.AgentConstants;
+import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
 import io.cattle.platform.core.constants.InstanceConstants.SystemContainer;
 import io.cattle.platform.core.dao.GenericResourceDao;
+import io.cattle.platform.core.model.Account;
 import io.cattle.platform.core.model.Agent;
 import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.NetworkServiceProvider;
@@ -58,6 +60,12 @@ public class AgentInstanceManagerImpl implements AgentInstanceManager {
         Instance instance = objectManager.loadResource(Instance.class, nic.getInstanceId());
 
         if (instance == null) {
+            return result;
+        }
+
+        Account account = objectManager.loadResource(Account.class, instance.getAccountId());
+        List<String> removedStates = Arrays.asList(CommonStatesConstants.REMOVED, CommonStatesConstants.REMOVING);
+        if (account == null || removedStates.contains(account.getState())) {
             return result;
         }
 

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/MetaDataInfoDao.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/MetaDataInfoDao.java
@@ -42,4 +42,6 @@ public interface MetaDataInfoDao {
     List<HostMetaData> getAllInstanceHostMetaData(long accountId);
 
     List<HostMetaData> getInstanceHostMetaData(long accountId, Instance instance);
+
+    List<String> getPrimaryIpsOnInstanceHost(Instance instance);
 }


### PR DESCRIPTION
We cleanup all instances in order no matter of their types, and sometimes network agent is removed first. Then on regular instance removal, config items are updated, and we span one more network agent, and so on.

@ibuildthecloud 