### PR TITLE
Active Directory: Changes to add login restrictions for groups

### DIFF
--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/LDAPUtils.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/LDAPUtils.java
@@ -1,5 +1,6 @@
 package io.cattle.platform.iaas.api.auth.integration.ldap;
 
+import io.cattle.platform.iaas.api.auth.SecurityConstants;
 import io.cattle.platform.iaas.api.auth.integration.ldap.interfaces.LDAPConstants;
 import io.github.ibuildthecloud.gdapi.exception.ClientVisibleException;
 import io.github.ibuildthecloud.gdapi.util.ResponseCodes;
@@ -8,6 +9,7 @@ import java.net.ConnectException;
 import java.util.Hashtable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import javax.naming.Context;
 import javax.naming.NamingException;
 import javax.naming.ldap.InitialLdapContext;
@@ -32,7 +34,7 @@ public class LDAPUtils {
      * and resubmit it, without locking them out of cattle.
      */
     public static void validateConfig(LDAPConstants ldapConfig) {
-        if (ldapConfig.getEnabled() == null || !ldapConfig.getEnabled()) {
+        if (ldapConfig.getEnabled() == null || !ldapConfig.getEnabled() || SecurityConstants.SECURITY.get()) {
             return;
         }
         if (StringUtils.isBlank(ldapConfig.getServiceAccountUsername()) || StringUtils.isBlank(ldapConfig.getServiceAccountPassword())) {

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPConfig.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPConfig.java
@@ -1,9 +1,13 @@
 package io.cattle.platform.iaas.api.auth.integration.ldap.OpenLDAP;
 
+import io.cattle.platform.api.auth.Identity;
 import io.cattle.platform.iaas.api.auth.integration.interfaces.Configurable;
 import io.cattle.platform.iaas.api.auth.integration.ldap.interfaces.LDAPConfig;
 import io.github.ibuildthecloud.gdapi.annotation.Field;
 import io.github.ibuildthecloud.gdapi.annotation.Type;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Type(name = OpenLDAPConstants.CONFIG)
 public class OpenLDAPConfig implements Configurable, LDAPConfig {
@@ -173,5 +177,10 @@ public class OpenLDAPConfig implements Configurable, LDAPConfig {
     @Field(nullable = false, required = true, defaultValue = "1000")
     public long getConnectionTimeout() {
         return connectionTimeout;
+    }
+
+    @Override
+    public List<Identity> getAllowedIdentities() {
+        return new ArrayList<>();
     }
 }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPConstantsConfig.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPConstantsConfig.java
@@ -1,7 +1,10 @@
 package io.cattle.platform.iaas.api.auth.integration.ldap.OpenLDAP;
 
+import io.cattle.platform.api.auth.Identity;
 import io.cattle.platform.iaas.api.auth.integration.ldap.interfaces.LDAPConstants;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 public class OpenLDAPConstantsConfig extends OpenLDAPConfigurable implements LDAPConstants{
@@ -143,5 +146,10 @@ public class OpenLDAPConstantsConfig extends OpenLDAPConfigurable implements LDA
     @Override
     public Set<String> scopes() {
         return OpenLDAPConstants.SCOPES;
+    }
+
+    @Override
+    public List<Identity> getAllowedIdentities() {
+        return new ArrayList<>();
     }
 }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADConfig.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADConfig.java
@@ -1,9 +1,13 @@
 package io.cattle.platform.iaas.api.auth.integration.ldap.ad;
 
+
 import io.cattle.platform.iaas.api.auth.integration.interfaces.Configurable;
 import io.cattle.platform.iaas.api.auth.integration.ldap.interfaces.LDAPConfig;
+import io.cattle.platform.api.auth.Identity;
 import io.github.ibuildthecloud.gdapi.annotation.Field;
 import io.github.ibuildthecloud.gdapi.annotation.Type;
+
+import java.util.List;
 
 @Type(name = ADConstants.CONFIG)
 public class ADConfig implements Configurable, LDAPConfig {
@@ -27,12 +31,13 @@ public class ADConfig implements Configurable, LDAPConfig {
     private final String groupObjectClass;
     private final String groupNameField;
     private final long connectionTimeout;
+    private List<Identity> allowedIdentities;
 
     public ADConfig(String server, Integer port, Integer userDisabledBitMask, String loginDomain, String domain,
                     Boolean enabled, String accessMode, String serviceAccountUsername,
                     String serviceAccountPassword, Boolean tls, String userSearchField, String userLoginField,
                     String userObjectClass, String userNameField, String userEnabledAttribute, String groupSearchField,
-                    String groupObjectClass, String groupNameField, long connectionTimeout) {
+                    String groupObjectClass, String groupNameField, long connectionTimeout, List<Identity> allowedIdentities) {
         this.server = server;
         this.port = port;
         this.userDisabledBitMask = userDisabledBitMask;
@@ -52,6 +57,7 @@ public class ADConfig implements Configurable, LDAPConfig {
         this.groupObjectClass = groupObjectClass;
         this.groupNameField = groupNameField;
         this.connectionTimeout = connectionTimeout;
+        this.allowedIdentities = allowedIdentities;
     }
 
     @Field(required = true, nullable = false, minLength = 1)
@@ -181,5 +187,11 @@ public class ADConfig implements Configurable, LDAPConfig {
     @Field(nullable = false, required = true, defaultValue = "1000")
     public long getConnectionTimeout() {
         return connectionTimeout;
+    }
+
+    @Override
+    @Field(nullable = true)
+    public List<Identity> getAllowedIdentities() {
+        return allowedIdentities;
     }
 }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADConfigManager.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADConfigManager.java
@@ -1,21 +1,26 @@
 package io.cattle.platform.iaas.api.auth.integration.ldap.ad;
 
+import io.cattle.platform.api.auth.Identity;
 import io.cattle.platform.core.util.SettingsUtils;
+import io.cattle.platform.iaas.api.auth.AbstractTokenUtil;
 import io.cattle.platform.iaas.api.auth.SecurityConstants;
 import io.cattle.platform.iaas.api.auth.integration.ldap.LDAPUtils;
 import io.cattle.platform.iaas.api.auth.integration.ldap.interfaces.LDAPConstants;
 import io.cattle.platform.json.JsonMapper;
+import io.cattle.platform.util.type.CollectionUtils;
 import io.github.ibuildthecloud.gdapi.factory.SchemaFactory;
 import io.github.ibuildthecloud.gdapi.model.ListOptions;
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 import io.github.ibuildthecloud.gdapi.request.resource.impl.AbstractNoOpResourceManager;
-
+import java.util.List;
 import java.util.Map;
+
 import javax.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
 
 public class ADConfigManager extends AbstractNoOpResourceManager {
+
 
     @Inject
     SettingsUtils settingsUtils;
@@ -39,88 +44,94 @@ public class ADConfigManager extends AbstractNoOpResourceManager {
 
         LDAPConstants config = request.proxyRequestObject(LDAPConstants.class);
         LDAPUtils.validateConfig(config);
-        return updateCurrentConfig(config);
+        Map<String, Object> configMap = CollectionUtils.toMap(request.getRequestObject());
+        return updateCurrentConfig(configMap);
     }
 
-    private ADConfig currentLdapConfig(LDAPConstants config) {
+    private ADConfig currentLdapConfig(Map<String, Object> config) {
         ADConfig currentConfig = (ADConfig) listInternal(null, null, null, null);
         String domain = currentConfig.getDomain();
-        if (config.getDomain() != null) {
-            domain = config.getDomain();
+        if (config.get(ADConstants.CONFIG_DOMAIN) != null) {
+            domain = (String)config.get(ADConstants.CONFIG_DOMAIN);
         }
         String server = currentConfig.getServer();
-        if (config.getServer() != null) {
-            server = config.getServer();
+        if (config.get(ADConstants.CONFIG_SERVER) != null) {
+            server = (String)config.get(ADConstants.CONFIG_SERVER);
         }
         String loginDomain = currentConfig.getLoginDomain();
-        if (config.getLoginDomain() != null) {
-            loginDomain = config.getLoginDomain();
+        if (config.get(ADConstants.CONFIG_LOGIN_DOMAIN) != null) {
+            loginDomain = (String)config.get(ADConstants.CONFIG_LOGIN_DOMAIN);
         }
         String accessMode = currentConfig.getAccessMode();
-        if (config.getAccessMode() != null) {
-            accessMode = config.getAccessMode();
+        if (config.get(AbstractTokenUtil.ACCESSMODE) != null) {
+            accessMode = (String)config.get(AbstractTokenUtil.ACCESSMODE);
         }
         String serviceAccountUsername = currentConfig.getServiceAccountUsername();
-        if (config.getServiceAccountUsername() != null) {
-            serviceAccountUsername = config.getServiceAccountUsername();
+        if (config.get(ADConstants.CONFIG_SERVICE_ACCOUNT_USERNAME) != null) {
+            serviceAccountUsername = (String)config.get(ADConstants.CONFIG_SERVICE_ACCOUNT_USERNAME);
         }
         String serviceAccountPassword = currentConfig.getServiceAccountPassword();
-        if (config.getServiceAccountPassword() != null) {
-            serviceAccountPassword = config.getServiceAccountPassword();
+        if (config.get(ADConstants.CONFIG_SERVICE_ACCOUNT_PASSWORD) != null) {
+            serviceAccountPassword = (String)config.get(ADConstants.CONFIG_SERVICE_ACCOUNT_PASSWORD);
         }
         boolean tls = currentConfig.getTls();
-        if (config.getTls() != null) {
-            tls = config.getTls();
+        if (config.get(ADConstants.CONFIG_TLS) != null) {
+            tls = (Boolean)config.get(ADConstants.CONFIG_TLS);
         }
         int port = currentConfig.getPort();
-        if (config.getPort() != null) {
-            port = config.getPort();
+        if (config.get(ADConstants.CONFIG_PORT) != null) {
+            port = ((Long)config.get(ADConstants.CONFIG_PORT)).intValue();
         }
         boolean enabled = currentConfig.getEnabled();
-        if (config.getEnabled() != null) {
-            enabled = config.getEnabled();
+        if (config.get(ADConstants.CONFIG_SECURITY) != null) {
+            enabled = (Boolean)config.get(ADConstants.CONFIG_SECURITY);
         }
         String userSearchField = currentConfig.getUserSearchField();
-        if (config.getUserSearchField() != null){
-            userSearchField = config.getUserSearchField();
+        if (config.get(ADConstants.CONFIG_USER_SEARCH_FIELD) != null){
+            userSearchField = (String)config.get(ADConstants.CONFIG_USER_SEARCH_FIELD);
         }
         String groupSearchField = currentConfig.getGroupSearchField();
-        if (config.getGroupSearchField() != null){
-            groupSearchField = config.getGroupSearchField();
+        if (config.get(ADConstants.CONFIG_GROUP_SEARCH_FIELD) != null){
+            groupSearchField = (String)config.get(ADConstants.CONFIG_GROUP_SEARCH_FIELD);
         }
         String userLoginField = currentConfig.getUserLoginField();
-        if (config.getUserLoginField() != null){
-            userLoginField = config.getUserLoginField();
+        if (config.get(ADConstants.CONFIG_USER_LOGIN_FIELD) != null){
+            userLoginField = (String)config.get(ADConstants.CONFIG_USER_LOGIN_FIELD);
         }
         int userEnabledMaskBit = currentConfig.getUserDisabledBitMask();
-        if (config.getUserDisabledBitMask() !=null){
-            userEnabledMaskBit = config.getUserDisabledBitMask();
+        if (config.get(ADConstants.CONFIG_USER_DISABLED_BIT_MASK) !=null){
+            userEnabledMaskBit = ((Long)config.get(ADConstants.CONFIG_USER_DISABLED_BIT_MASK)).intValue();
         }
 
         String userObjectClass = currentConfig.getUserObjectClass();
-        if (config.getUserObjectClass() != null) {
-            userObjectClass = config.getUserObjectClass();
+        if (config.get(ADConstants.CONFIG_USER_OBJECT_CLASS) != null) {
+            userObjectClass = (String)config.get(ADConstants.CONFIG_USER_OBJECT_CLASS);
         }
         String userNameField = currentConfig.getUserNameField();
-        if (config.getUserNameField() != null){
-            userNameField = config.getUserNameField();
+        if (config.get(ADConstants.CONFIG_USER_NAME_FIELD) != null){
+            userNameField = (String)config.get(ADConstants.CONFIG_USER_NAME_FIELD);
         }
         String userEnabledAttribute = currentConfig.getUserEnabledAttribute();
-        if (config.getUserEnabledAttribute() != null){
-            userEnabledAttribute = config.getUserEnabledAttribute();
+        if (config.get(ADConstants.CONFIG_USER_ENABLED_ATTRIBUTE) != null){
+            userEnabledAttribute = (String)config.get(ADConstants.CONFIG_USER_ENABLED_ATTRIBUTE);
         }
         String groupObjectClass  = currentConfig.getGroupObjectClass();
-        if (config.getGroupObjectClass()!= null){
-            groupObjectClass = config.getGroupObjectClass();
+        if (config.get(ADConstants.CONFIG_GROUP_OBJECT_CLASS)!= null){
+            groupObjectClass = (String)config.get(ADConstants.CONFIG_GROUP_OBJECT_CLASS);
         }
         String groupNameField = currentConfig.getGroupNameField();
-        if (config.getGroupNameField() != null){
-            groupNameField = config.getGroupNameField();
+        if (config.get(ADConstants.CONFIG_GROUP_NAME_FIELD) != null){
+            groupNameField = (String)config.get(ADConstants.CONFIG_GROUP_NAME_FIELD);
+        }
+        List<Identity> identities = currentConfig.getAllowedIdentities();
+        if (config.get(ADConstants.CONFIG_ALLOWED_IDENTITIES) != null && (String)config.get(AbstractTokenUtil.ACCESSMODE) != null 
+                && "restricted".equalsIgnoreCase((String)config.get(AbstractTokenUtil.ACCESSMODE))){
+            identities = adIdentityProvider.getIdentities((List<Map<String, String>>) config.get(ADConstants.CONFIG_ALLOWED_IDENTITIES));
         }
         return new ADConfig(server, port, userEnabledMaskBit, loginDomain, domain, enabled, accessMode,
                 serviceAccountUsername, serviceAccountPassword, tls, userSearchField, userLoginField,
                 userObjectClass, userNameField, userEnabledAttribute, groupSearchField, groupObjectClass, groupNameField,
-                config.getConnectionTimeout());
+                (Long)config.get(ADConstants.CONFIG_TIMEOUT), identities);
     }
 
     @Override
@@ -145,37 +156,51 @@ public class ADConfigManager extends AbstractNoOpResourceManager {
         String userEnabledAttribute = ADConstants.USER_ENABLED_ATTRIBUTE.get();
         String groupNameField = ADConstants.GROUP_NAME_FIELD.get();
         long connectionTimeout = ADConstants.CONNECTION_TIMEOUT.get();
+        List<Identity> identities = adIdentityProvider.savedIdentities();
         return new ADConfig(server, port, userEnabledMaskBit, loginDomain, domain, enabled, accessMode,
                 serviceAccountUsername, serviceAccountPassword, tls, userSearchField, userLoginField, userObjectClass,
                 userNameField, userEnabledAttribute, groupSearchField, groupObjectClass, groupNameField,
-                connectionTimeout);
+                connectionTimeout, identities);
     }
 
-    public ADConfig updateCurrentConfig(LDAPConstants config) {
-        settingsUtils.changeSetting(ADConstants.ACCESS_MODE_SETTING, config.getAccessMode());
-        settingsUtils.changeSetting(ADConstants.DOMAIN_SETTING, config.getDomain());
-        settingsUtils.changeSetting(ADConstants.GROUP_NAME_FIELD_SETTING, config.getGroupNameField());
-        settingsUtils.changeSetting(ADConstants.GROUP_OBJECT_CLASS_SETTING, config.getGroupObjectClass());
-        settingsUtils.changeSetting(ADConstants.GROUP_SEARCH_FIELD_SETTING, config.getGroupSearchField());
-        settingsUtils.changeSetting(ADConstants.LOGIN_DOMAIN_SETTING, config.getLoginDomain());
-        settingsUtils.changeSetting(ADConstants.PORT_SETTING, config.getPort());
-        settingsUtils.changeSetting(ADConstants.SERVER_SETTING, config.getServer());
-        settingsUtils.changeSetting(ADConstants.SERVICE_ACCOUNT_PASSWORD_SETTING, config.getServiceAccountPassword());
-        settingsUtils.changeSetting(ADConstants.SERVICE_ACCOUNT_USERNAME_SETTING, config.getServiceAccountUsername());
-        settingsUtils.changeSetting(ADConstants.TLS_SETTING, config.getTls());
-        settingsUtils.changeSetting(ADConstants.USER_DISABLED_BIT_MASK_SETTING, config.getUserDisabledBitMask());
-        settingsUtils.changeSetting(ADConstants.USER_ENABLED_ATTRIBUTE_SETTING, config.getUserEnabledAttribute());
-        settingsUtils.changeSetting(ADConstants.USER_LOGIN_FIELD_SETTING, config.getUserLoginField());
-        settingsUtils.changeSetting(ADConstants.USER_NAME_FIELD_SETTING, config.getUserNameField());
-        settingsUtils.changeSetting(ADConstants.USER_OBJECT_CLASS_SETTING, config.getUserObjectClass());
-        settingsUtils.changeSetting(ADConstants.USER_SEARCH_FIELD_SETTING, config.getUserSearchField());
-        settingsUtils.changeSetting(ADConstants.TIMEOUT_SETTING, config.getConnectionTimeout());
-        settingsUtils.changeSetting(SecurityConstants.SECURITY_SETTING, config.getEnabled());
-        if (config.getEnabled() != null){
+    public ADConfig updateCurrentConfig(Map<String, Object> config) {
+        settingsUtils.changeSetting(ADConstants.ACCESS_MODE_SETTING, config.get(AbstractTokenUtil.ACCESSMODE));
+        settingsUtils.changeSetting(ADConstants.DOMAIN_SETTING, config.get(ADConstants.CONFIG_DOMAIN));
+        settingsUtils.changeSetting(ADConstants.GROUP_NAME_FIELD_SETTING, config.get(ADConstants.CONFIG_GROUP_NAME_FIELD));
+        settingsUtils.changeSetting(ADConstants.GROUP_OBJECT_CLASS_SETTING, config.get(ADConstants.CONFIG_GROUP_OBJECT_CLASS));
+        settingsUtils.changeSetting(ADConstants.GROUP_SEARCH_FIELD_SETTING, config.get(ADConstants.CONFIG_GROUP_SEARCH_FIELD));
+        settingsUtils.changeSetting(ADConstants.LOGIN_DOMAIN_SETTING, config.get(ADConstants.CONFIG_LOGIN_DOMAIN));
+        settingsUtils.changeSetting(ADConstants.PORT_SETTING, config.get(ADConstants.CONFIG_PORT));
+        settingsUtils.changeSetting(ADConstants.SERVER_SETTING, config.get(ADConstants.CONFIG_SERVER));
+        if(config.get(ADConstants.CONFIG_SERVICE_ACCOUNT_PASSWORD) != null){
+            settingsUtils.changeSetting(ADConstants.SERVICE_ACCOUNT_PASSWORD_SETTING, config.get(ADConstants.CONFIG_SERVICE_ACCOUNT_PASSWORD));
+        }
+        settingsUtils.changeSetting(ADConstants.SERVICE_ACCOUNT_USERNAME_SETTING, config.get(ADConstants.CONFIG_SERVICE_ACCOUNT_USERNAME));
+        settingsUtils.changeSetting(ADConstants.TLS_SETTING, config.get(ADConstants.CONFIG_TLS));
+        settingsUtils.changeSetting(ADConstants.USER_DISABLED_BIT_MASK_SETTING, config.get(ADConstants.CONFIG_USER_DISABLED_BIT_MASK));
+        settingsUtils.changeSetting(ADConstants.USER_ENABLED_ATTRIBUTE_SETTING, config.get(ADConstants.CONFIG_USER_ENABLED_ATTRIBUTE));
+        settingsUtils.changeSetting(ADConstants.USER_LOGIN_FIELD_SETTING, config.get(ADConstants.CONFIG_USER_LOGIN_FIELD));
+        settingsUtils.changeSetting(ADConstants.USER_NAME_FIELD_SETTING, config.get(ADConstants.CONFIG_USER_NAME_FIELD));
+        settingsUtils.changeSetting(ADConstants.USER_OBJECT_CLASS_SETTING, config.get(ADConstants.CONFIG_USER_OBJECT_CLASS));
+        settingsUtils.changeSetting(ADConstants.USER_SEARCH_FIELD_SETTING, config.get(ADConstants.CONFIG_USER_SEARCH_FIELD));
+        settingsUtils.changeSetting(ADConstants.TIMEOUT_SETTING, config.get(ADConstants.CONFIG_TIMEOUT));
+        settingsUtils.changeSetting(SecurityConstants.SECURITY_SETTING, config.get(ADConstants.CONFIG_SECURITY));
+
+        if (config.get(ADConstants.CONFIG_SECURITY) != null){
             settingsUtils.changeSetting(SecurityConstants.AUTH_PROVIDER_SETTING, ADConstants.CONFIG);
         } else {
             settingsUtils.changeSetting(SecurityConstants.AUTH_PROVIDER_SETTING, SecurityConstants.NO_PROVIDER);
         }
+
+        if ("restricted".equalsIgnoreCase((String)config.get(AbstractTokenUtil.ACCESSMODE))) {
+            //validate the allowedIdentities
+            String ids = adIdentityProvider.validateIdentities((List<Map<String, String>>) config.get(ADConstants.CONFIG_ALLOWED_IDENTITIES));
+            settingsUtils.changeSetting(ADConstants.ALLOWED_IDENTITIES_SETTING, ids);
+        } else if ("unrestricted".equalsIgnoreCase((String)config.get(AbstractTokenUtil.ACCESSMODE))) {
+            //clear out the allowedIdentities Set
+            settingsUtils.changeSetting(ADConstants.ALLOWED_IDENTITIES_SETTING, null);
+        }
+
         return currentLdapConfig(config);
     }
 

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADConstants.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADConstants.java
@@ -1,7 +1,6 @@
 package io.cattle.platform.iaas.api.auth.integration.ldap.ad;
 
 import io.cattle.platform.archaius.util.ArchaiusUtil;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -43,6 +42,7 @@ public class ADConstants {
     public static final String GROUP_NAME_FIELD_SETTING = SETTING_BASE + "group.name.field";
     public static final String TLS_SETTING = SETTING_BASE + "tls";
     public static final String TIMEOUT_SETTING = SETTING_BASE + "connection.timeout";
+    public static final String ALLOWED_IDENTITIES_SETTING = SETTING_BASE + "allowed.identities";
 
     public static final Set<String> SCOPES = Collections.unmodifiableSet(
             new HashSet<>(Arrays.asList(
@@ -66,6 +66,7 @@ public class ADConstants {
     public static final DynamicStringProperty USER_OBJECT_CLASS = ArchaiusUtil.getString(USER_OBJECT_CLASS_SETTING);
     public static final DynamicIntProperty USER_DISABLED_BIT_MASK = ArchaiusUtil.getInt(USER_DISABLED_BIT_MASK_SETTING);
     public static final DynamicStringProperty USER_ENABLED_ATTRIBUTE = ArchaiusUtil.getString(USER_ENABLED_ATTRIBUTE_SETTING);
+    public static final DynamicStringProperty AD_ALLOWED_IDENTITIES = ArchaiusUtil.getString(ALLOWED_IDENTITIES_SETTING);
     public static final String MANAGER = NAME + "Manager";
 
 
@@ -81,4 +82,24 @@ public class ADConstants {
     public static final DynamicStringProperty GROUP_OBJECT_CLASS = ArchaiusUtil.getString(GROUP_OBJECT_CLASS_SETTING);
 
     public static final DynamicLongProperty CONNECTION_TIMEOUT = ArchaiusUtil.getLong(TIMEOUT_SETTING);
+
+    public static final String CONFIG_DOMAIN = "domain";
+    public static final String CONFIG_ALLOWED_IDENTITIES = "allowedIdentities";
+    public static final String CONFIG_GROUP_NAME_FIELD = "groupNameField";
+    public static final String CONFIG_GROUP_OBJECT_CLASS = "groupObjectClass";
+    public static final String CONFIG_GROUP_SEARCH_FIELD = "groupSearchField";
+    public static final String CONFIG_LOGIN_DOMAIN = "loginDomain";
+    public static final String CONFIG_PORT = "port";
+    public static final String CONFIG_SERVER = "server";
+    public static final String CONFIG_SERVICE_ACCOUNT_PASSWORD = "serviceAccountPassword";
+    public static final String CONFIG_SERVICE_ACCOUNT_USERNAME = "serviceAccountUsername";
+    public static final String CONFIG_TLS = "tls";
+    public static final String CONFIG_USER_DISABLED_BIT_MASK = "userDisabledBitMask";
+    public static final String CONFIG_USER_ENABLED_ATTRIBUTE = "userEnabledAttribute";
+    public static final String CONFIG_USER_LOGIN_FIELD = "userLoginField";
+    public static final String CONFIG_USER_NAME_FIELD = "userNameField";
+    public static final String CONFIG_USER_OBJECT_CLASS = "userObjectClass";
+    public static final String CONFIG_USER_SEARCH_FIELD = "userSearchField";
+    public static final String CONFIG_TIMEOUT = "connectionTimeout";
+    public static final String CONFIG_SECURITY = "enabled";
 }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADConstantsConfig.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADConstantsConfig.java
@@ -1,7 +1,10 @@
 package io.cattle.platform.iaas.api.auth.integration.ldap.ad;
 
+import io.cattle.platform.api.auth.Identity;
 import io.cattle.platform.iaas.api.auth.integration.ldap.interfaces.LDAPConstants;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 public class ADConstantsConfig extends ADConfigurable implements LDAPConstants{
@@ -143,5 +146,10 @@ public class ADConstantsConfig extends ADConfigurable implements LDAPConstants{
     @Override
     public Set<String> scopes() {
         return ADConstants.SCOPES;
+    }
+
+    @Override
+    public List<Identity> getAllowedIdentities() {
+        return new ArrayList<>();
     }
 }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADTokenUtils.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADTokenUtils.java
@@ -1,9 +1,14 @@
 package io.cattle.platform.iaas.api.auth.integration.ldap.ad;
 
+import io.cattle.platform.api.auth.Identity;
 import io.cattle.platform.core.model.Account;
 import io.cattle.platform.iaas.api.auth.AbstractTokenUtil;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class ADTokenUtils extends AbstractTokenUtil {
 
@@ -14,8 +19,42 @@ public class ADTokenUtils extends AbstractTokenUtil {
 
     @Override
     protected boolean isWhitelisted(List<String> idList) {
-        //TODO Real white listing needed.
-        return true;
+        if (idList == null || idList.isEmpty()) {
+            return false;
+        }
+        List<String> whitelistedValues = fromHashSeparatedString(ADConstants.AD_ALLOWED_IDENTITIES.get());
+
+        for (String id : idList) {
+            for (String whiteId: whitelistedValues){
+                if (StringUtils.equals(id, whiteId)){
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public String toHashSeparatedString(List<Identity> identities) {
+        StringBuilder sb = new StringBuilder();
+        Iterator<Identity> identityIterator = identities.iterator();
+        while (identityIterator.hasNext()){
+            sb.append(identityIterator.next().getId().trim());
+            if (identityIterator.hasNext()) sb.append('#');
+        }
+        return sb.toString();
+    }
+
+    public List<String> fromHashSeparatedString(String string) {
+        if (StringUtils.isEmpty(string)) {
+            return new ArrayList<>();
+        }
+        List<String> strings = new ArrayList<>();
+        String[] splitted = string.split("#");
+        for (String aSplitted : splitted) {
+            String element = aSplitted.trim();
+            strings.add(element);
+        }
+        return strings;
     }
 
     @Override

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/interfaces/LDAPConfig.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/interfaces/LDAPConfig.java
@@ -1,5 +1,9 @@
 package io.cattle.platform.iaas.api.auth.integration.ldap.interfaces;
 
+import io.cattle.platform.api.auth.Identity;
+
+import java.util.List;
+
 public interface LDAPConfig {
 
     String getAccessMode();
@@ -43,5 +47,7 @@ public interface LDAPConfig {
     String getGroupMemberMappingAttribute();
 
     long getConnectionTimeout();
+
+    List<Identity> getAllowedIdentities();
 
 }

--- a/resources/content/schema/admin/admin-auth.json
+++ b/resources/content/schema/admin/admin-auth.json
@@ -146,6 +146,7 @@
         "ldapconfig.userMemberAttribute" : "cr",
         "ldapconfig.groupMemberMappingAttribute" : "cr",
         "ldapconfig.connectionTimeout" : "cr",
+        "ldapconfig.allowedIdentities": "cr",
 
         "localAuthConfig" : "cr",
         "localAuthConfig.accessMode" : "cr",

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -495,7 +495,8 @@ def test_ldap_auth(admin_user_client, user_client, project_client):
         'userSearchField': 'cr',
         'groupMemberMappingAttribute': 'cr',
         'userMemberAttribute': 'cr',
-        'connectionTimeout': 'cr'
+        'connectionTimeout': 'cr',
+        'allowedIdentities': 'cr'
     })
 
 


### PR DESCRIPTION
Changes to add "restricted" access_mode functionality for AD access control.

This will allow the admin to specify the list of groups to which the users must belong to, to be able to login to rancher.

Also fixes for https://github.com/rancher/rancher/issues/5134