### PR TITLE
reload haproxy as a pre listener on instance.stop

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/LoadBalancerInfoFactory.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/LoadBalancerInfoFactory.java
@@ -109,9 +109,6 @@ public class LoadBalancerInfoFactory extends AbstractAgentBaseContextFactory {
         Map<Long, IpAddress> nicIdToIp = ipAddressDao.getNicIdToPrimaryIpAddress(instance.getAccountId());
         List<LoadBalancerTargetsInfo> targetsInfo = populateTargetsInfo(lbService, listeners, instanceIdtoInstance,
                 instanceIdtoNic, nicIdToIp);
-        if (targetsInfo.isEmpty()) {
-            return;
-        }
 
         Map<String, List<LoadBalancerTargetsInfo>> listenerToTargetMap = assignTargetsToListeners(listeners,
                 targetsInfo);

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceUpdateConfigPostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceUpdateConfigPostListener.java
@@ -1,0 +1,37 @@
+package io.cattle.platform.servicediscovery.process;
+
+import io.cattle.platform.core.constants.InstanceConstants;
+import io.cattle.platform.engine.handler.HandlerResult;
+import io.cattle.platform.engine.handler.ProcessPreListener;
+import io.cattle.platform.engine.process.ProcessInstance;
+import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.process.common.handler.AbstractObjectProcessLogic;
+import io.cattle.platform.util.type.Priority;
+
+import javax.inject.Inject;
+
+public class LoadBalancerServiceUpdateConfigPostListener extends AbstractObjectProcessLogic implements
+        ProcessPreListener, Priority {
+
+    @Inject
+    LoadBalancerServiceUpdateConfig updateConfig;
+
+    @Override
+    public String[] getProcessNames() {
+        return new String[] {
+                InstanceConstants.PROCESS_STOP
+        };
+    }
+
+    @Override
+    public HandlerResult handle(ProcessState state, ProcessInstance process) {
+        updateConfig.updateLoadBalancerServices(state, process, true);
+        return null;
+    }
+
+    @Override
+    public int getPriority() {
+        return Priority.DEFAULT;
+    }
+
+}

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/system-services/spring-system-services-context.xml
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/system-services/spring-system-services-context.xml
@@ -467,6 +467,7 @@
     <bean class="io.cattle.platform.servicediscovery.process.StackHealthStateUpdateTrigger" />
     <bean class="io.cattle.platform.servicediscovery.process.StackCreatePostListener" />
     <bean class="io.cattle.platform.servicediscovery.process.StackRemovePostListener" />
+    <bean class="io.cattle.platform.servicediscovery.process.LoadBalancerServiceUpdateConfigPostListener" />
 
     <bean class="io.cattle.platform.servicediscovery.dao.impl.ServiceConsumeMapDaoImpl" />
     <bean class="io.cattle.platform.servicediscovery.dao.impl.ServiceExposeMapDaoImpl">


### PR DESCRIPTION
so haproxy will get a chance to drain the connections (reload -sf option) for the stopping instances, and remove them from the new config.

https://github.com/rancher/rancher/issues/2777
