### PR TITLE
Fix for Global service rollback

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/planner/GlobalServiceDeploymentPlanner.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/planner/GlobalServiceDeploymentPlanner.java
@@ -8,6 +8,8 @@ import io.cattle.platform.servicediscovery.deployment.impl.DeploymentManagerImpl
 import io.cattle.platform.servicediscovery.deployment.impl.unit.DeploymentUnit;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,10 +37,43 @@ public class GlobalServiceDeploymentPlanner extends ServiceDeploymentPlanner {
 
     @Override
     public List<DeploymentUnit> deployHealthyUnits() {
+        // add missing units
         if (needToReconcileDeploymentImpl()) {
             addMissingUnits();
         }
+        // remove extra units
+        removeExtraUnits();
+
         return healthyUnits;
+    }
+
+    private void removeExtraUnits() {
+        // delete units
+        List<DeploymentUnit> watchList = new ArrayList<>();
+        Collections.sort(this.healthyUnits, new Comparator<DeploymentUnit>() {
+            @Override
+            public int compare(DeploymentUnit d1, DeploymentUnit d2) {
+                return Long.compare(d1.getCreateIndex(), d2.getCreateIndex());
+            }
+        });
+
+        List<String> hostIds = new ArrayList<>();
+        for (int i = 0; i < this.healthyUnits.size(); i++) {
+            DeploymentUnit unit = this.healthyUnits.get(i);
+            Map<String, String> unitLabels = unit.getLabels();
+            String hostId = unitLabels.get(ServiceDiscoveryConstants.LABEL_SERVICE_REQUESTED_HOST_ID);
+            if (hostIds.contains(hostId)) {
+                watchList.add(unit);
+                unit.remove(false, ServiceDiscoveryConstants.AUDIT_LOG_REMOVE_EXTRA);
+                this.healthyUnits.remove(i);
+            } else {
+                hostIds.add(hostId);
+            }
+        }
+
+        for (DeploymentUnit toWatch : watchList) {
+            toWatch.waitForRemoval();
+        }
     }
 
     private void addMissingUnits() {


### PR DESCRIPTION
On service upgrade, we do:

1) mark instance v0 for upgrade and stop it
2) wait till its v1 version is recreated by calling service.reconcile

On service rollback, we:

1) destroy one of the v1 instances
2) unmark v0 instance
3) call reconcile that would start v0 instance

and so on.

When we destroy new/unmark old instance for the rollback to pick it up, we do care to pick up a particular instance only in case when:

* the upgrade is partial - when not all launch configs get upgraded. Then we pick a deployment unit to rollback based on deployment unit uuid


But for cases like global service (and perhaps anti affinity constraint use case) it is also important that instance that is being destroyed, has the same hostId as the instance we rollback to. So the constraint never breaks. Otherwise all kinds of collision can possible happen. 

That correct fix would be too big to add at this point (it would impact the entire upgrade logic).
For now, to fix the Global service upgrade use case (and the bug for kubelet rollback found by QA) I've added cleanup logic to the globalDeploymentPlanner to kill the extra instances if the host already has the instance assigned to it. 

https://github.com/rancher/rancher/issues/5558