### PR TITLE
Add event data necessary for voluem restore process

### DIFF
--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/volume/VolumePreRevertRestore.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/volume/VolumePreRevertRestore.java
@@ -1,0 +1,35 @@
+package io.cattle.platform.process.volume;
+
+import io.cattle.platform.core.constants.VolumeConstants;
+import io.cattle.platform.core.model.Volume;
+import io.cattle.platform.engine.handler.HandlerResult;
+import io.cattle.platform.engine.handler.ProcessPreListener;
+import io.cattle.platform.engine.process.ProcessInstance;
+import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.process.common.handler.AbstractObjectProcessLogic;
+import io.cattle.platform.util.type.Priority;
+
+import javax.inject.Named;
+
+@Named
+public class VolumePreRevertRestore extends AbstractObjectProcessLogic implements ProcessPreListener, Priority {
+
+    @Override
+    public String[] getProcessNames() {
+        return new String[] { VolumeConstants.PROCESS_REVERT, VolumeConstants.PROCESS_RESTORE_FROM_BACKUP };
+    }
+
+    @Override
+    public HandlerResult handle(ProcessState state, ProcessInstance process) {
+        Volume v = (Volume)state.getResource();
+        state.getData().put("processId", process.getId().toString());
+        state.getData().put("volumeName", v.getName());
+        return null;
+    }
+
+    @Override
+    public int getPriority() {
+        return Priority.DEFAULT;
+    }
+
+}

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/process/spring-process-context.xml
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/process/spring-process-context.xml
@@ -145,6 +145,12 @@
         p:dataTypeClass="io.cattle.platform.core.model.Backup"
         p:processNames="volume.restorefrombackup"
         p:shortCircuitIfAgentRemoved="true" >
+        <property name="processDataKeys">
+            <list>
+                <value>processId</value>
+                <value>volumeName</value>
+            </list>
+        </property>
         <property name="priority">
             <util:constant static-field="io.cattle.platform.util.type.Priority.DEFAULT"/>
         </property>


### PR DESCRIPTION
Pass the process id as the identifier for the restore process so that
it can be uniquely identified if the restore is retried. Also use an
explicit volumeName parameter for constructing the volume api URL. This
is necessary because the volume embedded inside backup is where the
backup originated but the target of the restore may be a different
volume.