### PR TITLE
service and servicelink name validation

### DIFF
--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/common/AbstractDefaultResourceManagerFilter.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/common/AbstractDefaultResourceManagerFilter.java
@@ -2,12 +2,24 @@ package io.cattle.platform.iaas.api.filter.common;
 
 import io.cattle.platform.util.type.Priority;
 import io.github.ibuildthecloud.gdapi.request.resource.AbstractResourceManagerFilter;
+import io.github.ibuildthecloud.gdapi.validation.ValidationErrorCodes;
+
+import java.util.regex.Pattern;
 
 public class AbstractDefaultResourceManagerFilter extends AbstractResourceManagerFilter implements Priority {
+
+    private static final Pattern DNS_NAME_PATTERN = Pattern.compile("^[a-zA-Z0-9](?!.*--)[a-zA-Z0-9-]*[a-zA-Z0-9]$");
 
     @Override
     public int getPriority() {
         return Priority.DEFAULT;
+    }
+
+    protected void validateDNSPatternForName(String name) {
+        if (name != null && !DNS_NAME_PATTERN.matcher(name).matches()) {
+            ValidationErrorCodes.throwValidationError(ValidationErrorCodes.INVALID_CHARACTERS,
+                    "name");
+        }
     }
 
 }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceAddRemoveLinkServiceValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceAddRemoveLinkServiceValidationFilter.java
@@ -71,6 +71,8 @@ public class ServiceAddRemoveLinkServiceValidationFilter extends AbstractDefault
                 ValidationErrorCodes.throwValidationError(ValidationErrorCodes.INVALID_REFERENCE,
                         ServiceDiscoveryConstants.FIELD_SERVICE_ID);
             }
+            validateName(serviceLink.getName());
+
         } else {
             if (consumeMapDao.findMapToRemove(serviceId, serviceLink.getServiceId()) == null) {
                 ValidationErrorCodes.throwValidationError(ValidationErrorCodes.INVALID_REFERENCE,
@@ -78,4 +80,21 @@ public class ServiceAddRemoveLinkServiceValidationFilter extends AbstractDefault
             }
         }
     }
+
+
+    private void validateName(String linkName) {
+        if(linkName != null && !linkName.isEmpty()){
+            validateDNSPatternForName(linkName);
+            //check length
+            if (linkName.length() < 1) {
+                ValidationErrorCodes.throwValidationError(ValidationErrorCodes.MIN_LENGTH_EXCEEDED,
+                        "name");
+            }
+            if (linkName.length() > 63) {
+                ValidationErrorCodes.throwValidationError(ValidationErrorCodes.MAX_LENGTH_EXCEEDED,
+                        "name");
+            }
+        }
+    }
+
 }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceCreateValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceCreateValidationFilter.java
@@ -51,7 +51,6 @@ public class ServiceCreateValidationFilter extends AbstractDefaultResourceManage
     
     private static final int LB_HEALTH_CHECK_PORT = 42;
 
-
     @Override
     public Class<?>[] getTypeClasses() {
         return new Class<?>[] { Service.class };
@@ -338,12 +337,7 @@ public class ServiceCreateValidationFilter extends AbstractDefaultResourceManage
         }
     }
 
-
-
     protected void validateName(String name) {
-        if (name != null && (name.startsWith("-") || name.endsWith("-"))) {
-            ValidationErrorCodes.throwValidationError(ValidationErrorCodes.INVALID_CHARACTERS,
-                    "name");
-        }
+       validateDNSPatternForName(name);
     }
 }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceSetServiceLinksValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceSetServiceLinksValidationFilter.java
@@ -1,5 +1,6 @@
 package io.cattle.platform.servicediscovery.api.filter;
 
+import static io.github.ibuildthecloud.gdapi.validation.ValidationErrorCodes.*;
 import io.cattle.platform.core.addon.LoadBalancerServiceLink;
 import io.cattle.platform.core.addon.ServiceLink;
 import io.cattle.platform.core.model.Service;
@@ -81,6 +82,22 @@ public class ServiceSetServiceLinksValidationFilter extends AbstractDefaultResou
                     ValidationErrorCodes.throwValidationError(ValidationErrorCodes.INVALID_REFERENCE,
                             ServiceDiscoveryConstants.FIELD_SERVICE_ID);
                 }
+                validateName(serviceLink.getName());
+            }
+        }
+    }
+
+    private void validateName(String linkName) {
+       if(linkName != null && !linkName.isEmpty()){
+            validateDNSPatternForName(linkName);
+            //check length
+            if (linkName.length() < 1) {
+                ValidationErrorCodes.throwValidationError(ValidationErrorCodes.MIN_LENGTH_EXCEEDED,
+                        "name");
+            }
+            if (linkName.length() > 63) {
+                ValidationErrorCodes.throwValidationError(ValidationErrorCodes.MAX_LENGTH_EXCEEDED,
+                        "name");
             }
         }
     }

--- a/resources/content/schema/base/serviceLink.json
+++ b/resources/content/schema/base/serviceLink.json
@@ -4,6 +4,7 @@
         "name": {
             "type": "string",
             "required": false,
+            "validChars": "a-zA-Z0-9-",
             "nullable": true
         },
         "serviceId": {


### PR DESCRIPTION
service names and service link names become DNS labels so the name is heavily restricted to
what DNS allows. The rules are (or probably aren't, but should be):

1-63 characters long
Consisting only of A-Z, 0-9, and hyphen
Can't start of end with a hyphen
Can't contain 2 consecutive hyphens

https://github.com/rancher/rancher/issues/680