### PR TITLE
Service container name is available globally via dns

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/DnsInfoDaoImpl.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/DnsInfoDaoImpl.java
@@ -336,7 +336,11 @@ public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
                 if (StringUtils.isEmpty(targetInstanceName)) {
                     ipToInstanceName.put(targetIp, null);
                 } else {
-                    ipToInstanceName.put(targetIp, targetInstanceName + "." + dnsName);
+                    ipToInstanceName.put(
+                            targetIp,
+                            targetInstanceName
+                                    + "." + ServiceDiscoveryDnsUtil.getGlobalNamespace(targetInstance.getService())
+                                    + ".");
                 }
             } else {
                 ipToInstanceName.put(targetIp, null);

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/util/ServiceDiscoveryDnsUtil.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/util/ServiceDiscoveryDnsUtil.java
@@ -14,21 +14,21 @@ public class ServiceDiscoveryDnsUtil {
     public static final String METADATA_FQDN = "rancher-metadata" + "." + RANCHER_NAMESPACE + ".";
     public static final String NETWORK_AGENT_IP = "169.254.169.250";
 
-    private static String getNamespace(Service service) {
+    public static String getGlobalNamespace(Service service) {
         if (service.getKind().equalsIgnoreCase("kubernetesservice")) {
             return KUBERNETES_SVC_NAMESPACE;
         }
         return RANCHER_NAMESPACE;
     }
 
-    public static String getServiceNamespace(Environment stack, Service service, String launchConfigName) {
-        return new StringBuilder().append(launchConfigName).append(".").append(getStackNamespace(stack, service))
-                .toString().toLowerCase();
-    }
-
     public static String getStackNamespace(Environment stack, Service service) {
         return new StringBuilder().append(stack.getName()).append(".")
-                .append(getNamespace(service)).toString().toLowerCase();
+                .append(getGlobalNamespace(service)).toString().toLowerCase();
+    }
+
+    private static String getServiceNamespace(Environment stack, Service service, String launchConfigName) {
+        return new StringBuilder().append(launchConfigName).append(".").append(getStackNamespace(stack, service))
+                .toString().toLowerCase();
     }
 
     public static String getFqdn(Environment stack, Service service, String launchConfigName) {
@@ -54,10 +54,8 @@ public class ServiceDiscoveryDnsUtil {
 
     public static List<String> getNamespaces(Environment stack, Service service, String launchConfigName) {
         List<String> toReturn = new ArrayList<>();
-        toReturn.add(getNamespace(service));
+        toReturn.add(getGlobalNamespace(service));
         toReturn.add(getStackNamespace(stack, service));
-        String name = StringUtils.isEmpty(launchConfigName) ? service.getName() : launchConfigName;
-        toReturn.add(getServiceNamespace(stack, service, name));
 
         return toReturn;
     }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/util/ServiceDiscoveryDnsUtil.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/util/ServiceDiscoveryDnsUtil.java
@@ -21,14 +21,14 @@ public class ServiceDiscoveryDnsUtil {
         return RANCHER_NAMESPACE;
     }
 
-    public static String getStackNamespace(Environment stack, Service service) {
-        return new StringBuilder().append(stack.getName()).append(".")
-                .append(getGlobalNamespace(service)).toString().toLowerCase();
-    }
-
     private static String getServiceNamespace(Environment stack, Service service, String launchConfigName) {
         return new StringBuilder().append(launchConfigName).append(".").append(getStackNamespace(stack, service))
                 .toString().toLowerCase();
+    }
+
+    public static String getStackNamespace(Environment stack, Service service) {
+        return new StringBuilder().append(stack.getName()).append(".")
+                .append(getGlobalNamespace(service)).toString().toLowerCase();
     }
 
     public static String getFqdn(Environment stack, Service service, String launchConfigName) {

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
@@ -128,7 +128,7 @@ public abstract class DeploymentUnitInstance {
     }
 
     public List<String> getSearchDomains() {
-        String serviceNamespace = ServiceDiscoveryDnsUtil.getStackNamespace(this.stack, this.service);
-        return Arrays.asList(serviceNamespace);
+        String stackNamespace = ServiceDiscoveryDnsUtil.getStackNamespace(this.stack, this.service);
+        return Arrays.asList(stackNamespace);
     }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
@@ -8,7 +8,6 @@ import io.cattle.platform.core.model.ServiceExposeMap;
 import io.cattle.platform.core.model.ServiceIndex;
 import io.cattle.platform.object.process.StandardProcess;
 import io.cattle.platform.object.resource.ResourcePredicate;
-import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
 import io.cattle.platform.servicediscovery.api.util.ServiceDiscoveryDnsUtil;
 import io.cattle.platform.servicediscovery.deployment.impl.DeploymentManagerImpl.DeploymentServiceContext;
 
@@ -130,11 +129,6 @@ public abstract class DeploymentUnitInstance {
 
     public List<String> getSearchDomains() {
         String serviceNamespace = ServiceDiscoveryDnsUtil.getStackNamespace(this.stack, this.service);
-        String lcName = this.getLaunchConfigName().equalsIgnoreCase(
-                ServiceDiscoveryConstants.PRIMARY_LAUNCH_CONFIG_NAME) ? this.getService().getName() : this
-                .getLaunchConfigName();
-        String containerNamespace = ServiceDiscoveryDnsUtil
-                .getServiceNamespace(this.stack, this.service, lcName);
-        return Arrays.asList(serviceNamespace, containerNamespace);
+        return Arrays.asList(serviceNamespace);
     }
 }

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -217,7 +217,6 @@ def test_activate_single_service(client, context, super_client):
     assert container.capDrop == caps
     dns.append("169.254.169.250")
     assert set(dns).issubset(container.dns)
-    search.append(svc.name + "." + env.name + "." + "rancher.internal")
     search.append(env.name + "." + "rancher.internal")
     assert set(search).issubset(container.dnsSearch)
     assert container.privileged is True


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/4004

Also changed alias - link - names representation on dns. Instead of just linkName. it would be
    linkName.stackName.rancher.internal. + linkName.rancher.internal.
