### PR TITLE
DB data migration for serviceIndex

### DIFF
--- a/code/implementation/sample-setup/src/main/java/io/cattle/platform/sample/data/SampleDataStartupV5.java
+++ b/code/implementation/sample-setup/src/main/java/io/cattle/platform/sample/data/SampleDataStartupV5.java
@@ -1,0 +1,44 @@
+package io.cattle.platform.sample.data;
+
+import static io.cattle.platform.core.model.tables.InstanceTable.*;
+import static io.cattle.platform.core.model.tables.ServiceIndexTable.*;
+import io.cattle.platform.core.constants.InstanceConstants;
+import io.cattle.platform.core.model.Account;
+import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.ServiceIndex;
+import io.cattle.platform.object.util.DataAccessor;
+import io.github.ibuildthecloud.gdapi.condition.Condition;
+import io.github.ibuildthecloud.gdapi.condition.ConditionType;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SampleDataStartupV5 extends AbstractSampleData {
+
+    @Override
+    protected String getName() {
+        return "sampleDataVersion5";
+    }
+
+    @Override
+    protected void populatedData(Account system, List<Object> toCreate) {
+        List<Instance> instances = objectManager
+                .find(Instance.class, INSTANCE.REMOVED, new Condition(ConditionType.NULL));
+        List<ServiceIndex> serviceIndexes = objectManager
+                .find(ServiceIndex.class, SERVICE_INDEX.REMOVED, new Condition(ConditionType.NULL));
+        List<Long> serviceIndexIds = new ArrayList<>();
+        for (ServiceIndex index : serviceIndexes) {
+            serviceIndexIds.add(index.getId());
+        }
+        for (Instance instance : instances) {
+            Long toUpdate = DataAccessor.fieldLong(instance, InstanceConstants.FIELD_SERVICE_INSTANCE_SERVICE_INDEX_ID);
+            if (toUpdate != null && serviceIndexIds.contains(toUpdate)) {
+                Map<String, Object> data = new HashMap<>();
+                data.put(InstanceConstants.FIELD_SERVICE_INSTANCE_SERVICE_INDEX_ID, toUpdate);
+                objectManager.setFields(instance, data);
+            }
+        }
+    }
+}

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/system-services/spring-system-services-context.xml
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/system-services/spring-system-services-context.xml
@@ -410,6 +410,7 @@
     <bean class="io.cattle.platform.sample.data.SampleDataStartupV3" />
     <bean class="io.cattle.platform.sample.data.SampleDataStartupV4" />
     <bean class="io.cattle.platform.sample.data.SampleDataStartupV6" />
+    <bean class="io.cattle.platform.sample.data.SampleDataStartupV5" />
 
         
     <!-- We are not using this at the moment, we will just disable


### PR DESCRIPTION
and trigger healthState update for service/stack


@ibuildthecloud for health state upgrade, decided to just call "update" on the service. Bumping up reconcile config item had some caveats:

1) reconcile item could have not been present for the service
2) reconcile gets triggered only for services in active state, and health state should be updated for inactive services as well.

If 1) was possible to workaround by creating a new config_item_status, for 2) there is no workaround