### PR TITLE
Correct resource type for host event

### DIFF
--- a/code/iaas/agent-server/src/main/java/io/cattle/platform/agent/server/resource/impl/AgentResourcesMonitorImpl.java
+++ b/code/iaas/agent-server/src/main/java/io/cattle/platform/agent/server/resource/impl/AgentResourcesMonitorImpl.java
@@ -239,7 +239,7 @@ public class AgentResourcesMonitorImpl implements AgentResourcesEventListener {
                         // send host update event
                         Event event = EventVO.newEvent(FrameworkEvents.STATE_CHANGE)
                                 .withData(updateFields)
-                                .withResourceType(host.getKind())
+                                .withResourceType(HostConstants.TYPE)
                                 .withResourceId(host.getId().toString());
                         eventService.publish(event);
                     }


### PR DESCRIPTION
@vincent99 fixed the resourceType for host event. Here is the event rancher generates:

```
{
	"id": "2d2f91e1-022f-480b-a9dc-1bc7527e41a2",
	"name": "state.change",
	"replyTo": null,
	"resourceId": "1",
	"resourceType": "host",
	"publisher": null,
	"transitioning": null,
	"transitioningMessage": null,
	"transitioningInternalMessage": null,
	"previousIds": null,
	"previousNames": null,
	"data": {
		"info": {
			"cpuInfo": {
				"count": 1,
				"cpuCoresPercentages": [2.245],
				"loadAvg": [0.04, 0.06, 0.05],
				"mhz": 2800.0,
				"modelName": "Intel(R) Core(TM) i5-4308U CPU @ 2.80GHz"
			},
			"memoryInfo": {
				"memTotal": 2002.578,
				"swapTotal": 1403.301,
				"cached": 435.219,
				"swapCached": 0.0,
				"swapFree": 1403.301,
				"memAvailable": 1671.758,
				"memFree": 1303.137,
				"inactive": 181.582,
				"active": 440.715,
				"buffers": 70.211
			},
			"osInfo": {
				"kernelVersion": "4.1.18-boot2docker",
				"operatingSystem": "Boot2Docker 1.10.2 (TCL 6.4.1); master : 611be10 - Mon Feb 22 22:47:06 UTC 2016",
				"dockerVersion": "Docker version 1.10.2, build c3959b1"
			},
			"diskInfo": {
				"mountPoints": {
					"/dev/sda1": {
						"total": 200505.266,
						"free": 167672.449,
						"used": 32832.816,
						"percentUsed": 16.38
					}
				},
				"dockerStorageDriverStatus": {
					"Dirs": "322",
					"Dirperm1 Supported": "true",
					"Backing Filesystem": "extfs",
					"Root Dir": "/mnt/sda1/var/lib/docker/aufs"
				},
				"dockerStorageDriver": "aufs",
				"fileSystems": {
					"/dev/sda1": {
						"capacity": 200505.266
					}
				}
			}
		},
		"accountId": 5
	},
	"time": 1458506470148,
	"timeoutMillis": null,
	"transitioningProgress": null,
	"context": null
}
```

not sure how to check what event UI receives, and why you saw it as null. This field should never come as null as I always put accountId to the data