### PR TITLE
Added default init state for service/stack health state

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
@@ -596,7 +596,7 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
                     }
                     expectedCount++;
                     if (activeStates.contains(service.getState().toLowerCase()) && healthyStates.contains(sHS)) {
-                        if (service.getHealthState().equalsIgnoreCase(
+                        if (sHS.equalsIgnoreCase(
                                 HealthcheckConstants.SERVICE_HEALTH_STATE_STARTED_ONCE.toLowerCase())) {
                             startedOnce++;
                         }

--- a/resources/content/schema/defaults/environment.json
+++ b/resources/content/schema/defaults/environment.json
@@ -1,0 +1,3 @@
+{
+    "healthState" : "unhealthy"
+}

--- a/resources/content/schema/defaults/service.json
+++ b/resources/content/schema/defaults/service.json
@@ -1,0 +1,3 @@
+{
+    "healthState" : "unhealthy"
+}


### PR DESCRIPTION
@ibuildthecloud stack/service will get created initially with healthstate='unhealthy' (we use unhealthy when there is not a single healthy instance in it).

This fix will TF in test_restart_stack observed on master