### PR TITLE
Changes to add missing docker-compose parameters in the exported config

### DIFF
--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/resource/ServiceDiscoveryConfigItem.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/resource/ServiceDiscoveryConfigItem.java
@@ -58,6 +58,11 @@ public class ServiceDiscoveryConfigItem {
 
     public static final ServiceDiscoveryConfigItem LABELS = new ServiceDiscoveryConfigItem(
             InstanceConstants.FIELD_LABELS, InstanceConstants.FIELD_LABELS);
+    public static final ServiceDiscoveryConfigItem MEMSWAPLIMIT = new ServiceDiscoveryConfigItem(
+            DockerInstanceConstants.FIELD_MEMORY_SWAP, "memswap_limit");
+    public static final ServiceDiscoveryConfigItem PIDMODE = new ServiceDiscoveryConfigItem(DockerInstanceConstants.FIELD_PID_MODE, "pid");
+    public static final ServiceDiscoveryConfigItem DEVICES = new ServiceDiscoveryConfigItem(
+            DockerInstanceConstants.FIELD_DEVICES, DockerInstanceConstants.FIELD_DEVICES);
 
     // CATTLE PARAMETERS
     public static final ServiceDiscoveryConfigItem SCALE = new ServiceDiscoveryConfigItem("scale", "scale",

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -1804,6 +1804,10 @@ def test_export_config(client, context):
     launch_config = {"imageUuid": image_uuid,
                      "cpuSet": "0,1", "labels": labels,
                      "restartPolicy": restart_policy,
+                     "pidMode": "host",
+                     "memory": 1048576,
+                     "memorySwap": 2097152,
+                     "devices": ["/dev/sdc:/dev/xsdc:rwm"],
                      "logConfig": {"config": {"labels": "foo"},
                                    "driver": "json-file"}}
     service = client. \
@@ -1825,6 +1829,10 @@ def test_export_config(client, context):
     assert "restart" not in docker_yml[service.name]
     assert docker_yml[service.name]["log_driver"] == "json-file"
     assert docker_yml[service.name]["log_opt"] is not None
+    assert docker_yml[service.name]["pid"] == "host"
+    assert docker_yml[service.name]["mem_limit"] == 1048576
+    assert docker_yml[service.name]["memswap_limit"] == 2097152
+    assert docker_yml[service.name]["devices"] is not None
 
     rancher_yml = yaml.load(compose_config.rancherComposeConfig)
     assert 'scale' not in rancher_yml[service.name]


### PR DESCRIPTION
Changes to add missing docker-compose parameters pid, device, memswap_limit on exported config
Also added tests for the parameters

https://github.com/rancher/rancher/issues/4890
https://github.com/rancher/rancher/issues/4232
https://github.com/rancher/rancher/issues/5001