### PR TITLE
Change datatype of value in setting

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/Setting.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/Setting.java
@@ -44,7 +44,7 @@ public interface Setting extends java.io.Serializable {
 	/**
 	 * Getter for <code>cattle.setting.value</code>.
 	 */
-	@javax.persistence.Column(name = "value", nullable = false, length = 1024)
+	@javax.persistence.Column(name = "value", nullable = false, length = 16777215)
 	public java.lang.String getValue();
 
 	// -------------------------------------------------------------------------

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/SettingTable.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/SettingTable.java
@@ -11,7 +11,7 @@ package io.cattle.platform.core.model.tables;
 @java.lang.SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class SettingTable extends org.jooq.impl.TableImpl<io.cattle.platform.core.model.tables.records.SettingRecord> {
 
-	private static final long serialVersionUID = -1553846835;
+	private static final long serialVersionUID = -1623047745;
 
 	/**
 	 * The singleton instance of <code>cattle.setting</code>
@@ -39,7 +39,7 @@ public class SettingTable extends org.jooq.impl.TableImpl<io.cattle.platform.cor
 	/**
 	 * The column <code>cattle.setting.value</code>.
 	 */
-	public final org.jooq.TableField<io.cattle.platform.core.model.tables.records.SettingRecord, java.lang.String> VALUE = createField("value", org.jooq.impl.SQLDataType.VARCHAR.length(1024).nullable(false), this, "");
+	public final org.jooq.TableField<io.cattle.platform.core.model.tables.records.SettingRecord, java.lang.String> VALUE = createField("value", org.jooq.impl.SQLDataType.CLOB.length(16777215).nullable(false), this, "");
 
 	/**
 	 * Create a <code>cattle.setting</code> table reference

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/records/SettingRecord.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/records/SettingRecord.java
@@ -13,7 +13,7 @@ package io.cattle.platform.core.model.tables.records;
 @javax.persistence.Table(name = "setting", schema = "cattle")
 public class SettingRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.platform.core.model.tables.records.SettingRecord> implements io.cattle.platform.db.jooq.utils.TableRecordJaxb, org.jooq.Record3<java.lang.Long, java.lang.String, java.lang.String>, io.cattle.platform.core.model.Setting {
 
-	private static final long serialVersionUID = 1461494748;
+	private static final long serialVersionUID = 754121535;
 
 	/**
 	 * Setter for <code>cattle.setting.id</code>.
@@ -61,7 +61,7 @@ public class SettingRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.p
 	/**
 	 * Getter for <code>cattle.setting.value</code>.
 	 */
-	@javax.persistence.Column(name = "value", nullable = false, length = 1024)
+	@javax.persistence.Column(name = "value", nullable = false, length = 16777215)
 	@Override
 	public java.lang.String getValue() {
 		return (java.lang.String) getValue(2);

--- a/resources/content/db/changelog.xml
+++ b/resources/content/db/changelog.xml
@@ -103,4 +103,5 @@
     <include file="db/core-096.xml"/>
     <include file="db/core-097.xml"/>
     <include file="db/core-098.xml"/>
+    <include file="db/core-099.xml"/>
 </databaseChangeLog>

--- a/resources/content/db/core-099.xml
+++ b/resources/content/db/core-099.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+	<property name="mediumtext" value="TEXT" dbms="postgresql" />
+    <property name="mediumtext" value="MEDIUMTEXT(16777215)" />
+    <changeSet author="rajashree (generated)" id="dump1">
+        <modifyDataType columnName="value" newDataType="${mediumtext}" tableName="setting"/>
+    </changeSet>
+    <changeSet author="rajashree (generated)" id="dump2">
+        <addNotNullConstraint columnDataType="${mediumtext}" columnName="value" tableName="setting"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
This PR changes datatype of the column `value` in table `setting` from VARCHAR to mediumtext. Liquibase is showing mediumtext as `CLOB`. I tested the code changes by running cattle with postgres setup locally. In postgres cattle db, the table `setting` has `value` set to type `TEXT`, which is mysql equivalent of `MEDIUMTEXT`. So postgres supports the datatype CLOB generated