### PR TITLE
removed check for stopped state

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/ServiceDao.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/ServiceDao.java
@@ -1,5 +1,6 @@
 package io.cattle.platform.core.dao;
 
+import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.Service;
 import io.cattle.platform.core.model.ServiceIndex;
 
@@ -9,4 +10,6 @@ public interface ServiceDao {
     ServiceIndex createServiceIndex(Service service, String launchConfigName, String serviceIndex);
 
     Service getServiceByServiceIndexId(long serviceIndexId);
+
+    boolean isServiceInstance(Instance instance);
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/ServiceDaoImpl.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/ServiceDaoImpl.java
@@ -3,6 +3,7 @@ package io.cattle.platform.core.dao.impl;
 import static io.cattle.platform.core.model.tables.ServiceIndexTable.*;
 import static io.cattle.platform.core.model.tables.ServiceTable.*;
 import io.cattle.platform.core.dao.ServiceDao;
+import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.Service;
 import io.cattle.platform.core.model.ServiceIndex;
 import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
@@ -51,5 +52,10 @@ public class ServiceDaoImpl extends AbstractJooqDao implements ServiceDao {
                 .fetchAny();
 
         return record == null ? null : record.into(Service.class);
+    }
+
+    @Override
+    public boolean isServiceInstance(Instance instance) {
+        return instance.getDeploymentUnitUuid() != null;
     }
 }


### PR DESCRIPTION
for service containers.

https://github.com/rancher/rancher/issues/5941

The bug happens only when:

* service.reconcile is triggered for the service having stopped instances
* when there are sidekicks with volumes/network from dependency.

@ibuildthecloud service.reconcile schedules instance.start for all stopped instances. Within a deployment unit, it is all done in parallel, disregarding the dependencies. So there was a chance for a race condition when instanceStart for primary instance is hit before its sidekick enters starting state (still in stopped state). I've removed static state validation for service instances; service.reconcile would start/restart stopped instance anyways.

Or let me know if you think we should start instances in order in the deployment unit.

