### PR TITLE
cleanup ingress lb stack on k8s environment disable

### DIFF
--- a/code/implementation/system-stack/src/main/java/io/cattle/platform/systemstack/listener/SystemStackRemovePostHandler.java
+++ b/code/implementation/system-stack/src/main/java/io/cattle/platform/systemstack/listener/SystemStackRemovePostHandler.java
@@ -22,7 +22,8 @@ public class SystemStackRemovePostHandler extends AbstractObjectProcessLogic imp
     
     private static final Map<String, List<String>> STACKS_TO_CLEANUP = new HashMap<>();
     static {
-        STACKS_TO_CLEANUP.put("kubernetes", Arrays.asList("kubernetes://", "kubernetes-loadbalancers://"));
+        STACKS_TO_CLEANUP.put("kubernetes",
+                Arrays.asList("kubernetes://", "kubernetes-loadbalancers://", "kubernetes-ingress-lbs://"));
     }
 
     @Override


### PR DESCRIPTION
Used to cleanup as a part of ingress-controller shutdown; but it might have resulted in lb service downtime when ingress-controller container dies/gets recreated ([corresponding ingress-controller PR](https://github.com/rancher/ingress-controller/pull/8))