### PR TITLE
Fix failing tests

### DIFF
--- a/tests/integration/cattletest/core/test_allocation.py
+++ b/tests/integration/cattletest/core/test_allocation.py
@@ -624,25 +624,27 @@ def test_volumes_from_constraint(new_context):
 
 
 def test_network_mode_constraint(new_context):
+    client = new_context.client
+
     # Three hosts
     register_simulated_host(new_context)
     register_simulated_host(new_context)
 
     containers = []
     try:
-        c1 = new_context.create_container_no_success(startOnCreate=False)
+        c1 = new_context.create_container(startOnCreate=False)
 
         c2 = new_context.create_container(startOnCreate=False,
                                           networkMode='container',
                                           networkContainerId=c1.id)
 
-        c1 = c1.start()
-        c2 = c2.start()
+        c1 = client.wait_success(c1.start())
+        c2 = client.wait_success(c2.start())
 
-        c1 = new_context.wait_for_state(c1, 'running')
+        assert c1.state == 'running'
         containers.append(c1)
 
-        c2 = new_context.wait_for_state(c2, 'running')
+        assert c1.state == 'running'
         containers.append(c2)
 
         assert c1.hosts()[0].id == c2.hosts()[0].id

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -2326,7 +2326,7 @@ def test_remove_network_from_container(client, context, super_client):
     _wait_until_active_map_count(service, 2, client)
 
 
-def test_metadata(client, context, super_client):
+def test_metadata(client, context):
     env = _create_stack(client)
 
     image_uuid = context.image_uuid
@@ -2339,6 +2339,14 @@ def test_metadata(client, context, super_client):
     service = client.wait_success(service)
     assert service.metadata == metadata
 
+    # Wait until unhealthy to avoid a race condition
+    def wait_unhealthy():
+        svc = client.reload(service)
+        if svc.healthState == 'unhealthy':
+            return svc
+        else:
+            return None
+    service = wait_for(wait_unhealthy)
     metadata = {"bar1": {"foo1": [{"id": 0}]}}
     service = client.update(service, metadata=metadata)
     assert service.metadata == metadata


### PR DESCRIPTION
The metadata test can fail randomly because the update to metadata can
conflict with the service being updated from healthy to unhealthy by a
background process.

The test_network_mode_constraint test can fail because we cannot guarantee that c1 will always get through allocation before c2.