### PR TITLE
Make proxy redirects configurable

### DIFF
--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/servlet/filter/ProxyFilter.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/servlet/filter/ProxyFilter.java
@@ -3,6 +3,7 @@ package io.cattle.platform.iaas.api.servlet.filter;
 import io.cattle.platform.iaas.api.request.handler.GenericWhitelistedProxy;
 
 import java.io.IOException;
+
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -12,13 +13,20 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.lang3.StringUtils;
+
 public class ProxyFilter implements Filter {
 
     String proxy;
+    boolean redirects = true;
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
         proxy = filterConfig.getInitParameter("proxy");
+        String value = filterConfig.getInitParameter("redirects");
+        if (StringUtils.isNotBlank(value)) {
+            redirects = Boolean.parseBoolean(value);
+        }
     }
 
     @Override
@@ -26,6 +34,7 @@ public class ProxyFilter implements Filter {
         RequestDispatcher rd = request.getRequestDispatcher("/v1/proxy/" + proxy + ((HttpServletRequest)request).getRequestURI());
         request.setAttribute(GenericWhitelistedProxy.ALLOWED_HOST, true);
         request.setAttribute(GenericWhitelistedProxy.SET_HOST_CURRENT_HOST, true);
+        request.setAttribute(GenericWhitelistedProxy.REDIRECTS, redirects);
         rd.forward(request, response);
         return;
     }


### PR DESCRIPTION
Allow redirect to be disabled for the proxy through a filter init param

```xml
   <filter>
        <filter-name>Catalog</filter-name>
        <filter-class>io.cattle.platform.iaas.api.servlet.filter.ProxyFilter</filter-class>
        <init-param>
            <param-name>proxy</param-name>
            <param-value>http://localhost:8088</param-value>
        </init-param>
        <init-param>
            <param-name>redirects</param-name>
            <param-value>false</param-value>
        </init-param>
    </filter>
```