### PR TITLE
Bug fixes around host removal and agent.deactivate/remove

### DIFF
--- a/code/framework/eventing/src/main/java/io/cattle/platform/eventing/exception/AgentInactiveException.java
+++ b/code/framework/eventing/src/main/java/io/cattle/platform/eventing/exception/AgentInactiveException.java
@@ -1,0 +1,12 @@
+package io.cattle.platform.eventing.exception;
+
+import io.cattle.platform.eventing.model.Event;
+
+public class AgentInactiveException extends EventExecutionException {
+
+    private static final long serialVersionUID = -8135611084820936474L;
+
+    public AgentInactiveException(String message, Event event) {
+        super(message, event);
+    }
+}

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/host/HostRemove.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/host/HostRemove.java
@@ -31,11 +31,6 @@ public class HostRemove extends AbstractDefaultProcessHandler {
             return null;
         }
 
-        try {
-            objectProcessManager.scheduleStandardProcess(StandardProcess.DEACTIVATE, agent, null);
-        } catch (ProcessCancelException e) {
-        }
-
         removeInstances(host);
 
         return null;


### PR DESCRIPTION
This PR fixes a couple of bugs:

1) Host was removed, but agent was left around non-removed. Happened because we had agent.disconnect scheduled from 2 places: 

a) HostRemove handler
b) AgentResourceRemove post handler (triggered by host.remove process) - disconnect is scheduled with remove process chained. The bug was - disconnect/remove process was canceled at this point because a) already put agent to "disconnecting" state. So the agent was never removed as a result.

2) Agent reconnect process (AgentActivate handler) was waiting for the ping event when agent.disconnect was called. So we ended up having agent stuck in Disconnecting state because we were dropping events. It only timed out/got cancelled after ~5 mins, and Disconnect process was able to complete. The fix here would be - include deactivating/inactive/removing/removed/purged/purging to the list of states triggering AgentRemovedException, so Reconnecting process completes faster for the agent in these states, and Deactivate process can go through.

@ibuildthecloud let me know if the above sounds valid


https://github.com/rancher/rancher/issues/5047