### PR TITLE
Bump up agent instance to v0.8.2

### DIFF
--- a/resources/content/cattle-global.properties
+++ b/resources/content/cattle-global.properties
@@ -5,7 +5,7 @@
 api.ui.index=//releases.rancher.com/ui/latest
 api.ui.js.url=https://releases.rancher.com/api-ui/1.0.4/ui.min.js
 api.ui.css.url=https://releases.rancher.com/api-ui/1.0.4/ui.min.css
-agent.instance.image=rancher/agent-instance:v0.8.1
+agent.instance.image=rancher/agent-instance:v0.8.2
 cluster.image.name=${agent.instance.image}
 bootstrap.required.image=rancher/agent:v1.0.1
 agent.package.python.agent.url=https://github.com/rancher/python-agent/releases/download/v0.81.0/python-agent.tar.gz


### PR DESCRIPTION
This is a rebuild of v0.8.1 with a new openssl package that fixes a vulnerability reported in: rancher/rancher#5038