### PR TITLE
rename scheduler disksize label prefix string

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/util/SystemLabels.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/util/SystemLabels.java
@@ -23,7 +23,7 @@ public class SystemLabels {
     public static final String LABEL_VM_MEMORY = "io.rancher.vm.memory";
     public static final String LABEL_VM_VCPU = "io.rancher.vm.vcpu";
 
-    public static final String LABEL_SCHEDULER_DISKSIZE_PREFIX = "io.rancher.scheduler.disksize.";
+    public static final String LABEL_SCHEDULER_DISKSIZE_PREFIX = "io.rancher.resource.disksize.";
 
     // TODO - move "rancher.io" labels from other parts of the code, here
 }

--- a/tests/integration/cattletest/core/test_allocation.py
+++ b/tests/integration/cattletest/core/test_allocation.py
@@ -665,7 +665,7 @@ def test_container_label_disksize_single_volume(super_client, new_context):
         host1 = super_client.update(host1, info=diskInfo1)
 
         # schedule a container requiring 50 disk size
-        label = 'io.rancher.scheduler.disksize.v1'
+        label = 'io.rancher.resource.disksize.v1'
         c1 = new_context.super_create_container_no_success(labels={label: '50'})
         containers.append(c1)
         assert c1.transitioning == 'error'
@@ -715,8 +715,8 @@ def test_container_label_disksize_multiple_volumes(super_client, new_context):
         host1 = super_client.update(host1, info=diskInfo1)
 
         # schedule a container requiring 5 and 50 disk size volumes
-        label1 = 'io.rancher.scheduler.disksize.v1'
-        label2 = 'io.rancher.scheduler.disksize.v2'
+        label1 = 'io.rancher.resource.disksize.v1'
+        label2 = 'io.rancher.resource.disksize.v2'
         c1 = new_context.super_create_container_no_success(
             labels = {
                 label1 : '5',
@@ -761,7 +761,7 @@ def test_container_label_disksize_lifecycle(super_client, new_context):
     containers = []
 
     try:
-        label = 'io.rancher.scheduler.disksize.v1'
+        label = 'io.rancher.resource.disksize.v1'
 
         # set host with enough disk size
         total_size = 100.0 * 1024    # in MB for diskInfo, but we schedule in GB


### PR DESCRIPTION
@cjellick 
rename scheduler disksize label prefix string to "io.rancher.resource.disksize."