### PR TITLE
Add azuread_user and azuread_group to projectMember externalIdType enum

### DIFF
--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/azure/AzureIdentityProvider.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/azure/AzureIdentityProvider.java
@@ -161,7 +161,7 @@ public class AzureIdentityProvider extends AzureConfigurable implements Identity
                 return org.toIdentity(AzureConstants.GROUP_SCOPE);
             default:
                 throw new ClientVisibleException(ResponseCodes.BAD_REQUEST,
-                        IdentityConstants.INVALID_TYPE, "Invalid scope for GithubSearchProvider", null);
+                        IdentityConstants.INVALID_TYPE, "Invalid scope for AzureSearchProvider", null);
         }
     }
 

--- a/resources/content/schema/base/projectMember.json
+++ b/resources/content/schema/base/projectMember.json
@@ -26,7 +26,9 @@
         "ldap_user",
         "ldap_group",
         "openldap_user",
-        "openldap_group"
+        "openldap_group",
+        "azuread_user",
+        "azuread_group"
       ]
     }
   }


### PR DESCRIPTION
Add azuread_user and azuread_group to projectMember externalIdType enum in the API schema.

This was causing the validation error in creating the environment. 

Also fix a log statement

https://github.com/rancher/rancher/issues/5155