### PR TITLE
don't add dns record until container is running

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/DnsInfoDaoImpl.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/DnsInfoDaoImpl.java
@@ -132,8 +132,7 @@ public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
                         .and(targetNic.REMOVED.isNull())
                         .and(instanceLink.REMOVED.isNull())
                         .and(instanceLink.SERVICE_CONSUME_MAP_ID.isNull())
-                        .and(targetInstance.STATE.in(InstanceConstants.STATE_RUNNING,
-                                InstanceConstants.STATE_STARTING))
+                        .and(targetInstance.STATE.in(InstanceConstants.STATE_RUNNING))
                         .and(targetInstance.HEALTH_STATE.isNull().or(
                                 targetInstance.HEALTH_STATE.eq(HealthcheckConstants.HEALTH_STATE_HEALTHY))))
                 .fetch().map(mapper);
@@ -460,7 +459,7 @@ public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
             existingData.add(data);
             returnData.put(data.getService().getId(), existingData);
         }
-
+        
         // parse the health check
         Map<Long, List<ServiceInstanceData>> returnDataFiltered = new HashMap<>();
         if (client) {
@@ -475,8 +474,7 @@ public class DnsInfoDaoImpl extends AbstractJooqDao implements DnsInfoDao {
                         boolean isHealthy = instance.getInstance().getHealthState() == null
                                 || instance.getInstance().getHealthState()
                                         .equalsIgnoreCase(HealthcheckConstants.HEALTH_STATE_HEALTHY);
-                        boolean isRunning = Arrays.asList(InstanceConstants.STATE_RUNNING,
-                                InstanceConstants.STATE_STARTING).contains(instance.getInstance().getState());
+                        boolean isRunning = Arrays.asList(InstanceConstants.STATE_RUNNING).contains(instance.getInstance().getState());
                         if (isRunning && isHealthy) {
                             filteredInstances.add(instance);
                         } else if (i == originalInstances.size() - 1 && filteredInstances.size() == 0) {


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher/issues/5792

Full disclosure, I took my first actual look at the rancher codebase this afternoon and I have minimal experience with Java, so it's fair to say [I have no idea what I'm doing](http://i.imgur.com/kNGKIvW.jpg) and I apologize if I'm violating some protocol or standard here. I might even just be missing something if there is a reason the decision was made to include "starting" as a state in which to allow dns exposure. 

Pretty straightforward change, but to be sure I've tested by setting up a service on a local deployment with 3 nodes launched via 10acre-ranch, and scaling it across all 3 hosts while monitoring the dns records provided by rancher. Without this patch, IPs are exposed as soon as each container is scheduled, while the image is downloading, extracting, etc which effectively directs some traffic away from healthy instances to containers that don't exist yet. After this change, the IP is not exposed until the container enters the 'running' state and its healthchecks, if any, are passing (unless there are no available records, in which case one is still exposed immediately upon being scheduled...this looks like it was the existing behavior and I didn't see a reason to change it).

Let me know if this requires any additional information or due diligence before a PR can be accepted; I'd be happy to oblige.