### PR TITLE
No health state check on used indexes calculation

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
@@ -129,12 +129,6 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
         List<Integer> usedSuffixes = new ArrayList<>();
         List<? extends Instance> serviceInstances = exposeMapDao.listServiceManagedInstances(service, launchConfigName);
         for (Instance instance : serviceInstances) {
-            // exclude unhealthy instances as they are going to be replaced
-            if (StringUtils.equals(instance.getHealthState(), HealthcheckConstants.HEALTH_STATE_UNHEALTHY)
-                    || StringUtils.equals(instance.getHealthState(),
-                            HealthcheckConstants.HEALTH_STATE_UPDATING_UNHEALTHY)) {
-                continue;
-            }
             if (ServiceDiscoveryUtil.isServiceGeneratedName(env, service, instance.getName())) {
                 // legacy code - to support old data where service suffix wasn't set
                 String configName = launchConfigName == null


### PR DESCRIPTION
Before 1.1.0, unhealthy instances cleanup happened after their replacements were created. Therefore we had to exclude unheatlhy instances from used indexes as we were planning on replacing them anyway. Well, that didn't play well with non-default health check strategies. 

Starting 1.1.0, we cleanup unhealthy instances based on the strategy, before we create the new ones. As health state check is no longer relevant, so I removed it.