### PR TITLE
Downgrade back to py.test 2.7.1

### DIFF
--- a/tests/integration-v1/requirements.txt
+++ b/tests/integration-v1/requirements.txt
@@ -4,7 +4,7 @@ websocket-client==0.23.0
 PyJWT==1.4.0
 
 flake8==2.5.1
-pytest==3.0.2
+pytest==2.7.1
 pytest-xdist
 pyyaml
 netaddr

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -4,7 +4,7 @@ websocket-client==0.23.0
 PyJWT==1.4.0
 
 flake8==2.5.1
-pytest==3.0.2
+pytest==2.7.1
 pytest-xdist
 pyyaml
 netaddr


### PR DESCRIPTION
version 3.0.2 didn't display set diff assertion failures properly.
When this bug is fixed, we can upgrade:
https://github.com/pytest-dev/pytest/issues/1972