### PR TITLE
update metadata on instancehostmap.activate

### DIFF
--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/system-services/defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/system-services/defaults.properties
@@ -10,7 +10,7 @@ agent.instance.start.items.increment=agent-instance-startup
 
 agent.instance.services.base.items=${agent.instance.start.items.apply},${agent.instance.start.items.increment}
 
-agent.instance.services.processes=nic.activate,nic.deactivate,instance.start,instance.stop,instancelink.update,instancelink.activate,hostipaddressmap.activate,serviceexposemap.create,serviceconsumemap.create,serviceconsumemap.update,serviceconsumemap.remove,service.activate,service.deactivate,service.update,service.remove,healthcheckinstancehostmap.create,networkserviceproviderinstancemap.activate,networkserviceproviderinstancemap.remove,ipaddress.update,host.create,host.update,host.remove,instance.updateunhealthy,instance.updatehealthy,account.update,instance.remove
+agent.instance.services.processes=nic.activate,nic.deactivate,instance.start,instance.stop,instancehostmap.activate,instancelink.update,instancelink.activate,hostipaddressmap.activate,serviceexposemap.create,serviceconsumemap.create,serviceconsumemap.update,serviceconsumemap.remove,service.activate,service.deactivate,service.update,service.remove,healthcheckinstancehostmap.create,networkserviceproviderinstancemap.activate,networkserviceproviderinstancemap.remove,ipaddress.update,host.create,host.update,host.remove,instance.updateunhealthy,instance.updatehealthy,account.update,instance.remove
 
 ipaddress.update.agentInstanceProvider.ipsecTunnelService.increment=hosts,ipsec-hosts,ipsec
 
@@ -61,6 +61,7 @@ instance.updatehealthy.agentInstanceProvider.dnsService.increment=hosts
 instance.updateunhealthy.agentInstanceProvider.dnsService.increment=hosts
 account.update.agentInstanceProvider.dnsService.increment=hosts
 instance.remove.agentInstanceProvider.dnsService.increment=hosts
+instancehostmap.activate.agentInstanceProvider.dnsService.increment=hosts
 
 instance.start.agentInstanceProvider.healthCheckService.increment=healthcheck
 instance.stop.agentInstanceProvider.healthCheckService.increment=healthcheck


### PR DESCRIPTION
As labels are being back populated from docker via this event

https://github.com/rancher/rancher/issues/5985

@ibuildthecloud we would need this change for 1.1.4, it fixes the bug in metadata that @cloudnautique hit