### PR TITLE
Improve api error logging

### DIFF
--- a/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/request/ApiRequest.java
+++ b/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/request/ApiRequest.java
@@ -409,4 +409,8 @@ public class ApiRequest {
         this.subContext = subContext;
     }
 
+    @Override
+    public String toString() {
+        return requestUrl == null ? "" : requestUrl;
+    }
 }

--- a/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/request/handler/ExceptionHandler.java
+++ b/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/request/handler/ExceptionHandler.java
@@ -60,14 +60,16 @@ public class ExceptionHandler implements ApiRequestHandler {
     }
 
     protected ApiError getUnknownError(ApiRequest apiRequest, Throwable t) throws IOException, ServletException {
-        log.error("Exception in API for request [{}]", apiRequest, t);
         if (throwUnknownErrors) {
+            log.error("Rethrowing exception in API for request [{}]", apiRequest, t);
             ExceptionUtils.rethrowRuntime(t);
             ExceptionUtils.rethrow(t, IOException.class);
             ExceptionUtils.rethrow(t, ServletException.class);
             throw new ServletException(t);
         } else {
-            return populateError(new ErrorImpl(ResponseCodes.INTERNAL_SERVER_ERROR), apiRequest.getLocale());
+            ErrorImpl e = new ErrorImpl(ResponseCodes.INTERNAL_SERVER_ERROR);
+            log.error("Exception in API for request [{}]. Error id: [{}].", apiRequest, e.getId(), t);
+            return populateError(e, apiRequest.getLocale());
         }
     }
 


### PR DESCRIPTION
This change will make it easier to correlate specific failed api
requests to their logged stack traces. This will be particularly useful
in debugging build output.