### PR TITLE
tests: remove usage of docker_client.create_container(name='test') ...

### DIFF
--- a/tests/integration/cattletest/core/test_container_logs.py
+++ b/tests/integration/cattletest/core/test_container_logs.py
@@ -24,7 +24,7 @@ def _get_container_logs_ip(host):
 @if_docker
 def test_logs_container(docker_client, cattle_url):
     uuid = TEST_IMAGE_UUID
-    container = docker_client.create_container(name='test', imageUuid=uuid)
+    container = docker_client.create_container(imageUuid=uuid)
     container = docker_client.wait_success(container)
 
     assert len(container.hosts()) == 1

--- a/tests/integration/cattletest/core/test_container_stats.py
+++ b/tests/integration/cattletest/core/test_container_stats.py
@@ -9,7 +9,7 @@ docker_client
 @if_docker
 def test_stats_container(docker_client, cattle_url):
     uuid = TEST_IMAGE_UUID
-    container = docker_client.create_container(name='test', imageUuid=uuid)
+    container = docker_client.create_container(imageUuid=uuid)
     container = docker_client.wait_success(container)
 
     assert len(container.hosts()) == 1

--- a/tests/integration/cattletest/core/test_docker.py
+++ b/tests/integration/cattletest/core/test_docker.py
@@ -26,8 +26,7 @@ def docker_client(super_client):
 @if_docker
 def test_docker_create_only(docker_client, super_client):
     uuid = TEST_IMAGE_UUID
