### PR TITLE
Reduced number of healthcheck config items increments

### DIFF
--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/HealthcheckInstanceHostMapNicLookup.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/HealthcheckInstanceHostMapNicLookup.java
@@ -1,8 +1,8 @@
 package io.cattle.platform.agent.instance.service.impl;
 
-import static io.cattle.platform.core.model.tables.HealthcheckInstanceHostMapTable.HEALTHCHECK_INSTANCE_HOST_MAP;
-import static io.cattle.platform.core.model.tables.HealthcheckInstanceTable.HEALTHCHECK_INSTANCE;
-import static io.cattle.platform.core.model.tables.NicTable.NIC;
+import static io.cattle.platform.core.model.tables.HealthcheckInstanceHostMapTable.*;
+import static io.cattle.platform.core.model.tables.HealthcheckInstanceTable.*;
+import static io.cattle.platform.core.model.tables.NicTable.*;
 import io.cattle.platform.agent.instance.service.InstanceNicLookup;
 import io.cattle.platform.core.model.HealthcheckInstanceHostMap;
 import io.cattle.platform.core.model.Nic;
@@ -29,7 +29,7 @@ public class HealthcheckInstanceHostMapNicLookup extends AbstractJooqDao impleme
                 .where(HEALTHCHECK_INSTANCE_HOST_MAP.HOST_ID.eq(hostMap.getHostId())
                         .and(NIC.REMOVED.isNull())
                         .and(HEALTHCHECK_INSTANCE_HOST_MAP.REMOVED.isNull())
-                        .and(HEALTHCHECK_INSTANCE.REMOVED.isNull()))
+                        .and(HEALTHCHECK_INSTANCE.REMOVED.isNull())).limit(1)
                 .fetchInto(NicRecord.class);
     }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/HealthcheckConfigUpdate.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/HealthcheckConfigUpdate.java
@@ -1,0 +1,45 @@
+package io.cattle.platform.servicediscovery.process;
+
+import static io.cattle.platform.core.model.tables.HealthcheckInstanceHostMapTable.*;
+import io.cattle.platform.core.constants.CommonStatesConstants;
+import io.cattle.platform.core.model.HealthcheckInstanceHostMap;
+import io.cattle.platform.core.model.Nic;
+import io.cattle.platform.engine.handler.HandlerResult;
+import io.cattle.platform.engine.handler.ProcessPostListener;
+import io.cattle.platform.engine.process.ProcessInstance;
+import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.object.process.StandardProcess;
+import io.cattle.platform.process.common.handler.AbstractObjectProcessLogic;
+import io.cattle.platform.util.type.Priority;
+
+import java.util.List;
+
+public class HealthcheckConfigUpdate extends AbstractObjectProcessLogic implements ProcessPostListener, Priority {
+
+    @Override
+    public String[] getProcessNames() {
+        return new String[] {
+                "nic.activate",
+                "nic.deactivate"
+        };
+    }
+
+    @Override
+    public HandlerResult handle(ProcessState state, ProcessInstance process) {
+        Nic nic = (Nic) state.getResource();
+        List<? extends HealthcheckInstanceHostMap> hostMaps = objectManager.find(
+                HealthcheckInstanceHostMap.class, HEALTHCHECK_INSTANCE_HOST_MAP.INSTANCE_ID, nic.getInstanceId(),
+                HEALTHCHECK_INSTANCE_HOST_MAP.REMOVED, null, HEALTHCHECK_INSTANCE_HOST_MAP.STATE, CommonStatesConstants.ACTIVE);
+        for (HealthcheckInstanceHostMap hostMap : hostMaps) {
+            objectProcessManager.scheduleStandardProcess(StandardProcess.UPDATE, hostMap, null);
+        }
+
+        return null;
+    }
+
+    @Override
+    public int getPriority() {
+        return Priority.DEFAULT;
+    }
+
+}

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/process/spring-process-context.xml
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/process/spring-process-context.xml
@@ -330,6 +330,8 @@
     <!-- Instnace Healthcheck/Host map -->
     <process:process name="healthcheckinstancehostmap.create" resourceType="healthcheckInstanceHostMap" start="requested" transitioning="activating" done="active" />
     <process:process name="healthcheckinstancehostmap.remove" resourceType="healthcheckInstanceHostMap" start="active,activating" transitioning="removing" done="removed" />
