### PR TITLE
tests: mark test_docker_build as nonparallel to avoid test blowout

### DIFF
--- a/tests/integration/cattletest/core/test_docker.py
+++ b/tests/integration/cattletest/core/test_docker.py
@@ -124,6 +124,7 @@ def test_docker_create_with_start(docker_client, super_client):
 
 
 @if_docker
+@pytest.mark.nonparallel
 def test_docker_build(docker_client, super_client):
     uuid = 'image-' + random_str()
     url = 'https://github.com/rancherio/tiny-build/raw/master/build.tar'


### PR DESCRIPTION
Soooo this one is interesting ;) Not really a great fix but at least found how to avoid it or significantly reduce the probability of hitting it.

https://gist.github.com/dx9/29b6cee479551e9be50f8a429b0d045c

py27 runtests: commands[0] | py.test --durations=20 core/test_docker.py core/test_container_stats.py::test_stats_container core/test_container_logs.py::test_logs_container core/test_host_stats.py::test_stats_container -n 17 -vv
=========================================================================================================================================================================== test session starts ============================================================================================================================================================================
platform linux2 -- Python 2.7.6 -- py-1.4.31 -- pytest-2.7.1 -- /scratch/cattle.dfkTR/tests/integration/.tox/py27/bin/python2.7
rootdir: /scratch/cattle.dfkTR/tests/integration, inifile: 
plugins: xdist, xdist, xdist
[gw0] linux2 Python 2.7.6 cwd: /scratch/cattle.dfkTR/tests/integration/cattletest                                                           
[gw1] linux2 Python 2.7.6 cwd: /scratch/cattle.dfkTR/tests/integration/cattletest                                                           
[gw2] linux2 Python 2.7.6 cwd: /scratch/cattle.dfkTR/tests/integration/cattletest                                                           
[gw3] linux2 Python 2.7.6 cwd: /scratch/cattle.dfkTR/tests/integration/cattletest                                                           
[gw4] linux2 Python 2.7.6 cwd: /scratch/cattle.dfkTR/tests/integration/cattletest                                                           
[gw5] linux2 Python 2.7.6 cwd: /scratch/cattle.dfkTR/tests/integration/cattletest                                                           
[gw6] linux2 Python 2.7.6 cwd: /scratch/cattle.dfkTR/tests/integration/cattletest                                                           
[gw7] linux2 Python 2.7.6 cwd: /scratch/cattle.dfkTR/tests/integration/cattletest                                                           
[gw8] linux2 Python 2.7.6 cwd: /scratch/cattle.dfkTR/tests/integration/cattletest                                                           
[gw9] linux2 Python 2.7.6 cwd: /scratch/cattle.dfkTR/tests/integration/cattletest                                                           
[gw10] linux2 Python 2.7.6 cwd: /scratch/cattle.dfkTR/tests/integration/cattletest                                                          
[gw11] linux2 Python 2.7.6 cwd: /scratch/cattle.dfkTR/tests/integration/cattletest                                                          
[gw12] linux2 Python 2.7.6 cwd: /scratch/cattle.dfkTR/tests/integration/cattletest                                                          
[gw13] linux2 Python 2.7.6 cwd: /scratch/cattle.dfkTR/tests/integration/cattletest                                                          
[gw14] linux2 Python 2.7.6 cwd: /scratch/cattle.dfkTR/tests/integration/cattletest                                                          
[gw15] linux2 Python 2.7.6 cwd: /scratch/cattle.dfkTR/tests/integration/cattletest                                                          
[gw16] linux2 Python 2.7.6 cwd: /scratch/cattle.dfkTR/tests/integration/cattletest                                                          
[gw0] Python 2.7.6 (default, Jun 22 2015, 17:58:13)  -- [GCC 4.8.2]                                                                         
[gw1] Python 2.7.6 (default, Jun 22 2015, 17:58:13)  -- [GCC 4.8.2]                                                                          
[gw2] Python 2.7.6 (default, Jun 22 2015, 17:58:13)  -- [GCC 4.8.2]                                                                           
[gw3] Python 2.7.6 (default, Jun 22 2015, 17:58:13)  -- [GCC 4.8.2]                                                                            
[gw4] Python 2.7.6 (default, Jun 22 2015, 17:58:13)  -- [GCC 4.8.2]                                                                             
[gw5] Python 2.7.6 (default, Jun 22 2015, 17:58:13)  -- [GCC 4.8.2]                                                                              
[gw6] Python 2.7.6 (default, Jun 22 2015, 17:58:13)  -- [GCC 4.8.2]                                                                               
[gw7] Python 2.7.6 (default, Jun 22 2015, 17:58:13)  -- [GCC 4.8.2]                                                                                
[gw8] Python 2.7.6 (default, Jun 22 2015, 17:58:13)  -- [GCC 4.8.2]                                                                                 
[gw9] Python 2.7.6 (default, Jun 22 2015, 17:58:13)  -- [GCC 4.8.2]                                                                                  
[gw10] Python 2.7.6 (default, Jun 22 2015, 17:58:13)  -- [GCC 4.8.2]                                                                                  
[gw11] Python 2.7.6 (default, Jun 22 2015, 17:58:13)  -- [GCC 4.8.2]                                                                                   
[gw12] Python 2.7.6 (default, Jun 22 2015, 17:58:13)  -- [GCC 4.8.2]                                                                                    
[gw13] Python 2.7.6 (default, Jun 22 2015, 17:58:13)  -- [GCC 4.8.2]                                                                                     
[gw14] Python 2.7.6 (default, Jun 22 2015, 17:58:13)  -- [GCC 4.8.2]                                                                                      
[gw15] Python 2.7.6 (default, Jun 22 2015, 17:58:13)  -- [GCC 4.8.2]                                                                                       
[gw16] Python 2.7.6 (default, Jun 22 2015, 17:58:13)  -- [GCC 4.8.2]                                                                                                                  
gw0 [30] / gw1 [30] / gw2 [30] / gw3 [30] / gw4 [30] / gw5 [30] / gw6 [30] / gw7 [30] / gw8 [30] / gw9 [30] / gw10 [30] / gw11 [30] / gw12 [30] / gw13 [30] / gw14 [30] / gw15 [30] / gw16 [30]
scheduling tests via LoadScheduling

