### PR TITLE
Healthcheck config item: update on instance.stop/start

### DIFF
--- a/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/InstanceHealthcheckRegister.java
+++ b/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/InstanceHealthcheckRegister.java
@@ -60,7 +60,7 @@ public class InstanceHealthcheckRegister extends AbstractObjectProcessLogic impl
 
     @Override
     public int getPriority() {
-        return Priority.DEFAULT;
+        return Priority.PRE;
     }
 
 }

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/system-services/defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/system-services/defaults.properties
@@ -10,7 +10,7 @@ agent.instance.start.items.increment=agent-instance-startup
 
 agent.instance.services.base.items=${agent.instance.start.items.apply},${agent.instance.start.items.increment}
 
-agent.instance.services.processes=nic.activate,nic.deactivate,instancelink.update,instancelink.activate,hostipaddressmap.activate,serviceexposemap.create,serviceconsumemap.create,serviceconsumemap.update,serviceconsumemap.remove,service.activate,service.deactivate,service.update,service.remove,healthcheckinstancehostmap.create,networkserviceproviderinstancemap.activate,networkserviceproviderinstancemap.remove,ipaddress.update,host.create,host.remove,instance.updateunhealthy,instance.updatehealthy,account.update,instance.remove
+agent.instance.services.processes=nic.activate,nic.deactivate,instance.start,instance.stop,instancelink.update,instancelink.activate,hostipaddressmap.activate,serviceexposemap.create,serviceconsumemap.create,serviceconsumemap.update,serviceconsumemap.remove,service.activate,service.deactivate,service.update,service.remove,healthcheckinstancehostmap.create,networkserviceproviderinstancemap.activate,networkserviceproviderinstancemap.remove,ipaddress.update,host.create,host.remove,instance.updateunhealthy,instance.updatehealthy,account.update,instance.remove
 
 ipaddress.update.agentInstanceProvider.ipsecTunnelService.increment=hosts,ipsec-hosts,ipsec
 
@@ -61,10 +61,9 @@ instance.updateunhealthy.agentInstanceProvider.dnsService.increment=hosts
 account.update.agentInstanceProvider.dnsService.increment=hosts
 instance.remove.agentInstanceProvider.dnsService.increment=hosts
 
-nic.activate.agentInstanceProvider.healthCheckService.increment=healthcheck
-nic.deactivate.agentInstanceProvider.healthCheckService.increment=healthcheck
+instance.start.agentInstanceProvider.healthCheckService.increment=healthcheck
+instance.stop.agentInstanceProvider.healthCheckService.increment=healthcheck
 healthcheckinstancehostmap.create.agentInstanceProvider.healthCheckService.increment=healthcheck
-
 
 item.wait.for.event.tries=3
 item.wait.for.event.timeout.millis=7500


### PR DESCRIPTION
instead of nic.activate/deactivate. Because instance is reset to
initializing/reinitializing was moved from nic.activate/deactivate to instance.start/stop