+    <process:process name="healthcheckinstancehostmap.update" resourceType="healthcheckInstanceHostMap" start="active" transitioning="updating-active" done="active" />
+
 
     <!-- Container Event -->
     <process:process name="containerevent.create" resourceType="containerEvent" start="requested" transitioning="creating" done="created" />

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/system-services/defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/system-services/defaults.properties
@@ -10,7 +10,7 @@ agent.instance.start.items.increment=agent-instance-startup
 
 agent.instance.services.base.items=${agent.instance.start.items.apply},${agent.instance.start.items.increment}
 
-agent.instance.services.processes=nic.activate,nic.deactivate,instancelink.update,instancelink.activate,hostipaddressmap.activate,serviceexposemap.create,serviceconsumemap.create,serviceconsumemap.update,serviceconsumemap.remove,service.activate,service.deactivate,service.update,service.remove,healthcheckinstancehostmap.create,networkserviceproviderinstancemap.activate,networkserviceproviderinstancemap.remove,ipaddress.update,host.create,host.remove,instance.updateunhealthy,instance.updatehealthy,account.update,instance.remove
+agent.instance.services.processes=nic.activate,nic.deactivate,instancelink.update,instancelink.activate,hostipaddressmap.activate,serviceexposemap.create,serviceconsumemap.create,serviceconsumemap.update,serviceconsumemap.remove,service.activate,service.deactivate,service.update,service.remove,healthcheckinstancehostmap.update,healthcheckinstancehostmap.create,networkserviceproviderinstancemap.activate,networkserviceproviderinstancemap.remove,ipaddress.update,host.create,host.remove,instance.updateunhealthy,instance.updatehealthy,account.update,instance.remove
 
 ipaddress.update.agentInstanceProvider.ipsecTunnelService.increment=hosts,ipsec-hosts,ipsec
 
@@ -61,11 +61,10 @@ instance.updateunhealthy.agentInstanceProvider.dnsService.increment=hosts
 account.update.agentInstanceProvider.dnsService.increment=hosts
 instance.remove.agentInstanceProvider.dnsService.increment=hosts
 
-nic.activate.agentInstanceProvider.healthCheckService.increment=healthcheck
-nic.deactivate.agentInstanceProvider.healthCheckService.increment=healthcheck
 healthcheckinstancehostmap.create.agentInstanceProvider.healthCheckService.increment=healthcheck
+healthcheckinstancehostmap.update.agentInstanceProvider.healthCheckService.increment=healthcheck
 
-
+item.skip.others=healthcheck
 item.wait.for.event.tries=3
 item.wait.for.event.timeout.millis=7500
 item.sync.batch.size=100

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/system-services/spring-system-services-context.xml
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/system-services/spring-system-services-context.xml
@@ -446,6 +446,7 @@
     <bean class="io.cattle.platform.servicediscovery.process.LoadBalancerInstanceStart" />
     <bean class="io.cattle.platform.servicediscovery.process.StackHealthStateUpdate" />
     <bean class="io.cattle.platform.servicediscovery.process.StackHealthStateUpdateTrigger" />
+    <bean class="io.cattle.platform.servicediscovery.process.HealthcheckConfigUpdate" />
 
     <bean class="io.cattle.platform.servicediscovery.dao.impl.ServiceConsumeMapDaoImpl" />
     <bean class="io.cattle.platform.servicediscovery.dao.impl.ServiceExposeMapDaoImpl">


### PR DESCRIPTION
On instance stop/start, reload health check config only for the hosts where network agents running health checks for this instance are located. 

@ibuildthecloud 