### PR TITLE
Adding stack_uuid to container metadata

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/metadata/common/ContainerMetaData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/metadata/common/ContainerMetaData.java
@@ -28,6 +28,7 @@ public class ContainerMetaData {
     List<String> ports = new ArrayList<>();
     String service_name;
     String stack_name;
+    String stack_uuid;
     Map<String, String> labels = new HashMap<>();
     Long create_index;
     String host_uuid;
@@ -69,6 +70,14 @@ public class ContainerMetaData {
 
     public String getStack_name() {
         return stack_name;
+    }
+
+    public String getStack_uuid() {
+        return stack_uuid;
+    }
+
+    public void setStack_uuid(String stack_uuid) {
+        this.stack_uuid = stack_uuid;
     }
 
     public Map<String, String> getLabels() {

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/metadata/common/ServiceMetaData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/metadata/common/ServiceMetaData.java
@@ -21,6 +21,7 @@ public class ServiceMetaData {
     private boolean isPrimaryConfig;
     private String launchConfigName;
     private Long stackId;
+    private String stackUuid;
     private Service service;
     
     protected String name;
@@ -65,6 +66,7 @@ public class ServiceMetaData {
         this.isPrimaryConfig = that.isPrimaryConfig;
         this.launchConfigName = that.launchConfigName;
         this.stackId = that.stackId;
+        this.stackUuid = that.stackUuid;
     }
 
     public ServiceMetaData(Service service, String serviceName, Stack env, List<String> sidekicks,
@@ -75,6 +77,7 @@ public class ServiceMetaData {
         this.uuid = service.getUuid();
         this.stack_name = env.getName();
         this.stackId = env.getId();
+        this.stackUuid = env.getUuid();
         this.kind = service.getKind();
         this.sidekicks = sidekicks;
         this.vip = service.getVip();
@@ -89,7 +92,6 @@ public class ServiceMetaData {
         this.metadata = metadata;
         this.scale = DataAccessor.fieldInteger(service, ServiceDiscoveryConstants.FIELD_SCALE);
         this.fqdn = DataAccessor.fieldString(service, ServiceDiscoveryConstants.FIELD_FQDN);
-        this.stackId = env.getId();
         Integer desiredScale = DataAccessor.fieldInteger(service, ServiceDiscoveryConstants.FIELD_DESIRED_SCALE);
         if (desiredScale != null) {
             this.scale = desiredScale;
@@ -279,6 +281,14 @@ public class ServiceMetaData {
         } else {
             return new ServiceMetaDataVersion2(serviceData);
         }
+    }
+
+    public String getStackUuid() {
+        return stackUuid;
+    }
+
+    public void setStackUuid(String stackUuid) {
+        this.stackUuid = stackUuid;
     }
 
     

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/ServiceMetadataInfoFactory.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/ServiceMetadataInfoFactory.java
@@ -280,6 +280,7 @@ public class ServiceMetadataInfoFactory extends AbstractAgentBaseContextFactory 
                         continue;
                     }
                     containerMD.setStack_name(svcData.getStack_name());
+                    containerMD.setStack_uuid(svcData.getStackUuid());
                     containerMD.setService_name(svcData.getName());
 
                     Map<String, List<ContainerMetaData>> launchConfigToContainer = serviceIdToLaunchConfigToContainer


### PR DESCRIPTION
@alena1108 @ibuildthecloud : Could you please review the changes and merge these changes?

Summary: We already have the stack_name in the container metadata, adding the stack_uuid too.

Reason for this: In rancher-net this information is needed to determine if a remote container is a peer or if it belongs to the same stack.