### PR TITLE
Small clarifying tweaks to allocator

### DIFF
--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/AccountConstraint.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/AccountConstraint.java
@@ -12,13 +12,8 @@ public class AccountConstraint extends HardConstraint implements Constraint {
 
     @Override
     public boolean matches(AllocationAttempt attempt, AllocationCandidate candidate) {
-        // This constraint is used to build the initial candidate query and to obtain an allocation lock, but it doesn't need to 
-        // do any matching since the query will limit allocation based on account id.
+        // This constraint and doesn't need to  do any matching since the query will limit allocation based on account id.
         return true;
-    }
-
-    public long getAccountId() {
-        return accountId;
     }
 
     @Override

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AbstractAllocator.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AbstractAllocator.java
@@ -136,7 +136,8 @@ public abstract class AbstractAllocator implements Allocator {
             return;
         }
 
-        final Host host = allocatorDao.getHost(instance);
+        Host host = allocatorDao.getHost(instance);
+        final Long hostId = host == null ? null : host.getId();
         final Set<Volume> volumes = new HashSet<Volume>(objectManager.children(instance, Volume.class));
         volumes.addAll(InstanceHelpers.extractVolumesFromMounts(instance, objectManager));
         final Map<Volume, Set<StoragePool>> pools = new HashMap<Volume, Set<StoragePool>>();
@@ -158,7 +159,7 @@ public abstract class AbstractAllocator implements Allocator {
         lockManager.lock(new AllocateVolumesResourceLock(volumes), new LockCallbackNoReturn() {
             @Override
             public void doWithLockNoResult() {
-                AllocationAttempt attempt = new AllocationAttempt(instance.getAccountId(), instance, host, volumes, pools, nics, subnets);
+                AllocationAttempt attempt = new AllocationAttempt(instance.getAccountId(), instance, hostId, volumes, pools, nics, subnets);
 
                 doAllocate(request, attempt, instance);
             }

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AllocationAttempt.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AllocationAttempt.java
@@ -26,7 +26,6 @@ public class AllocationAttempt {
 
     Long hostId;
 
-    Set<Volume> volumes;
     Set<Long> volumeIds;
 
     Map<Volume, Set<StoragePool>> pools;
@@ -48,7 +47,6 @@ public class AllocationAttempt {
         this.accountId = accountId;
         this.instance = instance;
         this.hostId = hostId;
-        this.volumes = volumes;
         this.pools = pools;
         this.nics = nics;
         this.subnets = subnets == null ? Collections.<Nic, Subnet> emptyMap() : subnets;
@@ -104,10 +102,6 @@ public class AllocationAttempt {
         return hostId;
     }
 
-    public Set<Volume> getVolumes() {
-        return volumes;
-    }
-
     public Map<Volume, Set<StoragePool>> getPools() {
         return pools;
     }
@@ -130,10 +124,6 @@ public class AllocationAttempt {
 
     public void setHostId(Long hostId) {
         this.hostId = hostId;
-    }
-
-    public void setVolumes(Set<Volume> volumes) {
-        this.volumes = volumes;
     }
 
     public void setPools(Map<Volume, Set<StoragePool>> pools) {

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AllocationAttempt.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AllocationAttempt.java
@@ -2,7 +2,6 @@ package io.cattle.platform.allocator.service;
 
 import io.cattle.platform.allocator.constraint.Constraint;
 import io.cattle.platform.allocator.constraint.IsValidConstraint;
-import io.cattle.platform.core.model.Host;
 import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.Nic;
 import io.cattle.platform.core.model.StoragePool;
@@ -25,7 +24,6 @@ public class AllocationAttempt {
 
     Instance instance;
 
-    Host host;
     Long hostId;
 
     Set<Volume> volumes;
@@ -44,17 +42,16 @@ public class AllocationAttempt {
     List<AllocationCandidate> candidates = new ArrayList<AllocationCandidate>();
     AllocationCandidate matchedCandidate;
 
-    public AllocationAttempt(long accountId, Instance instance, Host host, Set<Volume> volumes, Map<Volume, Set<StoragePool>> pools, Set<Nic> nics,
+    public AllocationAttempt(long accountId, Instance instance, Long hostId, Set<Volume> volumes, Map<Volume, Set<StoragePool>> pools, Set<Nic> nics,
             Map<Nic, Subnet> subnets) {
         super();
         this.accountId = accountId;
         this.instance = instance;
-        this.host = host;
+        this.hostId = hostId;
         this.volumes = volumes;
         this.pools = pools;
         this.nics = nics;
         this.subnets = subnets == null ? Collections.<Nic, Subnet> emptyMap() : subnets;
-        this.hostId = host == null ? null : host.getId();
 
         this.volumeIds = new HashSet<Long>(volumes.size());
         this.poolIds = new HashMap<Long, Set<Long>>();
@@ -103,8 +100,8 @@ public class AllocationAttempt {
         return instance == null ? null : instance.getId();
     }
 
-    public Host getHost() {
-        return host;
+    public Long getHostId() {
+        return hostId;
     }
 
     public Set<Volume> getVolumes() {
@@ -131,8 +128,8 @@ public class AllocationAttempt {
         this.instance = instance;
     }
 
-    public void setHost(Host host) {
-        this.host = host;
+    public void setHostId(Long hostId) {
+        this.hostId = hostId;
     }
 
     public void setVolumes(Set<Volume> volumes) {
@@ -161,14 +158,6 @@ public class AllocationAttempt {
 
     public void setMatchedCandidate(AllocationCandidate matchedCandidate) {
         this.matchedCandidate = matchedCandidate;
-    }
-
-    public Long getHostId() {
-        return hostId;
-    }
-
-    public void setHostId(Long hostId) {
-        this.hostId = hostId;
     }
 
     public Set<Long> getVolumeIds() {

--- a/code/iaas/simple-allocator/src/main/java/io/cattle/platform/simple/allocator/SimpleAllocator.java
+++ b/code/iaas/simple-allocator/src/main/java/io/cattle/platform/simple/allocator/SimpleAllocator.java
@@ -29,18 +29,6 @@ public class SimpleAllocator extends AbstractAllocator implements Allocator, Nam
     SimpleAllocatorDao simpleAllocatorDao;
 
     @Override
-    protected synchronized void acquireLockAndAllocate(AllocationRequest request, AllocationAttempt attempt, Object deallocate) {
-        /* Overriding just to add synchronized */
-        super.acquireLockAndAllocate(request, attempt, deallocate);
-    }
-
-    @Override
-    protected synchronized void acquireLockAndDeallocate(AllocationRequest request) {
-        /* Overriding just to add synchronized */
-        super.acquireLockAndDeallocate(request);
-    }
-
-    @Override
     protected LockDefinition getAllocationLock(AllocationRequest request, AllocationAttempt attempt) {
         if (attempt != null) {
             return new AccountAllocatorLock(attempt.getAccountId());

--- a/code/iaas/simple-allocator/src/main/java/io/cattle/platform/simple/allocator/SimpleAllocator.java
+++ b/code/iaas/simple-allocator/src/main/java/io/cattle/platform/simple/allocator/SimpleAllocator.java
@@ -1,6 +1,5 @@
 package io.cattle.platform.simple.allocator;
 
-import io.cattle.platform.allocator.constraint.AccountConstraint;
 import io.cattle.platform.allocator.constraint.Constraint;
 import io.cattle.platform.allocator.constraint.ValidHostsConstraint;
 import io.cattle.platform.allocator.service.AbstractAllocator;
@@ -44,11 +43,7 @@ public class SimpleAllocator extends AbstractAllocator implements Allocator, Nam
     @Override
     protected LockDefinition getAllocationLock(AllocationRequest request, AllocationAttempt attempt) {
         if (attempt != null) {
-            for (Constraint constraint : attempt.getConstraints()) {
-                if (constraint instanceof AccountConstraint) {
-                    return new AccountAllocatorLock(((AccountConstraint) constraint).getAccountId());
-                }
-            }
+            return new AccountAllocatorLock(attempt.getAccountId());
         }
 
         return new SimpleAllocatorLock();
@@ -63,13 +58,11 @@ public class SimpleAllocator extends AbstractAllocator implements Allocator, Nam
 
         QueryOptions options = new QueryOptions();
 
+        options.setAccountId(request.getAccountId());
+
         for (Constraint constraint : request.getConstraints()) {
             if (constraint instanceof ValidHostsConstraint) {
                 options.getHosts().addAll(((ValidHostsConstraint) constraint).getHosts());
-            }
-
-            if (constraint instanceof AccountConstraint) {
-                options.setAccountId(((AccountConstraint) constraint).getAccountId());
             }
         }
 

--- a/code/iaas/simple-allocator/src/main/java/io/cattle/platform/simple/allocator/SimpleAllocator.java
+++ b/code/iaas/simple-allocator/src/main/java/io/cattle/platform/simple/allocator/SimpleAllocator.java
@@ -7,7 +7,6 @@ import io.cattle.platform.allocator.service.AllocationAttempt;
 import io.cattle.platform.allocator.service.AllocationCandidate;
 import io.cattle.platform.allocator.service.AllocationRequest;
 import io.cattle.platform.allocator.service.Allocator;
-import io.cattle.platform.core.model.Volume;
 import io.cattle.platform.lock.definition.LockDefinition;
 import io.cattle.platform.simple.allocator.dao.QueryOptions;
 import io.cattle.platform.simple.allocator.dao.SimpleAllocatorDao;
@@ -39,10 +38,7 @@ public class SimpleAllocator extends AbstractAllocator implements Allocator, Nam
 
     @Override
     protected Iterator<AllocationCandidate> getCandidates(AllocationAttempt request) {
-        List<Long> volumeIds = new ArrayList<Long>(request.getVolumes().size());
-        for (Volume v : request.getVolumes()) {
-            volumeIds.add(v.getId());
-        }
+        List<Long> volumeIds = new ArrayList<Long>(request.getVolumeIds());
 
         QueryOptions options = new QueryOptions();
 


### PR DESCRIPTION
The biggest and potentially most impactful change of this code is removing synchronized from allocator methods. I see that it has been like that since day one, but I also see that the method is safely locked on a per account basis. So, I think this should be a safe change and the tests seem to agree. Let me know what you think @ibuildthecloud,

Use account id on attempt rather than on constraint

AlloctionAttempt had both host and hostId as properties. Host was not
used in the rest of the code base and hostId was simply derviced from
host. This duplicate data was confusing.