### PR TITLE
Changes to support "required" accessMode for github and AD

### DIFF
--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADConfigManager.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADConfigManager.java
@@ -124,8 +124,10 @@ public class ADConfigManager extends AbstractNoOpResourceManager {
             groupNameField = (String)config.get(ADConstants.CONFIG_GROUP_NAME_FIELD);
         }
         List<Identity> identities = currentConfig.getAllowedIdentities();
-        if (config.get(ADConstants.CONFIG_ALLOWED_IDENTITIES) != null && (String)config.get(AbstractTokenUtil.ACCESSMODE) != null 
-                && "restricted".equalsIgnoreCase((String)config.get(AbstractTokenUtil.ACCESSMODE))){
+
+        String accessModeInConfig = (String)config.get(AbstractTokenUtil.ACCESSMODE);
+        if (config.get(ADConstants.CONFIG_ALLOWED_IDENTITIES) != null && accessModeInConfig != null 
+                && (AbstractTokenUtil.isRestrictedAccess(accessModeInConfig) || AbstractTokenUtil.isRequiredAccess(accessModeInConfig))) {
             identities = adIdentityProvider.getIdentities((List<Map<String, String>>) config.get(ADConstants.CONFIG_ALLOWED_IDENTITIES));
         }
         return new ADConfig(server, port, userEnabledMaskBit, loginDomain, domain, enabled, accessMode,
@@ -192,11 +194,12 @@ public class ADConfigManager extends AbstractNoOpResourceManager {
             settingsUtils.changeSetting(SecurityConstants.AUTH_PROVIDER_SETTING, SecurityConstants.NO_PROVIDER);
         }
 
-        if ("restricted".equalsIgnoreCase((String)config.get(AbstractTokenUtil.ACCESSMODE))) {
+        String accessModeInConfig = (String)config.get(AbstractTokenUtil.ACCESSMODE);
+        if (AbstractTokenUtil.isRestrictedAccess(accessModeInConfig) || AbstractTokenUtil.isRequiredAccess(accessModeInConfig)) {
             //validate the allowedIdentities
             String ids = adIdentityProvider.validateIdentities((List<Map<String, String>>) config.get(ADConstants.CONFIG_ALLOWED_IDENTITIES));
             settingsUtils.changeSetting(ADConstants.ALLOWED_IDENTITIES_SETTING, ids);
-        } else if ("unrestricted".equalsIgnoreCase((String)config.get(AbstractTokenUtil.ACCESSMODE))) {
+        } else if (AbstractTokenUtil.isUnrestrictedAccess(accessModeInConfig)) {
             //clear out the allowedIdentities Set
             settingsUtils.changeSetting(ADConstants.ALLOWED_IDENTITIES_SETTING, null);
         }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADIdentityProvider.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADIdentityProvider.java
@@ -196,8 +196,8 @@ public class ADIdentityProvider extends LDAPIdentityProvider implements Identity
         }
         String name = getSamName(username);
         String query = "(" + getConstantsConfig().getUserLoginField() + '=' + name + ")";
-        //if restricted access
-        if("restricted".equalsIgnoreCase(adTokenUtils.accessMode())) {
+        //if required access
+        if(AbstractTokenUtil.isRequiredAccess(adTokenUtils.accessMode())) {
             String groupFilter = getAllowedIdentitiesFilter();
             if(groupFilter.length() > 1) {
                 StringBuilder groupQuery = new StringBuilder("(&");


### PR DESCRIPTION
Adding a new "accessMode" value "required". 

New definitions of accessMode are:

When "accessMode" = "required", then a user can log in only when they are present in the "allowed" set of users/groups.

When "accessMode" = "restricted", then a user can log in if  (they are present in the "allowed" set of users/groups) OR (user has access to some project )

When "accessMode" = "unrestricted", then a valid user can log in anytime
