### PR TITLE
Use default timeout in upgrade manager + TF failure in test_upgrade_stopped_with_health

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/upgrade/impl/UpgradeManagerImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/upgrade/impl/UpgradeManagerImpl.java
@@ -48,7 +48,6 @@ import javax.inject.Inject;
 import org.apache.commons.lang3.tuple.Pair;
 
 public class UpgradeManagerImpl implements UpgradeManager {
-    private static Long DEFAULT_WAIT_TIMEOUT = 60000L;
 
     private static final Set<String> UPGRADE_STATES = new HashSet<>(Arrays.asList(
             ServiceDiscoveryConstants.STATE_UPGRADING,
@@ -476,7 +475,7 @@ public class UpgradeManagerImpl implements UpgradeManager {
                         HealthcheckConstants.HEALTH_STATE_UPDATING_HEALTHY);
                 for (final Instance instance : serviceInstances) {
                     if (instance.getState().equalsIgnoreCase(InstanceConstants.STATE_RUNNING)) {
-                        resourceMntr.waitFor(instance, DEFAULT_WAIT_TIMEOUT,
+                        resourceMntr.waitFor(instance,
                                 new ResourcePredicate<Instance>() {
                                     @Override
                                     public boolean evaluate(Instance obj) {

--- a/tests/integration/cattletest/core/test_healthcheck.py
+++ b/tests/integration/cattletest/core/test_healthcheck.py
@@ -95,50 +95,6 @@ def test_upgrade_with_health(client, context, super_client):
     wait_for(lambda: super_client.reload(svc).state == 'upgraded')
 
 
-def test_upgrade_stopped_with_health(client, context, super_client):
-    env = client.create_stack(name='env-' + random_str())
-
-    image_uuid = context.image_uuid
-    launch_config = {"imageUuid": image_uuid,
-                     'healthCheck': {
-                         'port': 80,
-                     }}
-
-    svc = client.create_service(name=random_str(),
-                                stackId=env.id,
-                                launchConfig=launch_config,
-                                scale=1)
-    svc = client.wait_success(svc)
-    assert svc.state == "inactive"
-
-    env.activateservices()
-    svc = client.wait_success(svc, 120)
-    assert svc.state == "active"
-
-    m = super_client. \
-        list_serviceExposeMap(serviceId=svc.id, state='active', managed=True)
-
-    c = super_client.reload(m[0].instance())
-
-    # upgrade the service
-    new_launch_config = {"imageUuid": image_uuid}
-    strategy = {"launchConfig": new_launch_config,
-                "intervalMillis": 100}
-    svc.upgrade_action(inServiceStrategy=strategy)
-
-    # initial health state check should fail
-    try:
-        wait_for(lambda: super_client.reload(svc).state == 'upgraded',
-                 timeout=10)
-    except Exception:
-        pass
-
-    # stop the instance
-    super_client.wait_success(c.stop())
-
-    wait_for(lambda: super_client.reload(svc).state == 'upgraded')
-
-
 def test_rollback_with_health(client, context, super_client):
     env = client.create_stack(name='env-' + random_str())
 


### PR DESCRIPTION
when wait for service to become healthy.

Also removed unneeded test. With the latest code upgrade calls service.reconcile before shutting down next (batchSize). And the test relied on fact that the stopped instance would never be re-started by the reconcile. I’m going to remove this test as it is no longer relevant