### PR TITLE
Changes to service linkName validation rules.

### DIFF
--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/common/AbstractDefaultResourceManagerFilter.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/common/AbstractDefaultResourceManagerFilter.java
@@ -27,4 +27,40 @@ public class AbstractDefaultResourceManagerFilter extends AbstractResourceManage
         }
     }
 
+    protected void validateLinkName(String linkName){
+        if(linkName != null && !linkName.isEmpty()){
+            if(linkName.startsWith(".") || linkName.endsWith(".") || linkName.contains("..")) {
+                ValidationErrorCodes.throwValidationError(ValidationErrorCodes.INVALID_CHARACTERS,
+                        "name");
+            }
+            
+            //split around a "."
+            String[] parts = linkName.split("\\.");
+            if(parts.length > 1) {
+                //check total length <= 253
+                if (linkName.length() > 253) {
+                    ValidationErrorCodes.throwValidationError(ValidationErrorCodes.MAX_LENGTH_EXCEEDED,
+                            "name");
+                }
+            } 
+
+            for (String linkPart : parts) {
+                if(linkPart.startsWith("-") || linkPart.endsWith("-") || linkPart.contains("--")) {
+                    ValidationErrorCodes.throwValidationError(ValidationErrorCodes.INVALID_CHARACTERS,
+                            "name");
+                }
+                //check length
+                if (linkPart.length() < 1) {
+                    ValidationErrorCodes.throwValidationError(ValidationErrorCodes.MIN_LENGTH_EXCEEDED,
+                            "name");
+                }
+                if (linkPart.length() > 63) {
+                    ValidationErrorCodes.throwValidationError(ValidationErrorCodes.MAX_LENGTH_EXCEEDED,
+                            "name");
+                }
+
+            }
+        }
+    }
+
 }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceAddRemoveLinkServiceValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceAddRemoveLinkServiceValidationFilter.java
@@ -71,7 +71,7 @@ public class ServiceAddRemoveLinkServiceValidationFilter extends AbstractDefault
                 ValidationErrorCodes.throwValidationError(ValidationErrorCodes.INVALID_REFERENCE,
                         ServiceDiscoveryConstants.FIELD_SERVICE_ID);
             }
-            validateName(serviceLink.getName());
+            validateLinkName(serviceLink.getName());
 
         } else {
             if (consumeMapDao.findMapToRemove(serviceId, serviceLink.getServiceId()) == null) {
@@ -80,28 +80,4 @@ public class ServiceAddRemoveLinkServiceValidationFilter extends AbstractDefault
             }
         }
     }
-
-
-    private void validateName(String linkName) {
-        if(linkName != null && !linkName.isEmpty()) {
-            String[] parts = linkName.split("/");
-            if (parts.length > 2) {
-                ValidationErrorCodes.throwValidationError(ValidationErrorCodes.INVALID_CHARACTERS,
-                        "name");
-            }
-            for (String linkPart : parts) {
-                validateDNSPatternForName(linkPart);
-                //check length
-                if (linkPart.length() < 1) {
-                    ValidationErrorCodes.throwValidationError(ValidationErrorCodes.MIN_LENGTH_EXCEEDED,
-                            "name");
-                }
-                if (linkPart.length() > 63) {
-                    ValidationErrorCodes.throwValidationError(ValidationErrorCodes.MAX_LENGTH_EXCEEDED,
-                            "name");
-                }
-            }
-        }
-    }
-
 }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceSetServiceLinksValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceSetServiceLinksValidationFilter.java
@@ -1,6 +1,5 @@
 package io.cattle.platform.servicediscovery.api.filter;
 
-import static io.github.ibuildthecloud.gdapi.validation.ValidationErrorCodes.*;
 import io.cattle.platform.core.addon.LoadBalancerServiceLink;
 import io.cattle.platform.core.addon.ServiceLink;
 import io.cattle.platform.core.model.Service;
@@ -82,22 +81,7 @@ public class ServiceSetServiceLinksValidationFilter extends AbstractDefaultResou
                     ValidationErrorCodes.throwValidationError(ValidationErrorCodes.INVALID_REFERENCE,
                             ServiceDiscoveryConstants.FIELD_SERVICE_ID);
                 }
-                validateName(serviceLink.getName());
-            }
-        }
-    }
-
-    private void validateName(String linkName) {
-       if(linkName != null && !linkName.isEmpty()){
-            validateDNSPatternForName(linkName);
-            //check length
-            if (linkName.length() < 1) {
-                ValidationErrorCodes.throwValidationError(ValidationErrorCodes.MIN_LENGTH_EXCEEDED,
-                        "name");
-            }
-            if (linkName.length() > 63) {
-                ValidationErrorCodes.throwValidationError(ValidationErrorCodes.MAX_LENGTH_EXCEEDED,
-                        "name");
+                validateLinkName(serviceLink.getName());
             }
         }
     }

--- a/resources/content/schema/base/serviceLink.json
+++ b/resources/content/schema/base/serviceLink.json
@@ -4,7 +4,7 @@
         "name": {
             "type": "string",
             "required": false,
-            "validChars": "a-zA-Z0-9-",
+            "validChars": "a-zA-Z0-9-._",
             "nullable": true
         },
         "serviceId": {


### PR DESCRIPTION
Rules now are:
"validChars": "a-zA-Z0-9-/.\_"
Cannot start or end with a "-" or _ or "."
Cannot contain "--" or ".." or "__"
MinLength 1 and MaxLength 63

https://github.com/rancher/rancher/issues/4252