### PR TITLE
JSON file support to input catalogs

### DIFF
--- a/code/iaas/logic-common/src/main/java/io/cattle/platform/service/launcher/GenericServiceLauncher.java
+++ b/code/iaas/logic-common/src/main/java/io/cattle/platform/service/launcher/GenericServiceLauncher.java
@@ -67,7 +67,7 @@ public abstract class GenericServiceLauncher extends NoExceptionRunnable impleme
         Runnable cb = (new Runnable() {
             @Override
             public void run() {
-                processDestroy();
+                reload();
             }
         });
         future = executor.scheduleWithFixedDelay(this, WAIT, WAIT, TimeUnit.MILLISECONDS);
@@ -80,6 +80,10 @@ public abstract class GenericServiceLauncher extends NoExceptionRunnable impleme
             }
         }
         ProcessEngineUtils.HA_ENABLED.addCallback(cb);
+    }
+
+    public void reload() {
+        processDestroy();    
     }
 
     @Override
@@ -208,6 +212,6 @@ public abstract class GenericServiceLauncher extends NoExceptionRunnable impleme
         }
     }
 
-    protected void prepareProcess(ProcessBuilder pb) {
+    protected void prepareProcess(ProcessBuilder pb) throws IOException {
     }
 }

--- a/code/implementation/docker/machine/src/main/java/io/cattle/platform/docker/machine/launch/CatalogLauncher.java
+++ b/code/implementation/docker/machine/src/main/java/io/cattle/platform/docker/machine/launch/CatalogLauncher.java
@@ -1,13 +1,21 @@
 package io.cattle.platform.docker.machine.launch;
 
+import org.apache.http.client.fluent.Request;
+
 import io.cattle.platform.archaius.util.ArchaiusUtil;
+import io.cattle.platform.json.JsonMapper;
 import io.cattle.platform.lock.definition.LockDefinition;
 import io.cattle.platform.service.launcher.GenericServiceLauncher;
 import io.cattle.platform.util.type.InitializationTask;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import javax.inject.Inject;
 
 import com.netflix.config.DynamicBooleanProperty;
 import com.netflix.config.DynamicStringProperty;
@@ -18,6 +26,64 @@ public class CatalogLauncher extends GenericServiceLauncher implements Initializ
     private static final DynamicStringProperty CATALOG_REFRESH_INTERVAL = ArchaiusUtil.getString("catalog.refresh.interval.seconds");
     private static final DynamicStringProperty CATALOG_BINARY = ArchaiusUtil.getString("catalog.service.executable");
     private static final DynamicBooleanProperty LAUNCH_CATALOG = ArchaiusUtil.getBoolean("catalog.execute");
+
+    public static class CatalogEntry {
+        String name;
+        String repoURL;
+        String branch;
+
+        public CatalogEntry() {
+
+        }
+
+        public String getRepoURL() {
+            return repoURL;
+        }
+
+
+        public void setRepoURL(String repoURL) {
+            this.repoURL = repoURL;
+        }
+
+
+        public String getBranch() {
+            return branch;
+        }
+
+
+        public void setBranch(String branch) {
+            this.branch = branch;
+        }
+
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    public static class ConfigFileFields {
+        List<CatalogEntry> Catalogs;
+
+        public List<CatalogEntry> getCatalogs() {
+            return Catalogs;
+        }
+
+        public void setCatalogs(List<CatalogEntry> catalogs) {
+            Catalogs = catalogs;
+        }
+
+        public ConfigFileFields() {
+
+        }
+    }
+
+    @Inject
+    JsonMapper jsonMapper;
 
     @Override
     protected boolean shouldRun() {
@@ -38,12 +104,41 @@ public class CatalogLauncher extends GenericServiceLauncher implements Initializ
     }
 
     @Override
-    protected void prepareProcess(ProcessBuilder pb) {
+    protected void prepareProcess(ProcessBuilder pb) throws IOException {
         List<String> args = pb.command();
-        args.add("-catalogUrl");
-        args.add(CATALOG_URL.get());
+        args.add("-configFile");
+        prepareConfigFile();
+        args.add("repo.json");
         args.add("-refreshInterval");
         args.add(CATALOG_REFRESH_INTERVAL.get());
+    }
+
+    protected void prepareConfigFile() throws IOException {
+        File configFile = new File("repo.json");
+
+        String catUrl = CATALOG_URL.get();
+        ConfigFileFields configCatalogEntries = new ConfigFileFields();
+        FileOutputStream fos;
+        if(catUrl.startsWith("{")) {
+            configCatalogEntries = jsonMapper.readValue(catUrl, ConfigFileFields.class);
+            fos = new FileOutputStream(configFile.getAbsoluteFile());
+            jsonMapper.writeValue(fos, configCatalogEntries);
+        }
+        else {
+            String []catalogs = catUrl.split(",");
+            List<CatalogEntry> catalogEntryList = new ArrayList<>();
+            for (String catalog: catalogs) {
+                CatalogEntry entry = new CatalogEntry();
+                String[]splitted = catalog.split("=");
+                entry.setName(splitted[0]);
+                entry.setRepoURL(splitted[1]);
+                entry.setBranch("master");
+                catalogEntryList.add(entry);
+            }
+            configCatalogEntries.setCatalogs(catalogEntryList);
+            fos = new FileOutputStream(configFile.getAbsoluteFile());
+            jsonMapper.writeValue(fos, configCatalogEntries);
+        }
     }
 
     @Override
@@ -60,4 +155,12 @@ public class CatalogLauncher extends GenericServiceLauncher implements Initializ
         return true;
     }
 
+    public void reload() {
+        try {
+            prepareConfigFile();
+            Request.Post("http://localhost:8088/v1-catalog/templates?action=refresh").execute();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 }


### PR DESCRIPTION
JSON file is created for the value given to catalog.url in default.properties

In the file https://github.com/rancher/cattle/blob/master/code/packaging/app-config/src/main/resources/META-INF/cattle/process/defaults.properties, change
```
catalog.service.executable=rancher-catalog-service
catalog.execute=false
```
to
```
catalog.service.executable=<path to rancher-catalog-service executable>
catalog.execute=true
```

catalog.url in defaults.properties can be of the form:
```
catalog.url={"catalogs":[{"name":"test_wo_escape","repoURL":"https://github.com/mrajashree/my-rancher-catalog","branch":"new_branch"},{"name":"qa-cat","repoURL":"https://github.com/rancher/qa-catalog","branch":"master"}]}
```