### PR TITLE
ServiceConsumeMapDao: Expect more than one result, skip Removing records

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/dao/impl/ServiceConsumeMapDaoImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/dao/impl/ServiceConsumeMapDaoImpl.java
@@ -66,22 +66,27 @@ public class ServiceConsumeMapDaoImpl extends AbstractJooqDao implements Service
     @Override
     public ServiceConsumeMap findNonRemovedMap(long serviceId, long consumedServiceId, String linkName) {
         ServiceConsumeMap map = null;
+        List<? extends ServiceConsumeMap> maps = new ArrayList<>();
         if (linkName == null) {
-            map = objectManager.findOne(ServiceConsumeMap.class,
+            maps = objectManager.find(ServiceConsumeMap.class,
                     SERVICE_CONSUME_MAP.SERVICE_ID,
                     serviceId, SERVICE_CONSUME_MAP.CONSUMED_SERVICE_ID, consumedServiceId, SERVICE_CONSUME_MAP.REMOVED,
                     null);
         } else {
-            map = objectManager.findOne(ServiceConsumeMap.class,
+            maps = objectManager.find(ServiceConsumeMap.class,
                     SERVICE_CONSUME_MAP.SERVICE_ID,
                     serviceId, SERVICE_CONSUME_MAP.CONSUMED_SERVICE_ID, consumedServiceId, SERVICE_CONSUME_MAP.NAME,
                     linkName, SERVICE_CONSUME_MAP.REMOVED,
                     null);
         }
-        if (map != null && !map.getState().equalsIgnoreCase(CommonStatesConstants.REMOVING)) {
-            return map;
+
+        for (ServiceConsumeMap m : maps) {
+            if (m.getState().equalsIgnoreCase(CommonStatesConstants.REMOVING)) {
+                continue;
+            }
+            map = m;
         }
-        return null;
+        return map;
     }
 
     @Override


### PR DESCRIPTION
@ibuildthecloud customer was hitting "found more than one record when expecting one" at line 75. Yet to debug what led to this situation. But it's possible when the previously added and scheduled for removal link got stuck in Removing state, new link is added, and on a subsequent request you can get more than one. So this fix is to take care of this situation. 