### PR TITLE
Adds bindings field to stack

### DIFF
--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/core-model/spring-core-model-context.xml
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/core-model/spring-core-model-context.xml
@@ -90,6 +90,8 @@
                 <value>snapshotBackupInput,parent=backup</value>
                 <value>volumeSnapshotInput</value>
                 <value>nfsConfig</value>
+                <value>binding</value>
+                <value>serviceBinding</value>
             </set>
         </property>
     </bean>

--- a/resources/content/schema/base/binding.json
+++ b/resources/content/schema/base/binding.json
@@ -1,0 +1,7 @@
+{
+	"resourceFields": {
+		"services": {
+			"type": "map[serviceBinding]"
+		}
+	}
+}

--- a/resources/content/schema/base/serviceBinding.json
+++ b/resources/content/schema/base/serviceBinding.json
@@ -1,0 +1,13 @@
+{
+	"resourceFields": {
+		"labels": {
+			"type": "map[string]"
+		},
+		"scale": {
+			"type": "string"
+		},
+		"ports": {
+			"type": "array[string]"
+		}
+	}
+}

--- a/resources/content/schema/base/stack.json
+++ b/resources/content/schema/base/stack.json
@@ -41,6 +41,10 @@
         },
         "upgrade":{
             "type": "kubernetesStackUpgrade"
+        },
+        "binding":{
+        	"type": "binding",
+        	"nullable": true
         }
     },
     "resourceActions" : {

--- a/resources/content/schema/base/stackUpgrade.json
+++ b/resources/content/schema/base/stackUpgrade.json
@@ -12,6 +12,9 @@
         },
         "environment":{
             "type": "map[string]"
+        },
+        "binding":{
+        	"type": "binding"
         }
     }
 }

--- a/resources/content/schema/project/project-auth.json
+++ b/resources/content/schema/project/project-auth.json
@@ -70,6 +70,8 @@
         "rollingRestartStrategy" : "cr",
         "servicesPortRange" : "cru",
         "recreateOnQuorumStrategyConfig" : "cr",
+        "binding" : "cru",
+        "serviceBinding" : "cru",
         "end" : ""
     }
 }

--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -484,6 +484,7 @@
         "stack.previousEnvironment": "cru",
         "stack.outputs": "cru",
         "stack.startOnCreate": "cr",
+        "stack.binding": "cru",
 
         "composeProject" : "r",
         "composeProject.name": "cr",
@@ -661,6 +662,15 @@
         "kubernetesStackUpgrade.templates" : "cr",
         "kubernetesStackUpgrade.environment" : "cr",
         "kubernetesStackUpgrade.externalId" : "cr",
+        
+        "binding" : "r",
+        "binding.services" : "cr",
+
+        "serviceBinding" : "r",
+        "serviceBinding.labels" : "cr",
+        "serviceBinding.ports" : "cr",
+        "serviceBinding.scale" : "cr",
+        
 
         "serviceEvent" : "r",
         "serviceEvent.instanceId" : "r",

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -192,6 +192,8 @@ def test_user_types(user_client, adds=set(), removes=set()):
         'nfsConfig',
         'blkioDeviceOption',
         'scalePolicy',
+        'binding',
+        'serviceBinding',
     }
     types.update(adds)
     types.difference_update(removes)
@@ -414,7 +416,9 @@ def test_admin_types(admin_user_client, adds=set(), removes=set()):
         'volumeSnapshotInput',
         'nfsConfig',
         'blkioDeviceOption',
-        'scalePolicy'
+        'scalePolicy',
+        'binding',
+        'serviceBinding',
     }
     types.update(adds)
     types.difference_update(removes)
@@ -1793,6 +1797,7 @@ def test_auth_compose_project(admin_user_client, user_client, project_client):
         'previousExternalId': 'r',
         'previousEnvironment': 'r',
         'healthState': 'r',
+        'binding': 'r',
     })
 
     auth_check(user_client.schema, 'composeProject', 'r', {
@@ -1804,6 +1809,7 @@ def test_auth_compose_project(admin_user_client, user_client, project_client):
         'previousExternalId': 'r',
         'previousEnvironment': 'r',
         'healthState': 'r',
+        'binding': 'r',
     })
 
     auth_check(project_client.schema, 'composeProject', 'crud', {
@@ -1815,6 +1821,7 @@ def test_auth_compose_project(admin_user_client, user_client, project_client):
         'previousExternalId': 'cru',
         'previousEnvironment': 'cru',
         'healthState': 'r',
+        'binding': 'cru',
     })
 
 
@@ -1830,6 +1837,7 @@ def test_auth_kubernetes_stack(admin_user_client, user_client, project_client):
         'previousExternalId': 'r',
         'previousEnvironment': 'r',
         'healthState': 'r',
+        'binding': 'r',
     })
 
     auth_check(user_client.schema, 'kubernetesStack', 'r', {
@@ -1842,6 +1850,7 @@ def test_auth_kubernetes_stack(admin_user_client, user_client, project_client):
         'previousExternalId': 'r',
         'previousEnvironment': 'r',
         'healthState': 'r',
+        'binding': 'r',
     })
 
     auth_check(project_client.schema, 'kubernetesStack', 'crud', {
@@ -1854,6 +1863,7 @@ def test_auth_kubernetes_stack(admin_user_client, user_client, project_client):
         'previousExternalId': 'cru',
         'previousEnvironment': 'cru',
         'healthState': 'r',
+        'binding': 'cru',
     })
 
 
@@ -1871,6 +1881,7 @@ def test_svc_discovery_stack(admin_user_client, user_client, project_client):
         'outputs': 'r',
         'startOnCreate': 'r',
         'healthState': 'r',
+        'binding': 'r',
     })
 
     auth_check(user_client.schema, 'stack', 'r', {
@@ -1885,6 +1896,7 @@ def test_svc_discovery_stack(admin_user_client, user_client, project_client):
         'outputs': 'r',
         'startOnCreate': 'r',
         'healthState': 'r',
+        'binding': 'r',
     })
 
     auth_check(project_client.schema, 'stack', 'crud', {
@@ -1899,6 +1911,7 @@ def test_svc_discovery_stack(admin_user_client, user_client, project_client):
         'outputs': 'cru',
         'startOnCreate': 'cr',
         'healthState': 'r',
+        'binding': 'cru',
     })
 
 

--- a/tests/integration/cattletest/core/test_stack.py
+++ b/tests/integration/cattletest/core/test_stack.py
@@ -1,0 +1,22 @@
+from common_fixtures import *  # NOQA
+
+binding_input = {"services":
+                  {"service_1":
+                   {"labels":
+                    {"label_1": "value_1"},
+                    "ports": [],
+                    "scale": "scale_1"
+                    }
+                   }
+                  }
+
+
+def _create_stack(client):
+    env = client.create_stack(name=random_str(), binding=binding_input)
+    env = client.wait_success(env)
+    return env
+
+
+def test_create_stack_binding(client):
+    env = _create_stack(client)
+    assert env.binding == binding_input


### PR DESCRIPTION
`Bindings` field of type `map[json]` is added to `stack.json`. 
On `/v2-beta/projects/1a5/stacks`, on clicking the `Create` button its value can be set with other keys of stack.
It's value should be of the form:
`services: {"scale":2,"ports":[],"labels":{}}`
Tests are pending