### PR TITLE
Don't suppress service.reconcile config update on non-active states

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentManagerImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentManagerImpl.java
@@ -295,7 +295,7 @@ public class DeploymentManagerImpl implements DeploymentManager {
             @Override
             public void run() {
                 Service service = objectMgr.loadResource(Service.class, client.getResourceId());
-                if (service != null && service.getState().equalsIgnoreCase(CommonStatesConstants.ACTIVE)) {
+                if (service != null && sdSvc.isActiveService(service)) {
                     activate(service);
                 }
             }


### PR DESCRIPTION
Service reconcile initiate multiple operations like instance.stop,instance.start that themselves act as triggers for service.reconcile (done via config update). At some point I've enabled dropping config update requests for an intermediate service state (activating, updating-active) to reduce number of scheduled processes and chances of lockTimeout exceptions (we acquire lock on every reconcile). At the end of the process we double check if reconcile needs to be done, so I've assumed that chances for race conditions are pretty low. Yet not impossible, and this bug is a clear example of that:


https://github.com/rancher/rancher/issues/5005


Config update request for P2 was dropped as service was in updating-active state initiated by config update for P1. But at that point P1 already finished reconciling - only state update to active was left to be done - so instance was never deployed on the new reconnected host.