### PR TITLE
remove volume.activate from test as it was disabled on the api

### DIFF
--- a/tests/integration/cattletest/core/test_svc_volume_template.py
+++ b/tests/integration/cattletest/core/test_svc_volume_template.py
@@ -115,9 +115,6 @@ def test_stack_volume(client, context):
     assert 'per_container' not in vol
 
     # remove stack, validate its volume is removed
-    # activate volume
-    volume.activate()
-    wait_for(lambda: client.reload(volume).state == 'active')
     client.wait_success(stack.remove())
     wait_for(lambda: client.reload(volume).state == 'removed')
 


### PR DESCRIPTION
@ibuildthecloud the commit below disabled volume.activate from the API, so removing it from the test where I used it to emulate putting volume to an active state:

commit bdde163444d5f9f44b525d5a27722e2a4062e124
Author: Darren Shepherd <darren@rancher.com>
Date:   Tue Oct 4 14:03:14 2016 -0700

    Storage and Network Drivers