### PR TITLE
WIP - DNM Fix ipsec config race

### DIFF
--- a/code/iaas/config-item/api/src/main/java/io/cattle/platform/configitem/api/manager/ConfigContentManager.java
+++ b/code/iaas/config-item/api/src/main/java/io/cattle/platform/configitem/api/manager/ConfigContentManager.java
@@ -82,7 +82,6 @@ public class ConfigContentManager extends AbstractNoOpResourceManager {
                 throw new ClientVisibleException(ResponseCodes.NOT_FOUND);
             }
         } catch (IOException e) {
-            log.error("Failed to download [{}] for agent [{}]", id, agentId, e);
             throw new IllegalStateException("Failed to download [" + id + "] for agent [" + agentId + "]", e);
         }
 

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/server/template/impl/FreemarkerTemplate.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/server/template/impl/FreemarkerTemplate.java
@@ -41,7 +41,6 @@ public class FreemarkerTemplate implements io.cattle.platform.configitem.server.
             writer = new OutputStreamWriter(os);
             template.process(context, writer);
         } catch (TemplateException e) {
-            log.error("Failed to run template for [{}]", resource.getName(), e);
             throw new IOException(e);
         } finally {
             writer.flush();

--- a/resources/content/config-content/ipsec/content-home/etc/cattle/ipsec/psk.txt.ftl
+++ b/resources/content/config-content/ipsec/content-home/etc/cattle/ipsec/psk.txt.ftl
@@ -1,1 +1,1 @@
-${ipsecKey}
+<#if ipsecKey??>${ipsecKey}</#if>


### PR DESCRIPTION
@ibuildthecloud 

This doesn't seem to cause direct test failures but shows up in the logs.

SimulatorConfigUpdateProcessor tries to download the ipsec config before AgentInstanceIpsecNetworkServiceCreate has defined the key. This causes the template to fail because ipsecKey is undefined.

Unsure if this is expected behaviour. If so can we change the key in the template to be optional to avoid the log error?

If it's a real issue, another idea would be to try multiple times to read the key in IpsecInfoFactory (seems lame).

Thoughts?

racy logs: https://gist.github.com/dx9/fd4c91b112919be7131751bade55ddd8