-    container = docker_client.create_container(name='test',
-                                               imageUuid=uuid,
+    container = docker_client.create_container(imageUuid=uuid,
                                                startOnCreate=False)
     try:
         container = docker_client.wait_success(container)
@@ -96,7 +95,7 @@ def test_docker_create_only_from_sha(docker_client, super_client):
 @if_docker
 def test_docker_create_with_start(docker_client, super_client):
     uuid = TEST_IMAGE_UUID
-    container = docker_client.create_container(name='test', imageUuid=uuid)
+    container = docker_client.create_container(imageUuid=uuid)
 
     try:
         assert container.state == 'creating'
@@ -127,8 +126,7 @@ def test_docker_create_with_start(docker_client, super_client):
 def test_docker_build(docker_client, super_client):
     uuid = 'image-' + random_str()
     url = 'https://github.com/rancherio/tiny-build/raw/master/build.tar'
-    container = docker_client.create_container(name='test',
-                                               imageUuid='docker:' + uuid,
+    container = docker_client.create_container(imageUuid='docker:' + uuid,
                                                build={
                                                    'context': url,
                                                })
@@ -150,7 +148,7 @@ def test_docker_build(docker_client, super_client):
 def test_docker_create_with_start_using_docker_io(docker_client, super_client):
     image = 'docker.io/' + TEST_IMAGE
     uuid = 'docker:' + image
-    container = docker_client.create_container(name='test', imageUuid=uuid)
+    container = docker_client.create_container(imageUuid=uuid)
     container = super_client.wait_success(container)
     assert container.state == 'running'
     assert container.data.dockerContainer.Image == image + ':latest'
@@ -161,8 +159,7 @@ def test_docker_create_with_start_using_docker_io(docker_client, super_client):
 @if_docker
 def test_docker_command(docker_client, super_client):
     uuid = TEST_IMAGE_UUID
-    container = docker_client.create_container(name='test',
-                                               imageUuid=uuid,
+    container = docker_client.create_container(imageUuid=uuid,
                                                command=['sleep', '42'])
 
     try:
@@ -176,8 +173,7 @@ def test_docker_command(docker_client, super_client):
 @if_docker
 def test_docker_command_args(docker_client, super_client):
     uuid = TEST_IMAGE_UUID
-    container = docker_client.create_container(name='test',
-                                               imageUuid=uuid,
+    container = docker_client.create_container(imageUuid=uuid,
                                                command=['sleep', '1', '2',
                                                         '3'])
 
@@ -204,7 +200,7 @@ def test_short_lived_container(docker_client, super_client):
 @if_docker
 def test_docker_stop(docker_client):
     uuid = TEST_IMAGE_UUID
-    container = docker_client.create_container(name='test', imageUuid=uuid)
+    container = docker_client.create_container(imageUuid=uuid)
 
     assert container.state == 'creating'
 
@@ -225,7 +221,7 @@ def test_docker_stop(docker_client):
 @if_docker
 def test_docker_purge(docker_client):
     uuid = TEST_IMAGE_UUID
-    container = docker_client.create_container(name='test', imageUuid=uuid)
+    container = docker_client.create_container(imageUuid=uuid)
 
     assert container.state == 'creating'
 
@@ -257,7 +253,7 @@ def test_docker_purge(docker_client):
 @if_docker
 def test_docker_image_format(docker_client, super_client):
     uuid = TEST_IMAGE_UUID
-    container = docker_client.create_container(name='test', imageUuid=uuid)
+    container = docker_client.create_container(imageUuid=uuid)
 
     try:
         container = docker_client.wait_success(container)
@@ -275,7 +271,6 @@ def test_docker_image_format(docker_client, super_client):
 def test_docker_ports_from_container_publish_all(docker_client):
     uuid = TEST_IMAGE_UUID
     c = docker_client.create_container(networkMode='bridge',
-                                       name='test',
                                        publishAllPorts=True,
                                        imageUuid=uuid)
 
@@ -298,8 +293,7 @@ def test_docker_ports_from_container_publish_all(docker_client):
 @if_docker
 def test_docker_ports_from_container_no_publish(docker_client):
     uuid = TEST_IMAGE_UUID
-    c = docker_client.create_container(name='test',
-                                       imageUuid=uuid)
+    c = docker_client.create_container(imageUuid=uuid)
 
     c = docker_client.wait_success(c)
 
@@ -326,7 +320,6 @@ def test_docker_ports_from_container(docker_client, super_client):
 
     uuid = TEST_IMAGE_UUID
     c = docker_client.create_container(networkMode='bridge',
-                                       name='test',
                                        startOnCreate=False,
                                        publishAllPorts=True,
                                        imageUuid=uuid,
@@ -494,8 +487,7 @@ def test_docker_volumes(docker_client, super_client):
     baz_host_path = '/tmp/baz%s' % bind_mount_uuid
     baz_bind_mount = '%s:/baz:ro' % baz_host_path
 
-    c = docker_client.create_container(name="volumes_test",
-                                       imageUuid=uuid,
+    c = docker_client.create_container(imageUuid=uuid,
                                        startOnCreate=False,
                                        dataVolumes=['/foo',
                                                     bar_bind_mount,
@@ -769,8 +761,7 @@ def test_docker_mount_life_cycle(docker_client):
     bar_host_path = '/tmp/bar%s' % bind_mount_uuid
     bar_bind_mount = '%s:/bar' % bar_host_path
 
-    c = docker_client.create_container(name="volumes_test",
-                                       imageUuid=uuid,
+    c = docker_client.create_container(imageUuid=uuid,
                                        startOnCreate=False,
                                        dataVolumes=['%s:/foo' % random_str(),
                                                     bar_bind_mount])

--- a/tests/integration/cattletest/core/test_host_stats.py
+++ b/tests/integration/cattletest/core/test_host_stats.py
@@ -77,7 +77,7 @@ def _get_host_stats_ip(host):
 @if_docker
 def test_stats_container(docker_client):
     uuid = TEST_IMAGE_UUID
-    container = docker_client.create_container(name='test', imageUuid=uuid)
+    container = docker_client.create_container(imageUuid=uuid)
     container = docker_client.wait_success(container)
 
     assert container.state == 'running'


### PR DESCRIPTION
2016-05-03 18:39:37,905 ERROR [915a45cc-955d-47c0-95db-7dfe2833f76f:3945] [instance:180] [instance.start->(InstanceStart)] [] [ecutorService-1] [i.c.p.process.instance.InstanceStart] Failed to Starting for instance [180]
2016-05-03 18:39:37,911 ERROR [915a45cc-955d-47c0-95db-7dfe2833f76f:3945] [instance:180] [instance.start] [] [ecutorService-1] [c.p.e.p.i.DefaultProcessInstanceImpl] Unknown exception io.cattle.platform.eventing.exception.EventExecutionException: 409 Client Error: Conflict ("Conflict. The name "r-test" is already in use by container e9af21975e84. You have to remove (or rename) that container to be able to reuse that name.")
	at io.cattle.platform.eventing.exception.EventExecutionException.fromEvent(EventExecutionException.java:53) ~[cattle-framework-eventing-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.agent.impl.RemoteAgentImpl.callSync(RemoteAgentImpl.java:87) ~[cattle-iaas-agent-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.agent.impl.RemoteAgentImpl.callSync(RemoteAgentImpl.java:135) ~[cattle-iaas-agent-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.process.common.handler.AgentBasedProcessHandler.callSync(AgentBasedProcessHandler.java:180) ~[cattle-iaas-logic-common-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.process.common.handler.AgentBasedProcessHandler.handleEvent(AgentBasedProcessHandler.java:166) ~[cattle-iaas-logic-common-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.process.common.handler.AgentBasedProcessHandler.handle(AgentBasedProcessHandler.java:104) ~[cattle-iaas-logic-common-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl.runHandler(DefaultProcessInstanceImpl.java:446) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl$4.execute(DefaultProcessInstanceImpl.java:393) ~[cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl$4.execute(DefaultProcessInstanceImpl.java:387) ~[cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.idempotent.Idempotent.execute(Idempotent.java:54) ~[cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl.runHandlers(DefaultProcessInstanceImpl.java:387) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl.runLogic(DefaultProcessInstanceImpl.java:493) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl.runWithProcessLock(DefaultProcessInstanceImpl.java:320) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl$2.doWithLockNoResult(DefaultProcessInstanceImpl.java:260) ~[cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.LockCallbackNoReturn.doWithLock(LockCallbackNoReturn.java:7) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.LockCallbackNoReturn.doWithLock(LockCallbackNoReturn.java:3) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl$3.doWithLock(AbstractLockManagerImpl.java:40) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.LockManagerImpl.doLock(LockManagerImpl.java:33) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl.lock(AbstractLockManagerImpl.java:13) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl.lock(AbstractLockManagerImpl.java:37) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl.acquireLockAndRun(DefaultProcessInstanceImpl.java:257) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl.runDelegateLoop(DefaultProcessInstanceImpl.java:185) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl.executeWithProcessInstanceLock(DefaultProcessInstanceImpl.java:158) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl$1.doWithLock(DefaultProcessInstanceImpl.java:108) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl$1.doWithLock(DefaultProcessInstanceImpl.java:105) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl$3.doWithLock(AbstractLockManagerImpl.java:40) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.LockManagerImpl.doLock(LockManagerImpl.java:33) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl.lock(AbstractLockManagerImpl.java:13) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl.lock(AbstractLockManagerImpl.java:37) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl.execute(DefaultProcessInstanceImpl.java:105) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.object.process.impl.DefaultObjectProcessManager.executeStandardProcess(DefaultObjectProcessManager.java:29) ~[cattle-framework-object-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.process.common.handler.AbstractObjectProcessLogic.activate(AbstractObjectProcessLogic.java:31) ~[cattle-iaas-logic-common-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.process.instance.InstanceStart.compute(InstanceStart.java:229) ~[cattle-iaas-logic-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.process.instance.InstanceStart.handle(InstanceStart.java:92) ~[cattle-iaas-logic-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl.runHandler(DefaultProcessInstanceImpl.java:446) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl$4.execute(DefaultProcessInstanceImpl.java:393) ~[cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl$4.execute(DefaultProcessInstanceImpl.java:387) ~[cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.idempotent.Idempotent.execute(Idempotent.java:54) ~[cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl.runHandlers(DefaultProcessInstanceImpl.java:387) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl.runLogic(DefaultProcessInstanceImpl.java:493) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl.runWithProcessLock(DefaultProcessInstanceImpl.java:320) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl$2.doWithLockNoResult(DefaultProcessInstanceImpl.java:260) ~[cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.LockCallbackNoReturn.doWithLock(LockCallbackNoReturn.java:7) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.LockCallbackNoReturn.doWithLock(LockCallbackNoReturn.java:3) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl$3.doWithLock(AbstractLockManagerImpl.java:40) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.LockManagerImpl.doLock(LockManagerImpl.java:33) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl.lock(AbstractLockManagerImpl.java:13) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl.lock(AbstractLockManagerImpl.java:37) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl.acquireLockAndRun(DefaultProcessInstanceImpl.java:257) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl.runDelegateLoop(DefaultProcessInstanceImpl.java:185) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl.executeWithProcessInstanceLock(DefaultProcessInstanceImpl.java:158) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl$1.doWithLock(DefaultProcessInstanceImpl.java:108) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl$1.doWithLock(DefaultProcessInstanceImpl.java:105) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl$3.doWithLock(AbstractLockManagerImpl.java:40) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.LockManagerImpl.doLock(LockManagerImpl.java:33) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl.lock(AbstractLockManagerImpl.java:13) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl.lock(AbstractLockManagerImpl.java:37) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl.execute(DefaultProcessInstanceImpl.java:105) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.eventing.impl.ProcessEventListenerImpl.processExecute(ProcessEventListenerImpl.java:74) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.eventing.impl.ProcessEventListenerImpl.processExecute(ProcessEventListenerImpl.java:56) [cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at sun.reflect.GeneratedMethodAccessor502.invoke(Unknown Source) ~[na:na]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.7.0_95]
	at java.lang.reflect.Method.invoke(Method.java:606) ~[na:1.7.0_95]
	at io.cattle.platform.eventing.annotation.MethodInvokingListener$1.doWithLockNoResult(MethodInvokingListener.java:76) [cattle-framework-eventing-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.LockCallbackNoReturn.doWithLock(LockCallbackNoReturn.java:7) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.LockCallbackNoReturn.doWithLock(LockCallbackNoReturn.java:3) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl$3.doWithLock(AbstractLockManagerImpl.java:40) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.LockManagerImpl.doLock(LockManagerImpl.java:33) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl.lock(AbstractLockManagerImpl.java:13) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl.lock(AbstractLockManagerImpl.java:37) [cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.eventing.annotation.MethodInvokingListener.onEvent(MethodInvokingListener.java:72) [cattle-framework-eventing-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.eventing.impl.AbstractThreadPoolingEventService$2.doRun(AbstractThreadPoolingEventService.java:135) [cattle-framework-eventing-0.5.0-SNAPSHOT.jar:na]
	at org.apache.cloudstack.managed.context.NoExceptionRunnable.runInContext(NoExceptionRunnable.java:15) [cattle-framework-managed-context-0.5.0-SNAPSHOT.jar:na]
	at org.apache.cloudstack.managed.context.ManagedContextRunnable$1.run(ManagedContextRunnable.java:49) [cattle-framework-managed-context-0.5.0-SNAPSHOT.jar:na]
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext$1.call(DefaultManagedContext.java:55) [cattle-framework-managed-context-0.5.0-SNAPSHOT.jar:na]
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.callWithContext(DefaultManagedContext.java:108) [cattle-framework-managed-context-0.5.0-SNAPSHOT.jar:na]
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.runWithContext(DefaultManagedContext.java:52) [cattle-framework-managed-context-0.5.0-SNAPSHOT.jar:na]
	at org.apache.cloudstack.managed.context.ManagedContextRunnable.run(ManagedContextRunnable.java:46) [cattle-framework-managed-context-0.5.0-SNAPSHOT.jar:na]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_95]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_95]
	at java.lang.Thread.run(Thread.java:745) [na:1.7.0_95]