### PR TITLE
Add useful error message to failed HA tests

### DIFF
--- a/tests/integration/cattletest/core/common_fixtures.py
+++ b/tests/integration/cattletest/core/common_fixtures.py
@@ -599,14 +599,18 @@ def _sleep_time():
             sleep = 1
 
 
-def wait_for(callback, timeout=DEFAULT_TIMEOUT):
+def wait_for(callback, timeout=DEFAULT_TIMEOUT, fail_handler=None):
     sleep_time = _sleep_time()
     start = time.time()
     ret = callback()
     while ret is None or ret is False:
         time.sleep(sleep_time.next())
         if time.time() - start > timeout:
-            raise Exception('Timeout waiting for condition')
+            exception_msg = 'Timeout waiting for condition.'
+            if fail_handler:
+                exception_msg = exception_msg + ' Fail handler message: ' + \
+                                fail_handler()
+            raise Exception(exception_msg)
         ret = callback()
     return ret
 

--- a/tests/integration/cattletest/core/test_ha.py
+++ b/tests/integration/cattletest/core/test_ha.py
@@ -23,7 +23,8 @@ def test_container_ha_default(super_client, new_context):
             return None
         return processes
 
-    processes = wait_for(callback)
+    processes = wait_for(callback,
+                         fail_handler=lambda: proc_err(c, super_client))
 
     c = wait_for_condition(client, c,
                            lambda x: x.state == 'removed',
@@ -89,7 +90,8 @@ def test_container_ha_stop(super_client, new_context):
             return None
         return processes
 
-    processes = wait_for(callback)
+    processes = wait_for(callback,
+                         fail_handler=lambda: proc_err(c, super_client))
 
     wait_for_condition(super_client, c,
                        lambda x: x.state == 'stopped',
@@ -118,7 +120,8 @@ def test_container_ha_restart(super_client, new_context):
             return None
         return processes
 
-    processes = wait_for(callback)
+    processes = wait_for(callback,
+                         fail_handler=lambda: proc_err(c, super_client))
 
     wait_for_condition(super_client, c,
                        lambda x: x.state == 'running',
@@ -150,7 +153,8 @@ def test_container_ha_remove(super_client, new_context):
             return None
         return processes
 
-    processes = wait_for(callback)
+    processes = wait_for(callback,
+                         fail_handler=lambda: proc_err(c, super_client))
 
     wait_for_condition(super_client, c,
                        lambda x: x.state == 'removed',
@@ -164,3 +168,9 @@ def test_container_ha_remove(super_client, new_context):
 
 def process_executions(cli, id=None):
     return cli.list_process_execution(processInstanceId=id)
+
+
+def proc_err(c, super_client):
+    processes = process_instances(super_client, c, type='instance')
+    c = super_client.reload(c)
+    return 'Instance: %s\nProcesses: %s' % (c, processes.data)


### PR DESCRIPTION
Adds the instance and all of its processes to the error message
produced when one of a container HA test doesn't find the expected
processes for an instance's HA scenario.