### PR TITLE
Remove warning when trying to remove unset routes

### DIFF
--- a/resources/content/config-content/ipsec/apply.sh
+++ b/resources/content/config-content/ipsec/apply.sh
@@ -19,7 +19,7 @@ disable_proxyarp()
 
 route_tables()
 {
-    if ! ip rule list | cut -f1 -d: | grep -q 200; then
+    if ip rule list | cut -f1 -d: | grep -q 200; then
         ip rule del iif $NETDEV table $TABLE pref 200 || true
     fi
 }


### PR DESCRIPTION
Hi,

I'm not 100% sure this PR is a good idea,
correct me if I'm wrong to do this

---

Here is what I get without this PR

```console
# ip rule list
0:      from all lookup local
220:    from all lookup 220
32766:  from all lookup main
32767:  from all lookup default
# bash -x apply.sh
[...]
+ ip rule del iif eth0 table 200 pref 200
RTNETLINK answers: No such file or directory
[...]
````