### PR TITLE
Default logConfig addon "config" field

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
@@ -54,6 +54,7 @@ public class InstanceConstants {
     public static final String FIELD_HOST_ID = "hostId";
     public static final String FIELD_DNS_INTERNAL = "dnsInternal";
     public static final String FIELD_DNS_SEARCH_INTERNAL = "dnsSearchInternal";
+    public static final String FIELD_LOG_CONFIG = "logConfig";
 
     public static final String PROCESS_DATA_NO_OP = "containerNoOpEvent";
 

--- a/code/implementation/docker/common/src/main/java/io/cattle/platform/docker/constants/DockerInstanceConstants.java
+++ b/code/implementation/docker/common/src/main/java/io/cattle/platform/docker/constants/DockerInstanceConstants.java
@@ -32,7 +32,6 @@ public class DockerInstanceConstants {
     public static final String FIELD_DEVICES = "devices";
     public static final String FIELD_WORKING_DIR = "workingDir";
     public static final String FIELD_SECURITY_OPT = "securityOpt";
-    public static final String FIELD_LOG_CONFIG = "logConfig";
     public static final String FIELD_PID_MODE = "pidMode";
     public static final String FIELD_EXTRA_HOSTS = "extraHosts";
     public static final String FIELD_READ_ONLY = "readOnly";


### PR DESCRIPTION
If "config" field is missing in logConfig parameter, docker defaults log driver to the default one, json-file. UI already defaults this value to empty json map, and I wasn't sure how to set defaultValue to an empty map in LogDriver addon. So setting it on instance pre-create handler.

https://github.com/rancher/rancher/issues/4773