### PR TITLE
Changes to exclude the 'io.rancher.service.hash' from service metadata

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
@@ -49,6 +49,7 @@ public class InstanceConstants {
     public static final String FIELD_HEALTH_UPDATED = "healthUpdated";
     public static final String FIELD_ALLOCATED_IP_ADDRESS = "allocatedIpAddress";
     public static final String FIELD_SERVICE_INSTANCE_SERVICE_INDEX_ID = "serviceIndexId";
+    public static final String FIELD_METADATA = "metadata";
 
     public static final String PROCESS_DATA_NO_OP = "containerNoOpEvent";
 

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/service/impl/ServiceDiscoveryApiServiceImpl.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/service/impl/ServiceDiscoveryApiServiceImpl.java
@@ -127,7 +127,7 @@ public class ServiceDiscoveryApiServiceImpl implements ServiceDiscoveryApiServic
                 Map<String, Object> cattleServiceData = ServiceDiscoveryUtil.getServiceDataAsMap(service,
                         launchConfigName, allocatorService);
                 Map<String, Object> composeServiceData = new HashMap<>();
-                excludeLables(cattleServiceData);
+                excludeRancherHash(cattleServiceData);
                 formatScale(service, cattleServiceData);
                 for (String cattleService : cattleServiceData.keySet()) {
                     translateRancherToCompose(forDockerCompose, cattleServiceData, composeServiceData, cattleService, service);
@@ -152,7 +152,7 @@ public class ServiceDiscoveryApiServiceImpl implements ServiceDiscoveryApiServic
     }
 
     @SuppressWarnings("unchecked")
-    private void excludeLables(Map<String, Object> composeServiceData) {
+    private void excludeRancherHash(Map<String, Object> composeServiceData) {
         if (composeServiceData.get(InstanceConstants.FIELD_LABELS) != null) {
             Map<String, String> labels = new HashMap<>();
             labels.putAll((HashMap<String, String>) composeServiceData.get(InstanceConstants.FIELD_LABELS));
@@ -162,6 +162,17 @@ public class ServiceDiscoveryApiServiceImpl implements ServiceDiscoveryApiServic
                 composeServiceData.put(InstanceConstants.FIELD_LABELS, labels);
             }
         }
+
+        if (composeServiceData.get(InstanceConstants.FIELD_METADATA) != null) {
+            Map<String, String> metadata = new HashMap<>();
+            metadata.putAll((HashMap<String, String>) composeServiceData.get(InstanceConstants.FIELD_METADATA));
+            String serviceHash = metadata.get(ServiceDiscoveryConstants.LABEL_SERVICE_HASH);
+            if (serviceHash != null) {
+                metadata.remove(ServiceDiscoveryConstants.LABEL_SERVICE_HASH);
+                composeServiceData.put(InstanceConstants.FIELD_METADATA, metadata);
+            }
+        }
+
     }
 
     @SuppressWarnings("unchecked")

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -1792,7 +1792,8 @@ def test_export_config(client, context):
     image_uuid = context.image_uuid
     labels = {'io.rancher.scheduler.global': 'true',
               'io.rancher.service.hash': '088b54be-2b79-99e30b3a1a24'}
-    metadata = {"$bar": {"metadata": [{"$id$$foo$bar$$": "${HOSTNAME}"}]}}
+    metadata = {"io.rancher.service.hash": "088b54be-2b79-99e30b3a1a24",
+                "$bar": {"metadata": [{"$id$$foo$bar$$": "${HOSTNAME}"}]}}
     restart_policy = {"maximumRetryCount": 2, "name": "on-failure"}
     launch_config = {"imageUuid": image_uuid,
                      "cpuSet": "0,1", "labels": labels,


### PR DESCRIPTION
Changes to exclude the 'io.rancher.service.hash' from service metadata in rancher-compose.yml 
https://github.com/rancher/rancher/issues/3937

Also changed the test_export_config to make sure metadata gets changed.