### PR TITLE
Delegate exception handling - fixes 500 to 409 error code translation

### DIFF
--- a/code/framework/api/src/main/java/io/cattle/platform/api/resource/jooq/AbstractJooqResourceManager.java
+++ b/code/framework/api/src/main/java/io/cattle/platform/api/resource/jooq/AbstractJooqResourceManager.java
@@ -35,7 +35,6 @@ import org.jooq.SelectQuery;
 import org.jooq.Table;
 import org.jooq.TableField;
 import org.jooq.exception.DataAccessException;
-import org.jooq.exception.DataChangedException;
 import org.jooq.impl.DSL;
 import org.jooq.impl.DefaultDSLContext;
 import org.slf4j.Logger;
@@ -377,7 +376,7 @@ public abstract class AbstractJooqResourceManager extends AbstractObjectResource
         if (t instanceof ProcessCancelException) {
             log.info("Process cancel", t.getMessage());
             throw new ClientVisibleException(ResponseCodes.CONFLICT);
-        } else if (t instanceof DataAccessException || t instanceof DataChangedException) {
+        } else if (t instanceof DataAccessException) {
             log.info("Database error", t.getMessage());
             throw new ClientVisibleException(ResponseCodes.CONFLICT);
         }

--- a/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/request/handler/AbstractApiRequestHandler.java
+++ b/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/request/handler/AbstractApiRequestHandler.java
@@ -2,10 +2,14 @@ package io.github.ibuildthecloud.gdapi.request.handler;
 
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+
 public abstract class AbstractApiRequestHandler implements ApiRequestHandler {
 
     @Override
-    public boolean handleException(ApiRequest request, Throwable e) {
+    public boolean handleException(ApiRequest request, Throwable e) throws IOException, ServletException {
         return false;
     }
 

--- a/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/request/handler/ResourceManagerRequestHandler.java
+++ b/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/request/handler/ResourceManagerRequestHandler.java
@@ -10,6 +10,7 @@ import io.github.ibuildthecloud.gdapi.util.ResponseCodes;
 import java.io.IOException;
 
 import javax.inject.Inject;
+import javax.servlet.ServletException;
 
 public class ResourceManagerRequestHandler extends AbstractResponseGenerator {
 
@@ -59,7 +60,7 @@ public class ResourceManagerRequestHandler extends AbstractResponseGenerator {
     }
 
     @Override
-    public boolean handleException(ApiRequest request, Throwable e) {
+    public boolean handleException(ApiRequest request, Throwable e) throws IOException, ServletException {
         ResourceManager manager = resourceManagerLocator.getResourceManager(request);
 
         if (manager == null) {

--- a/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/request/handler/write/DefaultReadWriteApiDelegate.java
+++ b/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/request/handler/write/DefaultReadWriteApiDelegate.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.List;
 
 import javax.inject.Inject;
+import javax.servlet.ServletException;
 
 public class DefaultReadWriteApiDelegate implements ReadWriteApiDelegate {
 
@@ -35,6 +36,16 @@ public class DefaultReadWriteApiDelegate implements ReadWriteApiDelegate {
     @Inject
     public void setHandlers(List<ApiRequestHandler> handlers) {
         this.handlers = handlers;
+    }
+
+    @Override
+    public boolean handleException(ApiRequest request, Throwable e) throws IOException, ServletException {
+        for (ApiRequestHandler handler : handlers) {
+            if (handler.handleException(request, e)) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/request/handler/write/ReadWriteApiDelegate.java
+++ b/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/request/handler/write/ReadWriteApiDelegate.java
@@ -4,10 +4,13 @@ import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 
 import java.io.IOException;
 
+import javax.servlet.ServletException;
+
 public interface ReadWriteApiDelegate {
 
     void read(ApiRequest request) throws IOException;
 
     void write(ApiRequest request) throws IOException;
 
+    boolean handleException(ApiRequest request, Throwable e) throws IOException, ServletException;
 }

--- a/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/request/handler/write/ReadWriteApiHandler.java
+++ b/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/request/handler/write/ReadWriteApiHandler.java
@@ -8,6 +8,7 @@ import io.github.ibuildthecloud.gdapi.util.RequestUtils;
 import java.io.IOException;
 
 import javax.inject.Inject;
+import javax.servlet.ServletException;
 
 public class ReadWriteApiHandler extends AbstractApiRequestHandler implements ApiRequestHandler {
 
@@ -20,6 +21,11 @@ public class ReadWriteApiHandler extends AbstractApiRequestHandler implements Ap
         } else {
             delegate.read(request);
         }
+    }
+
+    @Override
+    public boolean handleException(ApiRequest request, Throwable e) throws IOException, ServletException {
+        return delegate.handleException(request, e);
     }
 
     public ReadWriteApiDelegate getDelegate() {


### PR DESCRIPTION
This PR is to test the fix for 500 Internal error caused by the DB not being translated to 409 conflict. 

ReadWriteApiHandler is registered as a ResourceManagerRequestHandler bean, and it delegates read/writes to ResourceManagerRequestHandler class: 

https://github.com/rancher/cattle/blob/dfab53f789b37217d34400e8143f75e0bcc03c30/code/packaging/app-config/src/main/resources/META-INF/cattle/iaas-api/spring-iaas-api-context.xml#L381

but exception handling wasn't delegated, therefore ResourceManagerRequestHandler.handleException translating 500 to 409 was never invoked. 

PR is WIP till the build finishes

@ibuildthecloud please comment