### PR TITLE
Changes to API to obfuscate the references present in the embedded resourceFields 

### DIFF
--- a/code/framework/api/src/main/java/io/cattle/platform/api/resource/AbstractObjectResourceManager.java
+++ b/code/framework/api/src/main/java/io/cattle/platform/api/resource/AbstractObjectResourceManager.java
@@ -359,7 +359,7 @@ public abstract class AbstractObjectResourceManager extends AbstractBaseResource
     @Override
     protected Resource constructResource(IdFormatter idFormatter, SchemaFactory schemaFactory, Schema schema, Object obj, ApiRequest apiRequest) {
         Map<String, Object> transitioningFields = metaDataManager.getTransitionFields(schema, obj);
-        return ApiUtils.createResourceWithAttachments(this, apiRequest, idFormatter, schema, obj, transitioningFields);
+        return ApiUtils.createResourceWithAttachments(this, apiRequest, idFormatter, schemaFactory, schema, obj, transitioningFields);
     }
 
     @Override

--- a/code/framework/api/src/main/java/io/cattle/platform/api/utils/ApiUtils.java
+++ b/code/framework/api/src/main/java/io/cattle/platform/api/utils/ApiUtils.java
@@ -149,7 +149,7 @@ public class ApiUtils {
     }
 
     public static Resource createResourceWithAttachments(final ResourceManager resourceManager, final ApiRequest request, final IdFormatter idFormatter,
-            final Schema schema, Object obj, Map<String, Object> inputAdditionalFields) {
+            final SchemaFactory schemaFactory, final Schema schema, Object obj, Map<String, Object> inputAdditionalFields) {
         Integer depth = DEPTH.get();
 
         try {
@@ -176,7 +176,7 @@ public class ApiUtils {
                 additionalFields.putAll(attachments);
             }
             String method = request == null ? null : request.getMethod();
-            return new WrappedResource(idFormatter, schema, obj, additionalFields, PRIORITY_FIELDS, method);
+            return new WrappedResource(idFormatter, schemaFactory, schema, obj, additionalFields, PRIORITY_FIELDS, method);
         } finally {
             DEPTH.set(depth);
         }

--- a/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/id/IdFormatterUtils.java
+++ b/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/id/IdFormatterUtils.java
@@ -1,7 +1,9 @@
 package io.github.ibuildthecloud.gdapi.id;
 
+import io.github.ibuildthecloud.gdapi.factory.SchemaFactory;
 import io.github.ibuildthecloud.gdapi.model.Field;
 import io.github.ibuildthecloud.gdapi.model.FieldType;
+import io.github.ibuildthecloud.gdapi.model.Schema;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -10,11 +12,12 @@ import java.util.Map;
 
 public class IdFormatterUtils {
 
-    public static Object formatReference(Field field, IdFormatter formatter, Object value) {
-        return formatReference(field.getTypeEnum(), field.getSubTypeEnums(), field.getSubTypes(), formatter, value);
+    public static Object formatReference(Field field, IdFormatter formatter, Object value, SchemaFactory schemaFactory) {
+        return formatReference(field, field.getTypeEnum(), field.getSubTypeEnums(), field.getSubTypes(), formatter, value, schemaFactory);
     }
 
-    private static Object formatReference(FieldType fieldType, List<FieldType> subTypeEnums, List<String> subTypes, IdFormatter formatter, Object value) {
+    private static Object formatReference(Field field, FieldType fieldType, List<FieldType> subTypeEnums,
+            List<String> subTypes, IdFormatter formatter, Object value, SchemaFactory schemaFactory) {
         if (value == null) {
             return value;
         }
@@ -27,9 +30,50 @@ public class IdFormatterUtils {
             return formatList(subTypeEnums, subTypes, formatter, value);
         case MAP:
             return formatMap(subTypeEnums, subTypes, formatter, value);
+        case TYPE:
+            if (field == null || schemaFactory == null) {
+                return value;
+            }
+            return formatType(field, subTypeEnums, subTypes, formatter, value, schemaFactory);
         default:
             return value;
         }
+    }
+
+
+    private static Object formatType(Field field, List<FieldType> subTypeEnums, List<String> subTypes,
+            IdFormatter formatter, Object value, SchemaFactory schemaFactory) {
+        if (value == null || !(value instanceof Map)) {
+            return value;
+        }
+
+        if(schemaFactory == null) {
+            return value;
+        }
+
+        Map<?, ?> inputs = (Map<?, ?>)value;
+        Map<Object, Object> result = new LinkedHashMap<Object, Object>();
+
+        Schema fieldSchema = schemaFactory.getSchema(field.getType());
+
+        for (Map.Entry<String, Field> entry : fieldSchema.getResourceFields().entrySet()) {
+
+            String fieldName = entry.getKey();
+            if (inputs.containsKey(fieldName)) {
+                Object subFieldValue = inputs.get(fieldName);
+
+                if (subFieldValue != null) {
+                    Field subField = entry.getValue();
+                    Object formattedValue = formatReference(subField, subField.getTypeEnum(), subField.getSubTypeEnums(),
+                            subField.getSubTypes(), formatter, subFieldValue, schemaFactory);
+                    result.put(fieldName, formattedValue);
+                } else {
+                    result.put(fieldName, subFieldValue);
+                }
+            }
+        }
+
+        return result;
     }
 
     private static Object formatList(List<FieldType> subTypeEnums, List<String> subTypes, IdFormatter formatter, Object value) {
@@ -48,7 +92,7 @@ public class IdFormatterUtils {
         subTypes = subTypes.subList(1, subTypes.size());
 
         for (Object input : inputs) {
-            result.add(formatReference(fieldType, subTypeEnums, subTypes, formatter, input));
+            result.add(formatReference(null, fieldType, subTypeEnums, subTypes, formatter, input, null));
         }
 
         return result;
@@ -70,7 +114,7 @@ public class IdFormatterUtils {
         subTypes = subTypes.subList(1, subTypes.size());
 
         for (Map.Entry<?, ?> entry : inputs.entrySet()) {
-            result.put(entry.getKey(), formatReference(fieldType, subTypeEnums, subTypes, formatter, entry.getValue()));
+            result.put(entry.getKey(), formatReference(null, fieldType, subTypeEnums, subTypes, formatter, entry.getValue(), null));
         }
 
         return result;

--- a/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/model/impl/WrappedResource.java
+++ b/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/model/impl/WrappedResource.java
@@ -1,6 +1,7 @@
 package io.github.ibuildthecloud.gdapi.model.impl;
 
 import io.github.ibuildthecloud.gdapi.context.ApiContext;
+import io.github.ibuildthecloud.gdapi.factory.SchemaFactory;
 import io.github.ibuildthecloud.gdapi.id.IdFormatter;
 import io.github.ibuildthecloud.gdapi.id.IdFormatterUtils;
 import io.github.ibuildthecloud.gdapi.model.Field;
@@ -23,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 public class WrappedResource extends ResourceImpl implements Resource {
 
     Schema schema;
+    SchemaFactory schemaFactory;
     Object obj;
     Map<String, Object> priorityFields = new LinkedHashMap<String, Object>();
     Map<String, Object> additionalFields;
@@ -33,12 +35,14 @@ public class WrappedResource extends ResourceImpl implements Resource {
     IdFormatter idFormatter;
 
     public WrappedResource(IdFormatter idFormatter, Schema schema, Object obj, Map<String, Object> additionalFields, String method) {
-        this(idFormatter, schema, obj, additionalFields, null, method);
+        this(idFormatter, null, schema, obj, additionalFields, null, method);
     }
 
-    public WrappedResource(IdFormatter idFormatter, Schema schema, Object obj, Map<String, Object> additionalFields, Set<String> priorityFieldNames,
-            String method) {
+    public WrappedResource(IdFormatter idFormatter, SchemaFactory schemaFactory,
+            Schema schema, Object obj, Map<String, Object> additionalFields,
+            Set<String> priorityFieldNames, String method) {
         super();
+        this.schemaFactory = schemaFactory;
         this.schema = schema;
         this.resourceFields = schema.getResourceFields();
         this.obj = obj;
@@ -49,8 +53,8 @@ public class WrappedResource extends ResourceImpl implements Resource {
         init();
     }
 
-    public WrappedResource(IdFormatter idFormatter, Schema schema, Object obj, String method) {
-        this(idFormatter, schema, obj, new HashMap<String, Object>(), method);
+    public WrappedResource(IdFormatter idFormatter, SchemaFactory schemaFactory, Schema schema, Object obj, String method) {
+        this(idFormatter, schemaFactory, schema, obj, new HashMap<String, Object>(), null, method);
     }
 
     protected void addField(String key, Object value) {
@@ -97,7 +101,7 @@ public class WrappedResource extends ResourceImpl implements Resource {
                 }
             }
 
-            addField(name, IdFormatterUtils.formatReference(field, idFormatter, value));
+            addField(name, IdFormatterUtils.formatReference(field, idFormatter, value, schemaFactory));
             if (createTsFields && field.getTypeEnum() == FieldType.DATE && value instanceof Date) {
                 addField(name + "TS", ((Date)value).getTime());
             }

--- a/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/request/resource/impl/AbstractBaseResourceManager.java
+++ b/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/request/resource/impl/AbstractBaseResourceManager.java
@@ -358,7 +358,7 @@ public abstract class AbstractBaseResourceManager implements ResourceManager {
     }
 
     protected Resource constructResource(IdFormatter idFormatter, SchemaFactory schemaFactory, Schema schema, Object obj, ApiRequest apiRequest) {
-        return new WrappedResource(idFormatter, schema, obj, apiRequest.getMethod());
+        return new WrappedResource(idFormatter, schemaFactory, schema, obj, apiRequest.getMethod());
     }
 
     protected void addLinks(Object obj, SchemaFactory schemaFactory, Schema schema, Resource resource) {

--- a/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/response/JsonResponseWriter.java
+++ b/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/response/JsonResponseWriter.java
@@ -97,7 +97,7 @@ public class JsonResponseWriter extends AbstractApiRequestHandler {
 
         Schema schema = schemaFactory.getSchema(obj.getClass());
         ApiContext apiContext = ApiContext.getContext();
-        return schema == null ? null : new WrappedResource(apiContext.getIdFormatter(), schema, obj, apiContext.getApiRequest().getMethod());
+        return schema == null ? null : new WrappedResource(apiContext.getIdFormatter(), schemaFactory, schema, obj, apiContext.getApiRequest().getMethod());
     }
 
     protected void writeJson(OutputStream os, Object responseObject, ApiRequest request) throws IOException {

--- a/code/implementation/extension-api/src/main/java/io/cattle/platform/extension/api/manager/ResourceDefinitionManager.java
+++ b/code/implementation/extension-api/src/main/java/io/cattle/platform/extension/api/manager/ResourceDefinitionManager.java
@@ -96,7 +96,7 @@ public class ResourceDefinitionManager extends AbstractNoOpResourceManager {
 
     @Override
     protected Resource constructResource(final IdFormatter idFormatter, SchemaFactory schemaFactory, final Schema schema, Object obj, ApiRequest apiRequest) {
-        return ApiUtils.createResourceWithAttachments(this, apiRequest, idFormatter, schema, obj, new HashMap<String, Object>());
+        return ApiUtils.createResourceWithAttachments(this, apiRequest, idFormatter, schemaFactory, schema, obj, new HashMap<String, Object>());
     }
 
     protected List<?> getLinkInternal(ResourceDefinition def, String link, ApiRequest request) {

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -163,7 +163,7 @@ def test_activate_single_service(client, context, super_client):
     assert len(svc.launchConfig.environment) == 1
     assert len(svc.launchConfig.ports) == 2
     assert len(svc.launchConfig.dataVolumes) == 1
-    # assert set(service.launchConfig.dataVolumesFrom) == set([container1.id])
+    assert svc.launchConfig.dataVolumesFrom == list([container1.id])
     assert svc.launchConfig.capAdd == caps
     assert svc.launchConfig.capDrop == caps
     assert svc.launchConfig.dns == dns
@@ -190,6 +190,7 @@ def test_activate_single_service(client, context, super_client):
     assert svc.launchConfig.healthCheck.port == 200
     assert svc.metadata == metadata
     assert svc.launchConfig.version == '0'
+    assert svc.launchConfig.requestedHostId == host.id
 
     # activate the service and validate that parameters were set for instance
     service = client.wait_success(svc.activate())


### PR DESCRIPTION
Changes to obfuscate the references present in the nested resourceFields of a resource where the resoureField is an object itself containing db references.

Tested the API UI manually as shown below.

Example: http://localhost:8080/v1/projects/1a5/services/1s2

Here in API response, the "service" object has resourceField "launchConfig" which is an object containing key "dataVolumesFrom" whose value is of type array[reference[container]]

So value of "dataVolumesFrom" should be obfuscated db container id's

"id": "1s2",
"type": "service",
"links": { … },
"actions": { … },
"name": "random-957277-1458161855",
"state": "inactive",
"accountId": "1a5",
"assignServiceIpAddress": false,
"createIndex": null,
"created": "2016-03-16T20:57:36Z",
"createdTS": 1458161856000,
"description": null,
"environmentId": "1e1",
"externalId": null,
"fqdn": null,
"healthState": null,
"kind": "service",
"launchConfig": {
"capAdd": [
"SYS_MODULE",
],
"capDrop": [
"SYS_MODULE",
],
"command": [ 2 items
"sleep",
"42",
],
"cpuSet": "2",
"cpuShares": 400,
"dataVolumes": [
"/foo",
],
"dataVolumesFrom": [
"1i1",
],
"dns": [ 2 items
"8.8.8.8",
"1.2.3.4",
],
"dnsSearch": [ 2 items
"foo",
"bar",
],
"domainName": "rancher.io",
"entryPoint": [ 2 items
"/bin/sh",
"-c",
],
"environment": {
"TEST_FILE": "/etc/testpath.conf",
},
"healthCheck": {
"healthyThreshold": 5,
"interval": 4,
"name": "check1",
"port": 200,
"requestLine": "index.html",
"responseTimeout": 3,
"unhealthyThreshold": 6,
"strategy": "recreate",
},
"hostname": "test",
"imageUuid": "sim:random-333122-1458161843",
"instanceLinks": {
"container2_link": "1i3",
},
"kind": "container",
"labels": {
"foo": "bar",
},
"memory": 8000000,
"networkMode": "managed",
"ports": [ 2 items
"64122:8681/tcp",
"58021:8082/tcp",
],
"privileged": true,
"publishAllPorts": false,
"readOnly": false,
"requestedHostId": "1h1",
"startOnCreate": true,
"stdinOpen": true,
"tty": true,
"user": "test",
"version": "0",
"workingDir": "/",
"vcpu": 1,
},


https://github.com/rancher/rancher/issues/594