### PR TITLE
Support fields in compose

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
@@ -54,6 +54,7 @@ public class InstanceConstants {
     public static final String FIELD_LOG_CONFIG = "logConfig";
     public static final String FIELD_SERVICE_IDS = "serviceIds";
     public static final String FIELD_MEMORY = "memory";
+    public static final String FIELD_MEMORY_RESERVATION = "memoryReservation";
 
     public static final String PROCESS_DATA_NO_OP = "containerNoOpEvent";
 

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/resource/ServiceDiscoveryConfigItem.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/resource/ServiceDiscoveryConfigItem.java
@@ -40,11 +40,14 @@ public class ServiceDiscoveryConfigItem {
     public static final ServiceDiscoveryConfigItem HOSTNAME = new ServiceDiscoveryConfigItem("hostname", "hostname", false);
     public static final ServiceDiscoveryConfigItem DOMAINNAME = new ServiceDiscoveryConfigItem("domainName", "domainname", false);
     public static final ServiceDiscoveryConfigItem MEMLIMIT = new ServiceDiscoveryConfigItem("memory", "mem_limit", false);
+    public static final ServiceDiscoveryConfigItem MEMRESERVATION = new ServiceDiscoveryConfigItem("memoryReservation", "memory_reservation", false);
     public static final ServiceDiscoveryConfigItem PRIVILEGED = new ServiceDiscoveryConfigItem("privileged", "privileged", false);
     public static final ServiceDiscoveryConfigItem RESTART = new ServiceDiscoveryConfigItem("restartPolicy", "restart", false);
     public static final ServiceDiscoveryConfigItem STDINOPEN = new ServiceDiscoveryConfigItem("stdinOpen", "stdin_open", false);
     public static final ServiceDiscoveryConfigItem TTY = new ServiceDiscoveryConfigItem("tty", "tty", false);
     public static final ServiceDiscoveryConfigItem CPUSHARES = new ServiceDiscoveryConfigItem("cpuShares", "cpu_shares", false);
+    public static final ServiceDiscoveryConfigItem MILLICPURESERVATION = new ServiceDiscoveryConfigItem("milliCpuReservation", "milli_cpu_reservation", true,
+            false, false);
     public static final ServiceDiscoveryConfigItem VOLUME_DRIVER = new ServiceDiscoveryConfigItem("volumeDriver", "volume_driver", false);
     public static final ServiceDiscoveryConfigItem EXPOSE = new ServiceDiscoveryConfigItem("expose", "expose", false);
     public static final ServiceDiscoveryConfigItem EXTERNALLINKS = new ServiceDiscoveryConfigItem("instanceLinks",

--- a/code/implementation/docker/common/src/main/java/io/cattle/platform/docker/transform/DockerTransformerImpl.java
+++ b/code/implementation/docker/common/src/main/java/io/cattle/platform/docker/transform/DockerTransformerImpl.java
@@ -193,6 +193,7 @@ public class DockerTransformerImpl implements DockerTransformer {
             setCapField(instance, FIELD_CAP_DROP, hostConfig.getCapDrop());
             setRestartPolicy(instance, hostConfig.getRestartPolicy());
             setDevices(instance, hostConfig.getDevices());
+            setMemoryReservation(fromInspect, instance);
         }
 
         setBlkioDeviceOptionss(instance, fromInspect);
@@ -210,6 +211,13 @@ public class DockerTransformerImpl implements DockerTransformer {
 
         // Currently not implemented: VolumesFrom, Links,
         // Consider: AttachStdin, AttachStdout, AttachStderr, StdinOnce,
+    }
+
+    void setMemoryReservation(Map<String, Object> fromInspect, Instance instance) {
+        Object memRes = CollectionUtils.getNestedValue(fromInspect, HOST_CONFIG, "MemoryReservation");
+        if (memRes != null && memRes instanceof Number) {
+            instance.setMemoryReservation(((Number)memRes).longValue());
+        }
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -2062,6 +2062,8 @@ def test_export_config(client, context):
                      "pidMode": "host",
                      "memory": 1048576,
                      "memorySwap": 2097152,
+                     "memoryReservation": 4194304,
+                     "milliCpuReservation": 1000,
                      "devices": ["/dev/sdc:/dev/xsdc:rwm"],
                      "logConfig": {"config": {"labels": "foo"},
                                    "driver": "json-file"}}
@@ -2090,6 +2092,7 @@ def test_export_config(client, context):
     assert svc["pid"] == "host"
     assert svc["mem_limit"] == 1048576
     assert svc["memswap_limit"] == 2097152
+    assert svc["memory_reservation"] == 4194304
     assert svc["devices"] is not None
 
     rancher_yml = yaml.load(compose_config.rancherComposeConfig)
@@ -2100,6 +2103,7 @@ def test_export_config(client, context):
     assert svc['metadata'] is not None
     assert svc['metadata'] == metadata
     assert svc['retain_ip'] is True
+    assert svc["milli_cpu_reservation"] == 1000
 
     launch_config_without_log = {"imageUuid": image_uuid,
                                  "cpuSet": "0,1", "labels": labels,


### PR DESCRIPTION
Add memory_reservation and milli_cpu_reservation to the logic that
converts fields to and from compose syntax.

Also add memoryReservation to back-population logic.