### PR TITLE
add host.update to the default processes

### DIFF
--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/system-services/defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/system-services/defaults.properties
@@ -10,7 +10,7 @@ agent.instance.start.items.increment=agent-instance-startup
 
 agent.instance.services.base.items=${agent.instance.start.items.apply},${agent.instance.start.items.increment}
 
-agent.instance.services.processes=nic.activate,nic.deactivate,instance.start,instance.stop,instancelink.update,instancelink.activate,hostipaddressmap.activate,serviceexposemap.create,serviceconsumemap.create,serviceconsumemap.update,serviceconsumemap.remove,service.activate,service.deactivate,service.update,service.remove,healthcheckinstancehostmap.create,networkserviceproviderinstancemap.activate,networkserviceproviderinstancemap.remove,ipaddress.update,host.create,host.remove,instance.updateunhealthy,instance.updatehealthy,account.update,instance.remove
+agent.instance.services.processes=nic.activate,nic.deactivate,instance.start,instance.stop,instancelink.update,instancelink.activate,hostipaddressmap.activate,serviceexposemap.create,serviceconsumemap.create,serviceconsumemap.update,serviceconsumemap.remove,service.activate,service.deactivate,service.update,service.remove,healthcheckinstancehostmap.create,networkserviceproviderinstancemap.activate,networkserviceproviderinstancemap.remove,ipaddress.update,host.create,host.update,host.remove,instance.updateunhealthy,instance.updatehealthy,account.update,instance.remove
 
 ipaddress.update.agentInstanceProvider.ipsecTunnelService.increment=hosts,ipsec-hosts,ipsec
 
@@ -55,6 +55,7 @@ service.remove.agentInstanceProvider.dnsService.increment=hosts
 networkserviceproviderinstancemap.activate.agentInstanceProvider.dnsService.increment=hosts
 networkserviceproviderinstancemap.remove.agentInstanceProvider.dnsService.increment=hosts
 host.create.agentInstanceProvider.dnsService.increment=hosts
+host.update.agentInstanceProvider.dnsService.increment=hosts
 host.remove.agentInstanceProvider.dnsService.increment=hosts
 instance.updatehealthy.agentInstanceProvider.dnsService.increment=hosts
 instance.updateunhealthy.agentInstanceProvider.dnsService.increment=hosts


### PR DESCRIPTION
@ibuildthecloud 

When we update host labels in the rancher UI, the change doesn't get updated in the metadata service immediately. This PR is meant to fix that. Tested and verified that `requested_version` and `applied_version` fields are updated immediately in the config_item_status table for these hosts, after changing the host label. Also tested that the metadata is updated immediately after updating labels. 

Fixes - https://github.com/rancher/rancher/issues/5493