### PR TITLE
Adds API local auth validation

### DIFF
--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/local/ChangeSecretActionHandler.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/local/ChangeSecretActionHandler.java
@@ -4,6 +4,7 @@ import io.cattle.platform.api.action.ActionHandler;
 import io.cattle.platform.api.auth.Policy;
 import io.cattle.platform.core.model.Credential;
 import io.cattle.platform.iaas.api.auth.dao.PasswordDao;
+import io.cattle.platform.json.JsonMapper;
 import io.github.ibuildthecloud.gdapi.context.ApiContext;
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 
@@ -14,11 +15,15 @@ public class ChangeSecretActionHandler implements ActionHandler {
     @Inject
     PasswordDao passwordDao;
 
+    @Inject
+    JsonMapper jsonMapper;
+
     @Override
     public Object perform(String name, Object obj, ApiRequest request) {
         Credential password = (Credential) obj;
         ChangePassword changePassword = request.proxyRequestObject(ChangePassword.class);
         Policy policy = (Policy) ApiContext.getContext().getPolicy();
+        LocalAuthPasswordValidator.validatePassword(changePassword.getNewSecret(), jsonMapper);
         return passwordDao.changePassword(password, changePassword, policy);
     }
 

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/local/LocalAuthConfigManager.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/local/LocalAuthConfigManager.java
@@ -3,12 +3,12 @@ package io.cattle.platform.iaas.api.auth.integration.local;
 import io.cattle.platform.core.util.SettingsUtils;
 import io.cattle.platform.iaas.api.auth.SecurityConstants;
 import io.cattle.platform.iaas.api.auth.dao.PasswordDao;
+import io.cattle.platform.json.JsonMapper;
 import io.cattle.platform.util.type.CollectionUtils;
 import io.github.ibuildthecloud.gdapi.factory.SchemaFactory;
 import io.github.ibuildthecloud.gdapi.model.ListOptions;
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 import io.github.ibuildthecloud.gdapi.request.resource.impl.AbstractNoOpResourceManager;
-
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -22,6 +22,9 @@ public class LocalAuthConfigManager extends AbstractNoOpResourceManager {
 
     @Inject
     SettingsUtils settingsUtils;
+
+    @Inject
+    JsonMapper jsonMapper;
 
     @Override
     public Class<?>[] getTypeClasses() {
@@ -48,6 +51,7 @@ public class LocalAuthConfigManager extends AbstractNoOpResourceManager {
         } else {
             settingsUtils.changeSetting(SecurityConstants.SECURITY_SETTING, enabled);
             if (StringUtils.isNotBlank(username)) {
+                LocalAuthPasswordValidator.validatePassword(password, jsonMapper);
                 passwordDao.verifyUsernamePassword(username, password, name);
             }
         }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/local/LocalAuthPasswordValidator.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/local/LocalAuthPasswordValidator.java
@@ -1,0 +1,72 @@
+package io.cattle.platform.iaas.api.auth.integration.local;
+
+import io.cattle.platform.archaius.util.ArchaiusUtil;
+import io.cattle.platform.json.JsonMapper;
+import io.github.ibuildthecloud.gdapi.exception.ClientVisibleException;
+import io.github.ibuildthecloud.gdapi.util.ResponseCodes;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.entity.ContentType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.config.DynamicStringProperty;
+
+public class LocalAuthPasswordValidator {
+
+    public static final DynamicStringProperty AUTH_VALIDATE_URL = ArchaiusUtil.getString("api.auth.local.validate.url");
+
+    final static Logger log = LoggerFactory.getLogger(LocalAuthPasswordValidator.class);
+
+    public static void validatePassword(String password, JsonMapper jsonMapper) {
+        String authValidateUrl = AUTH_VALIDATE_URL.get();
+        if (StringUtils.isBlank(authValidateUrl)) {
+            return;
+        }
+
+        Map<String, String> data = new HashMap<String, String>();
+        data.put("secret", password);
+        String jsonString = "";
+        Integer code;
+        HttpResponse response = null;
+
+        try {
+            jsonString = jsonMapper.writeValueAsString(data);
+        } catch (IOException e) {
+            log.error("Error in creating json for POST request", e);
+        }
+
+        try {
+            response =  Request.Post(authValidateUrl).bodyString(jsonString, ContentType.APPLICATION_JSON).execute().returnResponse();
+        } catch (IOException e) {
+            log.error("Error sending POST request", e);
+            throw new ClientVisibleException(ResponseCodes.BAD_REQUEST, "Error sending POST request");
+        }
+
+        code = response.getStatusLine().getStatusCode();
+        if (code >=400 && code <= 499) {
+            Map<String, Object> jsonData = new HashMap<String, Object>();
+            try {
+                jsonData = jsonMapper.readValue(response.getEntity().getContent());
+            } catch (IOException e) {
+                log.error("No JSON response from validator", e);
+            }
+
+            if (!jsonData.containsKey("type") || !jsonData.containsKey("message")) {
+                throw new ClientVisibleException(code, "Incomplete JSON response");
+            }
+
+            if (jsonData.get("type") != null) {
+                throw new ClientVisibleException(code, (String) jsonData.get("message"));
+            }
+        } else if (code < 200 || code > 299) {
+            throw new ClientVisibleException(ResponseCodes.INTERNAL_SERVER_ERROR, "Error talking to validator");
+        }
+    }
+}

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/process/defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/process/defaults.properties
@@ -117,3 +117,7 @@ registry.whitelist=
 auth.service.executable=rancher-auth-service
 auth.service.execute=false
 
+api.auth.local.validate.url=
+api.auth.local.validate.description=
+
+


### PR DESCRIPTION
This PR adds the following global settings for API local auth password webhook and description:
`api.auth.local.validate.url` and `api.auth.local.validate.description`
The password entered while creating admin user or changing password while user has logged in, is passed to the validation url, checked and the status is returned. Depending on the validation, either the user is created or error is displayed
