### PR TITLE
fix issue4774 user input service name is not respected as anti-affini…

### DIFF
--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AllocatorServiceImpl.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AllocatorServiceImpl.java
@@ -135,7 +135,7 @@ public class AllocatorServiceImpl implements AllocatorService {
                     String[] components = userEnteredServiceName.split("/");
                     if (components.length == 1 &&
                             stackServiceNameWithLaunchConfig != null) {
-                        if (serviceNamesInStack.contains(userEnteredServiceName)) {
+                        if (serviceNamesInStack.contains(userEnteredServiceName.toLowerCase())) {
                             // prepend stack name
                             userEnteredServiceName = stackName + "/" + userEnteredServiceName;
                         }
@@ -158,7 +158,7 @@ public class AllocatorServiceImpl implements AllocatorService {
         List<? extends Service> services = objectManager.find(Service.class, SERVICE.ENVIRONMENT_ID, environmentId, SERVICE.REMOVED,
                 null);
         for (Service service : services) {
-            servicesInEnv.add(service.getName());
+            servicesInEnv.add(service.getName().toLowerCase());
         }
         return servicesInEnv;
     }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/4775

original problem: Due to upper case service name without stack name, the stack_service name created inside affinity rule value part does not have the stack name prepended, then later on scheduler constraint match function will fail.

fix: when comparing user input service name with existing service names within the stack, it should not be case sensitive.

@alena1108 