### PR TITLE
Changes to the ProxyFilter to use the encoded RequestURI 

### DIFF
--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/request/handler/GenericWhitelistedProxy.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/request/handler/GenericWhitelistedProxy.java
@@ -111,7 +111,6 @@ public class GenericWhitelistedProxy extends AbstractResponseGenerator {
 
         String redirect = servletRequest.getRequestURI();
         redirect = StringUtils.substringAfter(redirect, "/proxy/");
-        redirect = URLDecoder.decode(redirect, "UTF-8");
         if (redirect.startsWith("http")) {
             /* We don't allow // so http:// will be http:/ and same with https. So we fixup here */
             redirect = redirect.replaceFirst("^http:/([^/])", "http://$1");

--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/servlet/filter/ProxyFilter.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/servlet/filter/ProxyFilter.java
@@ -23,7 +23,7 @@ public class ProxyFilter implements Filter {
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        RequestDispatcher rd = request.getRequestDispatcher("/v1/proxy/" + proxy + ((HttpServletRequest)request).getServletPath());
+        RequestDispatcher rd = request.getRequestDispatcher("/v1/proxy/" + proxy + ((HttpServletRequest)request).getRequestURI());
         request.setAttribute(GenericWhitelistedProxy.ALLOWED_HOST, true);
         request.setAttribute(GenericWhitelistedProxy.SET_HOST_CURRENT_HOST, true);
         rd.forward(request, response);


### PR DESCRIPTION
Fixes to ProxyFilter so that the url encoding is preserved in case the RequestURI have spaces

Also we should not be decoding the proxy uri, else we lose the encoded spaces

https://github.com/rancher/rancher/issues/3124