core/test_docker.py::test_docker_create_with_start 
core/test_docker.py::test_docker_create_only 
core/test_docker.py::test_docker_create_with_start_using_docker_io 
core/test_docker.py::test_docker_create_only_from_sha 
core/test_docker.py::test_docker_build 
core/test_docker.py::test_docker_command 
core/test_docker.py::test_docker_command_args 
core/test_docker.py::test_short_lived_container 
core/test_docker.py::test_docker_image_format 
core/test_docker.py::test_docker_stop 
core/test_docker.py::test_docker_ports_from_container_publish_all 
core/test_docker.py::test_docker_purge 
core/test_docker.py::test_docker_ports_from_container_no_publish 
core/test_docker.py::test_docker_volumes 
core/test_docker.py::test_no_port_override 
core/test_docker.py::test_docker_bind_address 
core/test_docker.py::test_docker_ports_from_container 
[gw14] PASSED core/test_docker.py::test_docker_create_only_from_sha 
core/test_docker.py::test_container_fields 
[gw16] PASSED core/test_docker.py::test_docker_create_only 
core/test_docker.py::test_volumes_from_more_than_one_container 
[gw12] PASSED core/test_docker.py::test_docker_ports_from_container_publish_all 
core/test_container_logs.py::test_logs_container 
[gw5] PASSED core/test_docker.py::test_docker_ports_from_container 
[gw4] FAILED core/test_docker.py::test_docker_build 
core/test_docker.py::test_docker_mount_life_cycle 
[gw10] FAILED core/test_docker.py::test_docker_purge 
core/test_docker.py::test_service_links_with_no_ports 
[gw0] FAILED core/test_docker.py::test_docker_ports_from_container_no_publish 
core/test_host_stats.py::test_stats_container 
[gw1] FAILED core/test_docker.py::test_docker_bind_address 
[gw9] FAILED core/test_docker.py::test_docker_command_args 
core/test_docker.py::test_container_bad_build 
[gw6] FAILED core/test_docker.py::test_docker_volumes 
[gw11] FAILED core/test_docker.py::test_docker_command 
core/test_docker.py::test_container_odd_fields 
[gw14] FAILED core/test_docker.py::test_container_fields 
[gw8] FAILED core/test_docker.py::test_docker_create_with_start 
core/test_docker.py::test_cleanup_volume_strategy 
[gw4] FAILED core/test_docker.py::test_docker_mount_life_cycle 
[gw12] FAILED core/test_container_logs.py::test_logs_container 
[gw7] FAILED core/test_docker.py::test_docker_create_with_start_using_docker_io 
core/test_docker.py::test_docker_labels 
[gw13] FAILED core/test_docker.py::test_docker_image_format 
core/test_container_stats.py::test_stats_container 
[gw3] FAILED core/test_docker.py::test_no_port_override 
[gw2] FAILED core/test_docker.py::test_docker_stop 
core/test_docker.py::test_delete_network_agent 
[gw16] FAILED core/test_docker.py::test_volumes_from_more_than_one_container 
[gw0] FAILED core/test_host_stats.py::test_stats_container 
[gw9] FAILED core/test_docker.py::test_container_bad_build 
[gw11] FAILED core/test_docker.py::test_container_odd_fields 
[gw8] FAILED core/test_docker.py::test_cleanup_volume_strategy 
[gw7] FAILED core/test_docker.py::test_docker_labels 
[gw2] FAILED core/test_docker.py::test_delete_network_agent 
[gw13] FAILED core/test_container_stats.py::test_stats_container 
[gw15] FAILED core/test_docker.py::test_short_lived_container