### PR TITLE
Adds default and whitelist registries

### DIFF
--- a/code/iaas/service-discovery/api/pom.xml
+++ b/code/iaas/service-discovery/api/pom.xml
@@ -52,5 +52,10 @@
             <artifactId>cattle-iaas-allocator</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.cattle</groupId>
+            <artifactId>cattle-docker-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/code/iaas/storage-service/src/main/java/io/cattle/platform/storage/api/filter/ExternalTemplateInstanceFilter.java
+++ b/code/iaas/storage-service/src/main/java/io/cattle/platform/storage/api/filter/ExternalTemplateInstanceFilter.java
@@ -1,5 +1,6 @@
 package io.cattle.platform.storage.api.filter;
 
+import io.cattle.platform.archaius.util.ArchaiusUtil;
 import io.cattle.platform.core.constants.InstanceConstants;
 import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.storage.service.StorageService;
@@ -10,11 +11,16 @@ import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 import io.github.ibuildthecloud.gdapi.request.resource.AbstractResourceManagerFilter;
 import io.github.ibuildthecloud.gdapi.request.resource.ResourceManager;
 import io.github.ibuildthecloud.gdapi.validation.ValidationErrorCodes;
+import io.cattle.platform.docker.client.DockerImage;
 
 import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.netflix.config.DynamicStringProperty;
 
 public class ExternalTemplateInstanceFilter extends AbstractResourceManagerFilter {
 
@@ -22,17 +28,89 @@ public class ExternalTemplateInstanceFilter extends AbstractResourceManagerFilte
     @Inject
     StorageService storageService;
 
+    public static final DynamicStringProperty DEFAULT_REGISTRY = ArchaiusUtil.getString("registry.default");
+    public static final DynamicStringProperty WHITELIST_REGISTRIES = ArchaiusUtil.getString("registry.whitelist");
     @Override
     public Object create(String type, ApiRequest request, ResourceManager next) {
         Map<String, Object> data = CollectionUtils.toMap(request.getRequestObject());
         Object imageUuid = data.get(InstanceConstants.FIELD_IMAGE_UUID);
 
         if (imageUuid != null) {
-            if (!storageService.isValidUUID(imageUuid.toString())) {
-                throw new ValidationErrorException(ValidationErrorCodes.INVALID_REFERENCE, InstanceConstants.FIELD_IMAGE_UUID);
+            String image = imageUuid.toString();
+            String fullImageName = getImageUuid(image, storageService);
+            if (!StringUtils.equals(image, fullImageName)) {
+                data.put(InstanceConstants.FIELD_IMAGE_UUID, fullImageName);
+                request.setRequestObject(data);
             }
         }
         return super.create(type, request, next);
+    }
+
+    public static String getImageUuid(String image, StorageService storageService) {
+        validateImageUuid(image);
+        DockerImage dockerImage = DockerImage.parse(image);
+        if (dockerImage == null) {
+            throw new ValidationErrorException(ValidationErrorCodes.INVALID_REFERENCE, InstanceConstants.FIELD_IMAGE_UUID);
+        }
+
+        String fullImageName = dockerImage.getFullName();
+        String server = dockerImage.getServer();
+        if (!fullImageName.startsWith(server)) {
+            String defaultRegistry = DEFAULT_REGISTRY.get();
+            if (!StringUtils.isBlank(defaultRegistry) && !StringUtils.isEmpty(defaultRegistry)) {
+                fullImageName = defaultRegistry + "/" + fullImageName;
+            }
+        }
+
+        if (image.startsWith(DockerImage.KIND_PREFIX)) {
+            fullImageName = DockerImage.KIND_PREFIX + fullImageName;
+        }
+        if (!storageService.isValidUUID(fullImageName.toString())) {
+            throw new ValidationErrorException(ValidationErrorCodes.INVALID_REFERENCE, InstanceConstants.FIELD_IMAGE_UUID);
+        }
+
+        return fullImageName;
+    }
+
+    protected static void validateImageUuid(String image) {
+        DockerImage dockerImage = DockerImage.parse(image);
+        if (dockerImage == null) {
+            return;
+        }
+        String userProvidedRegistry = dockerImage.getServer();
+        String whitelist = WHITELIST_REGISTRIES.get();
+        String defaultRegistry = DEFAULT_REGISTRY.get();
+        String[] whitelistRegistries;
+        if (specified(whitelist)) {
+            whitelistRegistries = WHITELIST_REGISTRIES.get().split(",");
+            if (!StringUtils.isEmpty(userProvidedRegistry) && !StringUtils.isBlank(userProvidedRegistry)) {
+                if (!contains(whitelistRegistries, userProvidedRegistry)) {
+                    throw new ValidationErrorException(ValidationErrorCodes.INVALID_OPTION, InstanceConstants.FIELD_IMAGE_UUID);
+                }
+            }
+            else {
+                if (!StringUtils.isEmpty(defaultRegistry) && !StringUtils.isBlank(defaultRegistry)) {
+                    if (!contains(whitelistRegistries, defaultRegistry)) {
+                        throw new ValidationErrorException(ValidationErrorCodes.INVALID_OPTION, InstanceConstants.FIELD_IMAGE_UUID);
+                    }
+                }
+            }
+        }
+    }
+
+    public static boolean contains(String[] arr, String target) {
+        for(String str: arr){
+            if(str.equals(target))
+                return true;
+        }
+        return false;
+    }
+
+    public static boolean specified(String registry) {
+        if (registry != null && !registry.isEmpty() && !registry.trim().isEmpty()) {
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/code/implementation/docker/common/src/main/java/io/cattle/platform/docker/client/DockerImage.java
+++ b/code/implementation/docker/common/src/main/java/io/cattle/platform/docker/client/DockerImage.java
@@ -11,7 +11,7 @@ public class DockerImage {
     String id, repository, namespace, tag, server, serverAddress;
     private static final DynamicStringProperty INDEX_URL = ArchaiusUtil.getString("docker.index.url");
     private static final DynamicStringProperty INDEX_SERVER = ArchaiusUtil.getString("docker.index.server");
-    private static final String KIND_PREFIX = "docker:";
+    public static final String KIND_PREFIX = "docker:";
 
     public DockerImage(String id, String server, String namespace, String repository, String tag) {
         super();

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/process/defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/process/defaults.properties
@@ -110,3 +110,6 @@ catalog.url=library=https://github.com/rancher/rancher-catalog.git,community=htt
 catalog.refresh.interval.seconds=300
 
 telemetry.service.executable=telemetry
+
+registry.default=
+registry.whitelist=

--- a/tests/integration-v1/cattletest/core/test_private_repos.py
+++ b/tests/integration-v1/cattletest/core/test_private_repos.py
@@ -49,7 +49,7 @@ def test_create_container_with_registry_credential(client, context):
     assert container is not None
     assert container.registryCredentialId == reg_cred.id
     assert container.startOnCreate is False
-    assert container.imageUuid == uuid
+    assert container.imageUuid == uuid+":latest"
 
 
 @if_docker

--- a/tests/integration/cattletest/core/test_container.py
+++ b/tests/integration/cattletest/core/test_container.py
@@ -40,6 +40,93 @@ def test_container_build(super_client, context, client):
     assert image.data.fields.build.rm
 
 
+def test_container_registry_default(super_client, client, context,
+                                    admin_user_client):
+
+    id = 'registry.default'
+    default_registry = admin_user_client.by_id_setting(id)
+    default_registry = admin_user_client.update(default_registry,
+                                                value='')
+
+    id = 'registry.whitelist'
+    whitelist_registries = admin_user_client.by_id_setting(id)
+
+    # case 1: whitelist is set to different values, default set to null
+    whitelist_value = 'index.docker.io,sim:rancher,docker.io'
+    whitelist_registries = admin_user_client.update(whitelist_registries,
+                                                    value=whitelist_value)
+    default_registry = admin_user_client.update(default_registry, value='')
+    uuid = "sim:{}".format(random_num())
+    # passes, because no default provided so index.docker.io
+    # gets prepended and that's whitelisted
+    container = client.create_container(imageUuid=uuid,
+                                        startOnCreate=False)
+
+    container = client.wait_success(container)
+
+    assert_fields(container, {
+        "type": "container",
+        "state": "stopped",
+        "imageUuid": uuid,
+        "firstRunning": None,
+    })
+
+    uuid = "sim:localhost.localdomain:5000/ubuntu:{}".format(random_num())
+    # will fail, registry localhost.localdomain:5000 not whitelisted
+    with pytest.raises(ApiError) as e:
+        client.create_container(imageUuid=uuid,
+                                startOnCreate=False)
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'InvalidOption'
+
+    # case 2: whitelist and default both set to different values
+    default_value = 'sim:localhost.localdomain:5000'
+    whitelist_value = 'sim:localhost.localdomain:5000,index.docker.io'
+    whitelist_value = whitelist_value+',sim:rancher,docker.io'
+    default_registry = admin_user_client.update(default_registry,
+                                                value=default_value)
+    whitelist_registries = admin_user_client.update(whitelist_registries,
+                                                    value=whitelist_value)
+    uuid = "sim:v2"
+    # passes, because no default provided so localhost.localdomain:5000
+    # gets prepended and that's whitelisted
+    container = client.create_container(imageUuid=uuid,
+                                        startOnCreate=False)
+
+    container = client.wait_success(container)
+
+    assert_fields(container, {
+        "type": "container",
+        "state": "stopped",
+        "imageUuid": "sim:localhost.localdomain:5000/sim:v2",
+        "firstRunning": None,
+    })
+
+    uuid = "sim:localhost.localdomain:5001/ubuntu:{}".format(random_num())
+    # will fail, registry localhost.localdomain:5001 not whitelisted
+    with pytest.raises(ApiError) as e:
+        client.create_container(imageUuid=uuid,
+                                startOnCreate=False)
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'InvalidOption'
+
+    uuid = "sim:localhost.localdomain:5000/ubuntu:{}".format(random_num())
+    # passes, since localhost.localdomain:5000/ whitelisted
+    container = client.create_container(imageUuid=uuid,
+                                        startOnCreate=False)
+
+    container = client.wait_success(container)
+
+    assert_fields(container, {
+        "type": "container",
+        "state": "stopped",
+        "imageUuid": uuid,
+        "firstRunning": None,
+    })
+    default_registry = admin_user_client.update(default_registry,
+                                                value='')
+
+
 def test_container_create_only(super_client, client, context):
     uuid = "sim:{}".format(random_num())
     container = super_client.create_container(accountId=context.project.id,

--- a/tests/integration/cattletest/core/test_private_repos.py
+++ b/tests/integration/cattletest/core/test_private_repos.py
@@ -49,7 +49,7 @@ def test_create_container_with_registry_credential(client, context):
     assert container is not None
     assert container.registryCredentialId == reg_cred.id
     assert container.startOnCreate is False
-    assert container.imageUuid == uuid
+    assert container.imageUuid == uuid+":latest"
 
 
 @if_docker
@@ -133,7 +133,13 @@ def test_deleting_registry_deletes_credentials(client):
 
 def test_container_image_and_registry_credential(client,
                                                  super_client):
+    id = 'registry.whitelist'
+    whitelist_registries = super_client.by_id_setting(id)
+
     server = 'server{0}.io'.format(random_num())
+    whitelist_value = 'index.docker.io,docker.io,sim:rancher,'+server
+    whitelist_registries = super_client.update(whitelist_registries,
+                                               value=whitelist_value)
     registry = client.create_registry(serverAddress=server,
                                       name=random_str())
     registry = client.wait_success(registry)

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -1,6 +1,7 @@
 from common_fixtures import *  # NOQA
 import yaml
 from netaddr import IPNetwork, IPAddress
+from cattle import ApiError
 
 
 def _create_stack(client):
@@ -93,17 +94,89 @@ def test_env_set_outputs(client, context):
     assert env.outputs == {'foo': 'bar', 'foo2': 'bar2', 'foo3': 'bar3'}
 
 
-def test_activate_single_service(client, context, super_client):
+def test_registries(super_client, client, context,
+                    admin_user_client):
+    id = 'registry.default'
+    default_registry = admin_user_client.by_id_setting(id)
+
+    id = 'registry.whitelist'
+    whitelist_registries = admin_user_client.by_id_setting(id)
+
+    default_value = 'sim:localhost.localdomain:5000'
+    whitelist_value = 'sim:localhost.localdomain:5000,index.docker.io'
+    whitelist_value = whitelist_value+',sim:rancher,docker.io'
+    default_registry = admin_user_client.update(default_registry,
+                                                value=default_value)
+    whitelist_registries = admin_user_client.update(whitelist_registries,
+                                                    value=whitelist_value)
+
+    env = _create_stack(client)
+
+    uuid = "sim:namespace/ubuntu:{}".format(random_num())
+    lc_registry = {"imageUuid": uuid}
+    with pytest.raises(ApiError) as e:
+        service = client.create_service(name=random_str(),
+                                        stackId=env.id,
+                                        launchConfig=lc_registry,
+                                        scale=1)
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'InvalidOption'
+
+    uuid = "sim:localhost.localdomain:5000/ubuntu:{}".format(random_num())
+    lc_registry = {"imageUuid": uuid}
+    service = client.create_service(name=random_str(),
+                                    stackId=env.id,
+                                    launchConfig=lc_registry,
+                                    scale=1)
+
+    assert service.launchConfig.imageUuid == uuid
+
+    uuid1 = "ubuntu:v1"
+    lc_registry = {"imageUuid": uuid1}
+    lc_registry_sec = {"imageUuid": uuid1, "name": "secondary"}
+    service = client.create_service(name=random_str(),
+                                    stackId=env.id,
+                                    launchConfig=lc_registry,
+                                    secondaryLaunchConfigs=[lc_registry_sec],
+                                    scale=1)
+
+    uuid2 = 'sim:localhost.localdomain:5000/ubuntu:v1'
+    assert service.launchConfig.imageUuid == uuid2
+    assert service.secondaryLaunchConfigs[0].imageUuid == uuid2
+
+    uuid1 = "ubuntu:v1"
+    lc_registry = {"imageUuid": uuid1}
+    launch_config_upgrade = {"imageUuid": "sim:registry/ubuntu:v1"}
+    service = client.create_service(name=random_str(),
+                                    stackId=env.id,
+                                    launchConfig=lc_registry,
+                                    scale=1)
+    service = wait_state(client, service, 'inactive')
+    with pytest.raises(ApiError) as e:
+        strategy = {"launchConfig": launch_config_upgrade,
+                    "intervalMillis": 100}
+        service.upgrade_action(inServiceStrategy=strategy)
+    assert e.value.error.status == 422
+    assert e.value.error.code == 'InvalidOption'
+
+    default_registry = admin_user_client.update(default_registry,
+                                                value='')
+
+
+def test_activate_single_service(client, context,
+                                 super_client, admin_user_client):
     env = _create_stack(client)
 
     image_uuid = context.image_uuid
-    host = context.host
+
     container1 = client.create_container(imageUuid=image_uuid,
                                          startOnCreate=True)
-    container1 = client.wait_success(container1)
-
     container2 = client.create_container(imageUuid=image_uuid,
                                          startOnCreate=True)
+
+    host = context.host
+    container1 = client.wait_success(container1)
+
     container2 = client.wait_success(container2)
 
     caps = ["SYS_MODULE"]
@@ -1513,7 +1586,13 @@ def test_global_add_host(new_context):
 
 
 def test_svc_container_reg_cred_and_image(super_client, client):
+    id = 'registry.whitelist'
+    whitelist_registries = super_client.by_id_setting(id)
+
     server = 'server{0}.io'.format(random_num())
+    whitelist_value = 'index.docker.io,'+server
+    whitelist_registries = super_client.update(whitelist_registries,
+                                               value=whitelist_value)
     registry = client.create_registry(serverAddress=server,
                                       name=random_str())
     registry = client.wait_success(registry)

--- a/tests/integration/cattletest/core/test_svc_selectors.py
+++ b/tests/integration/cattletest/core/test_svc_selectors.py
@@ -143,9 +143,15 @@ def _create_stack(client):
     return env
 
 
-def test_service_mixed_selector_based_wo_image(client, context):
+def test_service_mixed_selector_based_wo_image(client, context, super_client):
     env = _create_stack(client)
     image_uuid = context.image_uuid
+
+    id = 'registry.whitelist'
+    whitelist_registries = super_client.by_id_setting(id)
+    whitelist_value = 'index.docker.io,docker.io,sim:rancher'
+    whitelist_registries = super_client.update(whitelist_registries,
+                                               value=whitelist_value)
 
     labels = {'foo': "barbar"}
     container1 = client.create_container(imageUuid=image_uuid,


### PR DESCRIPTION
`default.registry` and `whitelist.registries` properties are added. If the whitelist registries are not provided, any image entered will pass. If whitelist registries are specified, the image entered passes only if its registry is whitelisted. If default registry is specified, it gets prepended to the image name if the image doesn't have a registry specified (eg, if the image entered is `ubuntu`, and the default registry property is set to `registry_1`, `registry_1` gets prepended to `ubuntu`)