### PR TITLE
Fix physicalHostId NPE in AgentResourcesMonitor

### DIFF
--- a/code/iaas/agent-server/src/main/java/io/cattle/platform/agent/server/resource/impl/AgentResourcesMonitor.java
+++ b/code/iaas/agent-server/src/main/java/io/cattle/platform/agent/server/resource/impl/AgentResourcesMonitor.java
@@ -207,20 +207,22 @@ public class AgentResourcesMonitor implements AnnotatedEventListener {
                 Map<Object, Object> updates = new HashMap<>();
                 Host host = hosts.get(uuid);
 
-                /* Add create labels and assign the agent ID */
-                if (physicalHostId.equals(host.getPhysicalHostId()) && host.getAgentId() == null) {
-                    PhysicalHost physicalHost = objectManager.loadResource(PhysicalHost.class, physicalHostId);
-                    /* Copy createLabels to labels */
-                    Map<String, Object> labels = CollectionUtils.toMap(data.get(HostConstants.FIELD_LABELS));
-                    labels.putAll(CollectionUtils.<String, Object>toMap(data.get(HostConstants.FIELD_CREATE_LABELS)));
+                if (physicalHostId != null) {
+                    /* Add create labels and assign the agent ID */
+                    if (physicalHostId.equals(host.getPhysicalHostId()) && host.getAgentId() == null) {
+                        PhysicalHost physicalHost = objectManager.loadResource(PhysicalHost.class, physicalHostId);
+                        /* Copy createLabels to labels */
+                        Map<String, Object> labels = CollectionUtils.toMap(data.get(HostConstants.FIELD_LABELS));
+                        labels.putAll(CollectionUtils.<String, Object>toMap(data.get(HostConstants.FIELD_CREATE_LABELS)));
 
-                    updates.putAll(createData(agent, uuid, data));
-                    updates.put(HostConstants.FIELD_LABELS, labels);
-                    updates.put(HostConstants.FIELD_AGENT_ID, physicalHost.getAgentId());
-                }
+                        updates.putAll(createData(agent, uuid, data));
+                        updates.put(HostConstants.FIELD_LABELS, labels);
+                        updates.put(HostConstants.FIELD_AGENT_ID, physicalHost.getAgentId());
+                    }
 
-                if (physicalHostId != null && !physicalHostId.equals(host.getPhysicalHostId())) {
-                    updates.put(HOST.PHYSICAL_HOST_ID, physicalHostId);
+                    if (!physicalHostId.equals(host.getPhysicalHostId())) {
+                        updates.put(HOST.PHYSICAL_HOST_ID, physicalHostId);
+                    }
                 }
 
                 for (String key : UPDATABLE_HOST_FIELDS) {


### PR DESCRIPTION
2016-09-29 18:39:32,709 ERROR [e4273b5e-626e-4e5a-899a-2bd200f1999e:10706] [agent:452] [agent.activate->(AgentActivate)] [] [ecutorService-9] [o.a.c.m.context.NoExceptionRunnable ] Uncaught exception java.lang.NullPointerException: null
                                                           	at io.cattle.platform.agent.server.resource.impl.AgentResourcesMonitor.setHosts(AgentResourcesMonitor.java:211) ~[cattle-iaas-agent-server-0.5.0-SNAPSHOT.jar:na]