### PR TITLE
Fix metadata update on instance.remove

### DIFF
--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/ContainerNicLookup.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/service/impl/ContainerNicLookup.java
@@ -30,8 +30,7 @@ public class ContainerNicLookup extends NicPerVnetNicLookup implements InstanceN
         }
         Instance container = (Instance) obj;
         return create().selectFrom(NIC)
-                .where(NIC.INSTANCE_ID.eq(container.getId())
-                        .and(NIC.REMOVED.isNull()))
+                .where(NIC.INSTANCE_ID.eq(container.getId()))
                 .fetch();
     }
 }


### PR DESCRIPTION
Omit non-removed check when search for instance nic (nic can be already
removed by the time config item post handler runs for the instance.remove process)


https://github.com/rancher/rancher/issues/4555