### PR TITLE
audit_log.data type change from text to mediumtext

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/AuditLog.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/AuditLog.java
@@ -132,7 +132,7 @@ public interface AuditLog extends java.io.Serializable {
 	/**
 	 * Getter for <code>cattle.audit_log.data</code>.
 	 */
-	@javax.persistence.Column(name = "data", length = 65535)
+	@javax.persistence.Column(name = "data", length = 16777215)
 	public java.util.Map<String,Object> getData();
 
 	/**

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/AuditLogTable.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/AuditLogTable.java
@@ -11,7 +11,7 @@ package io.cattle.platform.core.model.tables;
 @java.lang.SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class AuditLogTable extends org.jooq.impl.TableImpl<io.cattle.platform.core.model.tables.records.AuditLogRecord> {
 
-	private static final long serialVersionUID = 2009167210;
+	private static final long serialVersionUID = 1836262160;
 
 	/**
 	 * The singleton instance of <code>cattle.audit_log</code>
@@ -79,7 +79,7 @@ public class AuditLogTable extends org.jooq.impl.TableImpl<io.cattle.platform.co
 	/**
 	 * The column <code>cattle.audit_log.data</code>.
 	 */
-	public final org.jooq.TableField<io.cattle.platform.core.model.tables.records.AuditLogRecord, java.util.Map<String,Object>> DATA = createField("data", org.jooq.impl.SQLDataType.CLOB.length(65535).asConvertedDataType(new io.cattle.platform.db.jooq.converter.DataConverter()), this, "");
+	public final org.jooq.TableField<io.cattle.platform.core.model.tables.records.AuditLogRecord, java.util.Map<String,Object>> DATA = createField("data", org.jooq.impl.SQLDataType.CLOB.length(16777215).asConvertedDataType(new io.cattle.platform.db.jooq.converter.DataConverter()), this, "");
 
 	/**
 	 * The column <code>cattle.audit_log.authenticated_as_identity_id</code>.

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/records/AuditLogRecord.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/records/AuditLogRecord.java
@@ -13,7 +13,7 @@ package io.cattle.platform.core.model.tables.records;
 @javax.persistence.Table(name = "audit_log", schema = "cattle")
 public class AuditLogRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.platform.core.model.tables.records.AuditLogRecord> implements io.cattle.platform.db.jooq.utils.TableRecordJaxb, org.jooq.Record14<java.lang.Long, java.lang.Long, java.lang.Long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.Long, java.lang.String, java.util.Date, java.util.Map<String,Object>, java.lang.String, java.lang.Long, java.lang.String>, io.cattle.platform.core.model.AuditLog {
 
-	private static final long serialVersionUID = -649054779;
+	private static final long serialVersionUID = 1482167635;
 
 	/**
 	 * Setter for <code>cattle.audit_log.id</code>.
@@ -197,7 +197,7 @@ public class AuditLogRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.
 	/**
 	 * Getter for <code>cattle.audit_log.data</code>.
 	 */
-	@javax.persistence.Column(name = "data", length = 65535)
+	@javax.persistence.Column(name = "data", length = 16777215)
 	@Override
 	public java.util.Map<String,Object> getData() {
 		return (java.util.Map<String,Object>) getValue(10);

--- a/resources/content/db/changelog.xml
+++ b/resources/content/db/changelog.xml
@@ -86,4 +86,5 @@
     <include file="db/core-079.xml"/>
     <include file="db/core-080.xml"/>
     <include file="db/core-081.xml"/>
+    <include file="db/core-082.xml"/>
 </databaseChangeLog>

--- a/resources/content/db/core-082.xml
+++ b/resources/content/db/core-082.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+    <property name="mediumtext" value="TEXT" dbms="postgresql" />
+    <property name="mediumtext" value="MEDIUMTEXT" />
+    <changeSet author="alena (generated)" id="dump1">
+        <modifyDataType columnName="data" newDataType="MEDIUMTEXT(16777215)" tableName="audit_log"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
to match size of data fields of other cattle resources tables

https://github.com/rancher/rancher/issues/4094

we store resource in audit_log.data, and as resource data field has type mediumtext, audit_log.data should be medium_text as well

@ibuildthecloud 