### PR TITLE
CI Debug Tooling

### DIFF
--- a/scripts/ci
+++ b/scripts/ci
@@ -155,7 +155,7 @@ do
 
             set_up_agent
             set +e
-            ./test -- -n $threads -v $@ || test_failed $DB
+            DEBUG=true ./test -- -n $threads -v $@ || test_failed $DB
             set -e
             ;;
 

--- a/scripts/ci
+++ b/scripts/ci
@@ -9,9 +9,6 @@ declare -A RESULTS=( [h2]=0 [mysql]=0 [pgsql]=0 )
 export RUNTIME_DIR_CLEAN=true
 export CATTLE_LOGBACK_ROOT_LEVEL=error
 
-# Uncomment this if you're impatient
-#export CATTLE_IDEMPOTENT_CHECKS=false
-
 echo Launching Docker
 if grep -q overlay /proc/filesystems; then
     GRAPH=overlay

--- a/scripts/ci
+++ b/scripts/ci
@@ -52,7 +52,7 @@ run()
     echo
 }
 
-gist ()
+gist()
 {
     local result=0
     printf "\n\e[1;35mRESULTS\e[0m\n"
@@ -71,14 +71,24 @@ gist ()
     exit $result
 }
 
+set_up_agent() {
+    # Wait for completion now to ensure that images are pulled
+    ./test-warm
+
+    AGENT_IMAGE=$(grep bootstrap.required.image ../resources/content/cattle-global.properties | cut -f2 -d=)
+    docker run --rm -v /var/run/docker.sock:/var/run/docker.sock ${AGENT_IMAGE} http://localhost:8081 >/tmp/register.log &
+
+    ./wait-for-hosts
+}
+
 tear_down() {
-    echo "Shutting down agent..."
+    echo Shutting down agent...
     set +e
     docker stop $(docker ps -q) &>> /dev/null
     docker rm -fv $(docker ps -a -q) &>> /dev/null
     set -e
 
-    echo "Shutting down server..."
+    echo Shutting down server...
     pkill java
     case $DB in
         mysql ) service mysql stop ;;
@@ -86,7 +96,7 @@ tear_down() {
     esac
 }
 
-test_failed ()
+test_failed()
 {
     cat /tmp/run.log
     ((RESULTS[$1]++))
@@ -96,6 +106,11 @@ test_failed ()
 ./test-warm >/dev/null &
 
 CI=true MAVEN_ARGS='-B -q' run ./build
+
+threads=$(($(nproc) + 1))
+if [ $threads -gt 8 ]; then
+    threads=8
+fi
 
 for DB in "${!ENVIRONMENTS[@]}"
 do
@@ -126,7 +141,7 @@ do
 
         * )
 
-            echo "Unknown database specified."
+            echo Unknown database specified.
             exit 1
 
     esac
@@ -136,25 +151,20 @@ do
     # Test Environment
     case ${ENVIRONMENTS[$DB]} in
 
+        debug )
+
+            set_up_agent
+            set +e
+            ./test -- -n $threads -v $@ || test_failed $DB
+            set -e
+            ;;
+
         full )
 
-            threads=$(($(nproc) + 1))
-            if [ $threads -gt 8 ]; then
-                threads=8
-            fi
-
-            # Wait for completion now to ensure that images are pulled
-            ./test-warm
-
-            AGENT_IMAGE=$(grep bootstrap.required.image ../resources/content/cattle-global.properties | cut -f2 -d=)
-            docker run --rm -v /var/run/docker.sock:/var/run/docker.sock ${AGENT_IMAGE} http://localhost:8081 >/tmp/register.log &
-
-            ./wait-for-hosts
-
+            set_up_agent
             set +e
             ./test -e py27 -- -m nonparallel && ./test -- -m "'not nonparallel'" -n $threads -v || test_failed $DB
             set -e
-
             ;;
 
         lite )
@@ -166,7 +176,7 @@ do
 
         * )
 
-            echo "Unknown test plan specified."
+            echo Unknown test plan specified.
             exit 1
 
     esac

--- a/tests/integration/cattletest/core/common_fixtures.py
+++ b/tests/integration/cattletest/core/common_fixtures.py
@@ -8,11 +8,17 @@ import inspect
 from datetime import datetime, timedelta
 import requests
 import fcntl
+import logging
 
 NOT_NONE = object()
 DEFAULT_TIMEOUT = 300
 cattle.DEFAULT_TIMEOUT = 300
 _SUPER_CLIENT = None
+
+
+@pytest.fixture(scope='session', autouse=os.environ.get('DEBUG'))
+def log():
+    logging.basicConfig(level=logging.DEBUG)
 
 
 @pytest.fixture(scope='session')

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -5,6 +5,7 @@ PyJWT==1.4.0
 
 flake8==2.5.1
 pytest==3.0.2
+pytest-repeat
 pytest-xdist
 pyyaml
 netaddr


### PR DESCRIPTION
An attempt at a debug test plan. Stuff I keep doing by hand when looking into issues.

For example we can do something like this really quickly:

```
ENVIRONMENTS="([pgsql]=debug)" dapper ci --count=1000 -x core/test_api.py::test_pagination_include
```

Run core/test_api.py::test_pagination_include 1000 times until failure and capture API request log when it fails.