### PR TITLE
Access Control: Changes to not allow a user to login when the user is not in "allowed" set

### DIFF
--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/AbstractTokenUtil.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/AbstractTokenUtil.java
@@ -222,10 +222,9 @@ public abstract class AbstractTokenUtil implements TokenUtil {
 
     @Override
     public boolean isAllowed(List<String> idList, Set<Identity> identities) {
-        boolean hasAccessToAProject = authDao.hasAccessToAnyProject(identities, false, null);
         switch (accessMode()) {
             case "restricted":
-                if (hasAccessToAProject || isWhitelisted(idList)) {
+                if (isWhitelisted(idList)) {
                     break;
                 }
                 throw new ClientVisibleException(ResponseCodes.UNAUTHORIZED);


### PR DESCRIPTION
Changes to not allow a user to login when the user is not in the list of the "allowed" users/groups. Even if the user has been invited to some environment, unless she is part of the "allowed" identities, she cannot
login to rancher.

This is a change in behavior for github primarily since only github had "restricted" access mode so far.

This will apply for "restricted" accessmode of all auth providers.