### PR TITLE
Load balancer should not have search domains set

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
@@ -9,14 +9,13 @@ import io.cattle.platform.core.model.ServiceIndex;
 import io.cattle.platform.iaas.api.auditing.AuditEventType;
 import io.cattle.platform.object.process.StandardProcess;
 import io.cattle.platform.object.resource.ResourcePredicate;
-import io.cattle.platform.servicediscovery.api.util.ServiceDiscoveryDnsUtil;
 import io.cattle.platform.servicediscovery.deployment.impl.DeploymentManagerImpl.DeploymentServiceContext;
 import io.cattle.platform.servicediscovery.deployment.impl.unit.DefaultDeploymentUnitInstance;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 
 /**
  * TODO: Since the majority of the system references DeploymentUnitInstance and not InstanceUnit
@@ -130,13 +129,6 @@ public abstract class DeploymentUnitInstance {
         return stack;
     }
 
-    public List<String> getSearchDomains() {
-        String stackNamespace = ServiceDiscoveryDnsUtil.getStackNamespace(this.stack, this.service);
-        String serviceNamespace = ServiceDiscoveryDnsUtil
-                .getServiceNamespace(this.stack, this.service);
-        return Arrays.asList(stackNamespace, serviceNamespace);
-    }
-
     public void generateAuditLog(AuditEventType eventType, String description) {
         if (this instanceof DefaultDeploymentUnitInstance) {
             DefaultDeploymentUnitInstance defaultInstance = (DefaultDeploymentUnitInstance) this;
@@ -154,4 +146,6 @@ public abstract class DeploymentUnitInstance {
             }
         }
     }
+
+    public abstract List<String> getSearchDomains();
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/DefaultDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/DefaultDeploymentUnitInstance.java
@@ -21,6 +21,7 @@ import io.cattle.platform.object.util.DataAccessor;
 import io.cattle.platform.process.common.util.ProcessUtils;
 import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
 import io.cattle.platform.servicediscovery.api.resource.ServiceDiscoveryConfigItem;
+import io.cattle.platform.servicediscovery.api.util.ServiceDiscoveryDnsUtil;
 import io.cattle.platform.servicediscovery.api.util.ServiceDiscoveryUtil;
 import io.cattle.platform.servicediscovery.deployment.DeploymentUnitInstance;
 import io.cattle.platform.servicediscovery.deployment.InstanceUnit;
@@ -299,5 +300,14 @@ public class DefaultDeploymentUnitInstance extends DeploymentUnitInstance implem
         List<String> errorStates = Arrays.asList(InstanceConstants.STATE_ERROR, InstanceConstants.STATE_ERRORING);
         return this.instance != null && errorStates.contains(this.instance.getState());
     }
+
+    @Override
+    public List<String> getSearchDomains() {
+        String stackNamespace = ServiceDiscoveryDnsUtil.getStackNamespace(this.stack, this.service);
+        String serviceNamespace = ServiceDiscoveryDnsUtil
+                .getServiceNamespace(this.stack, this.service);
+        return Arrays.asList(stackNamespace, serviceNamespace);
+    }
+
 }
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/ExternalDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/ExternalDeploymentUnitInstance.java
@@ -140,4 +140,9 @@ public class ExternalDeploymentUnitInstance extends DeploymentUnitInstance {
     public boolean isIgnore() {
         return false;
     }
+
+    @Override
+    public List<String> getSearchDomains() {
+        return null;
+    }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/LoadBalancerDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/LoadBalancerDeploymentUnitInstance.java
@@ -73,4 +73,9 @@ public class LoadBalancerDeploymentUnitInstance extends DefaultDeploymentUnitIns
             launchConfigData.put(InstanceConstants.FIELD_PORTS, newPorts);
         }
     }
+
+    @Override
+    public List<String> getSearchDomains() {
+       return null;
+    }
 }

--- a/tests/integration/cattletest/core/test_svc_discovery_lb.py
+++ b/tests/integration/cattletest/core/test_svc_discovery_lb.py
@@ -514,6 +514,7 @@ def test_inactive_lb(super_client, client, context):
     assert lb_service.state == "active"
     maps = _validate_svc_instance_map_count(client, lb_service, "active", 1)
     lb_instance = _wait_for_instance_start(super_client, maps[0].instanceId)
+    assert lb_instance.data.fields.dnsSearch is None
     agent_id = lb_instance.agentId
     item_before = _get_config_item(super_client, agent_id)
 


### PR DESCRIPTION
Make DNS search domain only available for regular service container, not Load Balancer and external service containers.
Fixes https://github.com/rancher/rancher/issues/4373

@alena1108 