### PR TITLE
Allow upgrade for selector only services

### DIFF
--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/SelectorServiceCreateValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/SelectorServiceCreateValidationFilter.java
@@ -6,7 +6,6 @@ import io.cattle.platform.core.model.Service;
 import io.cattle.platform.iaas.api.filter.common.AbstractDefaultResourceManagerFilter;
 import io.cattle.platform.object.ObjectManager;
 import io.cattle.platform.servicediscovery.api.constants.ServiceDiscoveryConstants;
-import io.cattle.platform.servicediscovery.api.util.ServiceDiscoveryUtil;
 import io.cattle.platform.util.type.CollectionUtils;
 import io.github.ibuildthecloud.gdapi.exception.ValidationErrorException;
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
@@ -59,18 +58,5 @@ public class SelectorServiceCreateValidationFilter extends AbstractDefaultResour
                                 + " is not passed in");
             }
         }
-    }
-
-    @Override
-    public Object resourceAction(String type, ApiRequest request, ResourceManager next) {
-        if (request.getAction().equalsIgnoreCase(ServiceDiscoveryConstants.ACTION_SERVICE_UPGRADE)) {
-            Service service = objManager.loadResource(Service.class, request.getId());
-            if (ServiceDiscoveryUtil.isNoopService(service, allocatorService)) {
-                throw new ValidationErrorException(ValidationErrorCodes.INVALID_ACTION,
-                        "Can't upgrade selector only service");
-            }
-        }
-
-        return super.resourceAction(type, request, next);
     }
 }

--- a/tests/integration/cattletest/core/test_docker.py
+++ b/tests/integration/cattletest/core/test_docker.py
@@ -688,6 +688,10 @@ def test_container_fields(docker_client, super_client):
 
     c = super_client.wait_success(c)
 
+    wait_for(lambda: super_client.reload(c).data['dockerInspect'] is not None)
+    wait_for(lambda: super_client.
+             reload(c).data['dockerInspect']['HostConfig'] is not None)
+
     assert set(c.data['dockerInspect']['HostConfig']['CapAdd']) == set(caps)
     assert set(c.data['dockerInspect']['HostConfig']['CapDrop']) == set(caps)
     actual_dns = c.data['dockerInspect']['HostConfig']['Dns']

--- a/tests/integration/cattletest/core/test_svc_upgrade.py
+++ b/tests/integration/cattletest/core/test_svc_upgrade.py
@@ -407,30 +407,14 @@ def test_service_upgrade_no_image_selector(client):
                                  selectorContainer="foo=barbar")
     svc1 = client.wait_success(svc1)
     svc1 = client.wait_success(svc1.activate())
+    strategy = {"intervalMillis": 100, "launchConfig": {}}
 
-    with pytest.raises(ApiError) as e:
-        svc1.upgrade_action(launchConfig=launch_config,
-                            intervalMillis=100)
-
-    assert e.value.error.status == 422
-    assert e.value.error.code == 'InvalidAction'
+    svc1.upgrade_action(launchConfig=launch_config,
+                        inServiceStrategy=strategy)
 
 
 def test_service_upgrade_mixed_selector(client, context):
     env = _create_stack(client)
-    launch_config = {"imageUuid": "rancher/none"}
-    svc1 = client.create_service(name=random_str(),
-                                 environmentId=env.id,
-                                 launchConfig=launch_config,
-                                 selectorContainer="foo=barbar")
-    svc1 = client.wait_success(svc1)
-    svc1 = client.wait_success(svc1.activate())
-
-    with pytest.raises(ApiError) as e:
-        _run_insvc_upgrade(svc1, launchConfig={'labels': {'foo': "bar"}})
-
-    assert e.value.error.status == 422
-    assert e.value.error.code == 'InvalidAction'
 
     image_uuid = context.image_uuid
     launch_config = {"imageUuid": image_uuid}


### PR DESCRIPTION
which will be noop, but we wanted to unblock action on API level so
rancher-compose can run upgrades w/o determining type of the service.

@ibuildthecloud @vincent99 