### PR TITLE
Logic for passing devices directly to vms

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/StoragePoolConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/StoragePoolConstants.java
@@ -8,4 +8,6 @@ public class StoragePoolConstants {
 
     public static final String SERVER_ADDRESS = "serverAddress";
 
+    public static final String FIELD_BLOCK_DEVICE_PATH = "blockDevicePath";
+
 }

--- a/resources/content/schema/agent/storagePool.json
+++ b/resources/content/schema/agent/storagePool.json
@@ -14,6 +14,9 @@
         },
         "volumeAccessMode": {
             "create": true
+        },
+        "blockDevicePath": {
+            "create": true
         }
     }
 }

--- a/resources/content/schema/base/storagePool.json
+++ b/resources/content/schema/base/storagePool.json
@@ -1,0 +1,8 @@
+{
+    "resourceFields" : {
+        "blockDevicePath" : {
+            "type": "string",
+            "nullable": true
+        }
+    }
+}

--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -354,6 +354,7 @@
         "storagePool.externalId": "r",
         "storagePool.driverName": "r",
         "storagePool.volumeAccessMode": "r",
+        "storagePool.blockDevicePath": "r",
 
         "subscribe" : "",
         "subscribe.eventNames" : "cr",

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -702,6 +702,7 @@ def test_storagepool_auth(admin_user_client, user_client, project_client):
         'name': 'r',
         'driverName': 'r',
         'volumeAccessMode': 'r',
+        'blockDevicePath': 'r',
     })
 
     auth_check(user_client.schema, 'storagePool', 'r', {
@@ -710,6 +711,7 @@ def test_storagepool_auth(admin_user_client, user_client, project_client):
         'name': 'r',
         'driverName': 'r',
         'volumeAccessMode': 'r',
+        'blockDevicePath': 'r',
     })
 
     auth_check(project_client.schema, 'storagePool', 'r', {
@@ -718,6 +720,7 @@ def test_storagepool_auth(admin_user_client, user_client, project_client):
         'name': 'r',
         'driverName': 'r',
         'volumeAccessMode': 'r',
+        'blockDevicePath': 'r',
     })
 
 
@@ -1469,6 +1472,7 @@ def test_registry(admin_user_client, user_client, project_client):
         'externalId': 'r',
         'serverAddress': 'r',
         'volumeAccessMode': 'r',
+        'blockDevicePath': 'r',
     })
 
     auth_check(user_client.schema, 'registry', 'r', {
@@ -1477,6 +1481,7 @@ def test_registry(admin_user_client, user_client, project_client):
         'driverName': 'r',
         'serverAddress': 'r',
         'volumeAccessMode': 'r',
+        'blockDevicePath': 'r',
     })
 
     auth_check(project_client.schema, 'registry', 'crud', {
@@ -1485,6 +1490,7 @@ def test_registry(admin_user_client, user_client, project_client):
         'externalId': 'r',
         'serverAddress': 'cr',
         'volumeAccessMode': 'r',
+        'blockDevicePath': 'r',
     })
 
 

--- a/tests/integration/cattletest/core/test_shared_volumes.py
+++ b/tests/integration/cattletest/core/test_shared_volumes.py
@@ -15,14 +15,14 @@ def from_context(context):
     return context.client, context.agent_client, context.host
 
 
-def add_storage_pool(context, host_uuids=None):
+def add_storage_pool(context, host_uuids=None, **kwargs):
     client, agent_client, host = from_context(context)
     sp_name = 'convoy-%s' % random_str()
     if not host_uuids:
         host_uuids = [host.uuid]
 
     create_sp_event(client, agent_client, context,
-                    sp_name, sp_name, SP_CREATE, host_uuids, sp_name)
+                    sp_name, sp_name, SP_CREATE, host_uuids, sp_name, **kwargs)
     storage_pool = wait_for(lambda: sp_wait(client, sp_name))
     assert storage_pool.state == 'active'
     return storage_pool
@@ -571,7 +571,7 @@ def create_volume_event(client, agent_client, context, event_type,
 
 def create_sp_event(client, agent_client, context, external_id, name,
                     event_type, host_uuids, driver_name, agent_account=None,
-                    access_mode=None):
+                    access_mode=None, block_device_path=None):
     storage_pool = {
         'name': name,
         'externalId': external_id,
@@ -580,6 +580,9 @@ def create_sp_event(client, agent_client, context, external_id, name,
 
     if access_mode is not None:
         storage_pool['volumeAccessMode'] = access_mode
+
+    if block_device_path is not None:
+        storage_pool['blockDevicePath'] = block_device_path
 
     event = agent_client.create_external_storage_pool_event(
         externalId=external_id,


### PR DESCRIPTION
This logic integrates with the new longhorn design that allows us to
pass both root and data disks directly to kvm as devices as opposed to
following the normal docker volume workflow of bind mounting.