### PR TITLE
Enable multi-role auth in agents

### DIFF
--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/dao/AgentInstanceDao.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/dao/AgentInstanceDao.java
@@ -2,7 +2,6 @@ package io.cattle.platform.agent.instance.dao;
 
 import io.cattle.platform.agent.instance.service.NetworkServiceInfo;
 import io.cattle.platform.core.model.Agent;
-import io.cattle.platform.core.model.Credential;
 import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.NetworkServiceProvider;
 import io.cattle.platform.core.model.Nic;
@@ -24,7 +23,7 @@ public interface AgentInstanceDao {
 
     List<? extends Agent> getAgents(NetworkServiceProvider provider);
 
-    List<? extends Credential> getActivateCredentials(Agent agent);
+    boolean areAllCredentialsActive(Agent agent);
 
     NetworkServiceInfo getNetworkServiceInfo(long instance, String serviceKind);
 

--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/dao/impl/AgentInstanceDaoImpl.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/dao/impl/AgentInstanceDaoImpl.java
@@ -13,6 +13,7 @@ import static io.cattle.platform.core.model.tables.NetworkServiceTable.*;
 import static io.cattle.platform.core.model.tables.NicTable.*;
 import io.cattle.platform.agent.instance.dao.AgentInstanceDao;
 import io.cattle.platform.agent.instance.service.NetworkServiceInfo;
+import io.cattle.platform.core.constants.AgentConstants;
 import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.constants.HealthcheckConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
@@ -37,17 +38,23 @@ import io.cattle.platform.core.model.tables.records.NetworkServiceProviderRecord
 import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
 import io.cattle.platform.db.jooq.mapper.MultiRecordMapper;
 import io.cattle.platform.object.ObjectManager;
+import io.cattle.platform.object.util.DataAccessor;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Inject;
 
 public class AgentInstanceDaoImpl extends AbstractJooqDao implements AgentInstanceDao {
 
+    @Inject
     GenericResourceDao resourceDao;
+    
+    @Inject
     ObjectManager objectManager;
 
     @Override
@@ -139,16 +146,32 @@ public class AgentInstanceDaoImpl extends AbstractJooqDao implements AgentInstan
     }
 
     @Override
-    public List<? extends Credential> getActivateCredentials(Agent agent) {
-        if ( agent.getAccountId() == null ) {
-            return Collections.emptyList();
+    public boolean areAllCredentialsActive(Agent agent) {
+        List<Long> authedRoleAccountIds = DataAccessor.fieldLongList(agent, AgentConstants.FIELD_AUTHORIZED_ROLE_ACCOUNTS);
+
+        if (agent.getAccountId() == null) {
+            return false;
         }
 
-        return create()
+        Set<Long> accountIds = new HashSet<>();
+        accountIds.add(agent.getAccountId());
+
+        for (Long aId : authedRoleAccountIds) {
+            accountIds.add(aId);
+        }
+
+        List<? extends Credential> creds = create()
                 .selectFrom(CREDENTIAL)
                 .where(CREDENTIAL.STATE.eq(CommonStatesConstants.ACTIVE)
-                        .and(CREDENTIAL.ACCOUNT_ID.eq(agent.getAccountId())))
+                        .and(CREDENTIAL.ACCOUNT_ID.in(accountIds)))
                 .fetch();
+
+        Set<Long> credAccountIds = new HashSet<>();
+        for (Credential cred : creds) {
+            credAccountIds.add(cred.getAccountId());
+        }
+
+        return accountIds.equals(credAccountIds);
     }
 
     @Override
@@ -235,23 +258,4 @@ public class AgentInstanceDaoImpl extends AbstractJooqDao implements AgentInstan
                 .orderBy(INSTANCE.AGENT_ID.asc())
                 .fetch().intoArray(INSTANCE.AGENT_ID));
     }
-
-    public GenericResourceDao getResourceDao() {
-        return resourceDao;
-    }
-
-    @Inject
-    public void setResourceDao(GenericResourceDao resourceDao) {
-        this.resourceDao = resourceDao;
-    }
-
-    public ObjectManager getObjectManager() {
-        return objectManager;
-    }
-
-    @Inject
-    public void setObjectManager(ObjectManager objectManager) {
-        this.objectManager = objectManager;
-    }
-
 }

--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/factory/impl/AgentInstanceBuilderImpl.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/factory/impl/AgentInstanceBuilderImpl.java
@@ -11,6 +11,7 @@ import io.cattle.platform.object.util.DataAccessor;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import com.netflix.config.DynamicStringProperty;
 
@@ -32,18 +33,18 @@ public class AgentInstanceBuilderImpl implements AgentInstanceBuilder {
     boolean accountOwned = true;
     boolean managedConfig = false;
     boolean privileged = false;
-    Map<String, Object> accountData = null;
     AgentInstanceFactoryImpl factory;
     String uri;
     Map<String, Object> params = new HashMap<>();
     String systemContainerType;
+    Set<String> requestedRoles;
 
     public AgentInstanceBuilderImpl(AgentInstanceFactoryImpl factory) {
         super();
         this.factory = factory;
     }
 
-    public AgentInstanceBuilderImpl(AgentInstanceFactoryImpl factory, Instance instance, Map<String, Object> accountData) {
+    public AgentInstanceBuilderImpl(AgentInstanceFactoryImpl factory, Instance instance, Set<String> roles) {
         this(factory);
         this.accountId = instance.getAccountId();
         this.zoneId = instance.getZoneId();
@@ -55,7 +56,7 @@ public class AgentInstanceBuilderImpl implements AgentInstanceBuilder {
         }
         this.uri = uriPrefix + ":///instanceId=" + instance.getId();
         this.resourceAccountId = instance.getAccountId();
-        this.accountData = accountData;
+        this.requestedRoles = roles;
     }
 
     @Override
@@ -234,8 +235,8 @@ public class AgentInstanceBuilderImpl implements AgentInstanceBuilder {
         return params;
     }
 
-    public Map<String, Object> getAccountData() {
-        return accountData;
+    public Set<String> getRequestedRoles() {
+        return requestedRoles;
     }
 
     @Override

--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/factory/impl/AgentInstanceFactoryImpl.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/factory/impl/AgentInstanceFactoryImpl.java
@@ -2,14 +2,12 @@ package io.cattle.platform.agent.instance.factory.impl;
 
 import static io.cattle.platform.core.model.tables.AgentTable.*;
 import static io.cattle.platform.core.model.tables.InstanceTable.*;
-
 import io.cattle.platform.agent.AgentLocator;
 import io.cattle.platform.agent.RemoteAgent;
 import io.cattle.platform.agent.instance.dao.AgentInstanceDao;
 import io.cattle.platform.agent.instance.factory.AgentInstanceBuilder;
 import io.cattle.platform.agent.instance.factory.AgentInstanceFactory;
 import io.cattle.platform.agent.instance.factory.lock.AgentInstanceAgentCreateLock;
-import io.cattle.platform.core.constants.AccountConstants;
 import io.cattle.platform.core.constants.AgentConstants;
 import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
@@ -34,12 +32,13 @@ import io.cattle.platform.object.resource.ResourceMonitor;
 import io.cattle.platform.object.resource.ResourcePredicate;
 import io.cattle.platform.object.util.DataAccessor;
 import io.cattle.platform.process.common.util.ProcessUtils;
-import io.cattle.platform.util.type.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 import javax.inject.Inject;
@@ -134,25 +133,35 @@ public class AgentInstanceFactoryImpl implements AgentInstanceFactory {
     @Override
     public Agent createAgent(Instance instance) {
         if (shouldCreateAgent(instance)) {
-            Map<String, Object> accountData = new HashMap<>();
             Map<String, Object> labels = DataAccessor.fieldMap(instance, InstanceConstants.FIELD_LABELS);
-            if ("environment".equals(labels.get(SystemLabels.LABEL_AGENT_ROLE))) {
-                accountData = CollectionUtils.asMap(AccountConstants.DATA_ACT_AS_RESOURCE_ACCOUNT, true);
-            } else if ("environmentAdmin".equals(labels.get(SystemLabels.LABEL_AGENT_ROLE))) {
-                // allow to set this flag only for system services
-                List<? extends Service> services = instanceDao.findServicesNonRemovedLinksOnly(instance);
-                for (Service service : services) {
-                    Stack stack = objectManager.loadResource(Stack.class, service.getStackId());
-                    if (ServiceConstants.isSystem(stack)) {
-                        accountData = CollectionUtils.asMap(AccountConstants.DATA_ACT_AS_RESOURCE_ADMIN_ACCOUNT, true);
-                        break;
+            Set<String> filteredRoles = new HashSet<>();
+
+            String rolesVal = labels.get(SystemLabels.LABEL_AGENT_ROLE) != null ? labels.get(SystemLabels.LABEL_AGENT_ROLE).toString() : null;
+            if (rolesVal != null) {
+                String[] roles = rolesVal.split(",");
+                for (String r : roles) {
+                    if ("environment".equals(r) || "agent".equals(r)) {
+                        filteredRoles.add(r);
+                    } else if ("environmentAdmin".equals(r) && isSystem(instance)) {
+                        filteredRoles.add(r);
                     }
                 }
             }
 
-            return getAgent(new AgentInstanceBuilderImpl(this, instance, accountData));
+            return getAgent(new AgentInstanceBuilderImpl(this, instance, filteredRoles));
         }
         return null;
+    }
+
+    private boolean isSystem(Instance instance) {
+        List<? extends Service> services = instanceDao.findServicesNonRemovedLinksOnly(instance);
+        for (Service service : services) {
+            Stack stack = objectManager.loadResource(Stack.class, service.getStackId());
+            if (ServiceConstants.isSystem(stack)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -196,8 +205,8 @@ public class AgentInstanceFactoryImpl implements AgentInstanceFactory {
 
         agent = resourceMonitor.waitFor(agent, new ResourcePredicate<Agent>() {
             @Override
-            public boolean evaluate(Agent obj) {
-                return factoryDao.getActivateCredentials(obj).size() > 0;
+            public boolean evaluate(Agent agent) {
+                return factoryDao.areAllCredentialsActive(agent);
             }
 
             @Override
@@ -238,8 +247,9 @@ public class AgentInstanceFactoryImpl implements AgentInstanceFactory {
                 if (builder.getResourceAccountId() != null) {
                     data.put(AgentConstants.DATA_AGENT_RESOURCES_ACCOUNT_ID, builder.getResourceAccountId());
                 }
-                if (builder.getAccountData() != null) {
-                    data.put(AgentConstants.DATA_ACCOUNT_DATA, builder.getAccountData());
+
+                if (builder.getRequestedRoles() != null) {
+                    data.put(AgentConstants.DATA_REQUESTED_ROLES, new ArrayList<String>(builder.getRequestedRoles()));
                 }
 
                 if (agent == null) {

--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/serialization/AgentInstanceAuthObjectPostProcessor.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/serialization/AgentInstanceAuthObjectPostProcessor.java
@@ -1,7 +1,10 @@
 package io.cattle.platform.agent.instance.serialization;
 
 import io.cattle.platform.agent.util.AgentUtils;
+import io.cattle.platform.core.constants.AccountConstants;
+import io.cattle.platform.core.constants.AgentConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
+import io.cattle.platform.core.model.Account;
 import io.cattle.platform.core.model.Agent;
 import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.object.ObjectManager;
@@ -9,6 +12,7 @@ import io.cattle.platform.object.serialization.ObjectTypeSerializerPostProcessor
 import io.cattle.platform.object.util.DataAccessor;
 import io.cattle.platform.object.util.DataUtils;
 
+import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -35,7 +39,34 @@ public class AgentInstanceAuthObjectPostProcessor implements ObjectTypeSerialize
             return;
         }
 
-        Map<String, Object> auth = AgentUtils.getAgentAuth(agent, objectManager);
+        List<Long> authedRoleAccountIds = DataAccessor.fieldLongList(agent, AgentConstants.FIELD_AUTHORIZED_ROLE_ACCOUNTS);
+        if (authedRoleAccountIds.isEmpty()) {
+            Map<String, Object> auth = AgentUtils.getAgentAuth(agent, objectManager);
+            setAuthEnvVars(data, auth);
+        } else {
+            // Primary agent account
+            Account account = objectManager.loadResource(Account.class, agent.getAccountId());
+            Map<String, Object> auth = AgentUtils.getAccountScopedAuth(account, objectManager, account.getKind());
+            setAuthEnvVars(data, auth);
+
+            // Secondary authed roles
+            for (Long accountId : authedRoleAccountIds) {
+                account = objectManager.loadResource(Account.class, accountId);
+                String scope = null;
+                if (DataAccessor.fromDataFieldOf(account).withKey(AccountConstants.DATA_ACT_AS_RESOURCE_ACCOUNT).withDefault(false).as(Boolean.class)) {
+                    scope = "ENVIRONMENT";
+                } else if (DataAccessor.fromDataFieldOf(account).withKey(AccountConstants.DATA_ACT_AS_RESOURCE_ADMIN_ACCOUNT).withDefault(false).as(Boolean.class)){
+                    scope = "ENVIRONMENT_ADMIN";
+                }
+                if (scope != null) {
+                    Map<String, Object> secondaryAuth = AgentUtils.getAccountScopedAuth(account, objectManager, scope);
+                    setAuthEnvVars(data, secondaryAuth);
+                }
+            }
+        }
+    }
+
+    void setAuthEnvVars(Map<String, Object> data, Map<String, Object> auth) {
         if (auth != null) {
             Map<String, Object> fields = DataUtils.getWritableFields(data);
             for (Map.Entry<String, Object> entry : auth.entrySet()) {

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/internal/rancher/BasicAuthImpl.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/internal/rancher/BasicAuthImpl.java
@@ -86,7 +86,14 @@ public class BasicAuthImpl implements AccountLookup, Priority {
         }
 
         if (shouldSwitch) {
-            Agent agent = objectManager.findAny(Agent.class, AGENT.ACCOUNT_ID, account.getId());
+            Long agentOwnerId = DataAccessor.fromDataFieldOf(account).withKey(AccountConstants.DATA_AGENT_OWNER_ID).as(Long.class);
+            Agent agent = null;
+            if (agentOwnerId != null) {
+                agent = objectManager.findAny(Agent.class, AGENT.ID, agentOwnerId);
+            } else {
+                agent = objectManager.findAny(Agent.class, AGENT.ACCOUNT_ID, account.getId()); 
+            }
+
             if (agent != null) {
                 Long resourceAccId = DataAccessor.fromDataFieldOf(agent)
                         .withKey(AgentConstants.DATA_AGENT_RESOURCES_ACCOUNT_ID)

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/account/AccountCreate.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/account/AccountCreate.java
@@ -45,7 +45,7 @@ public class AccountCreate extends AbstractDefaultProcessHandler {
         String apiKeyKind = DataAccessor.fromMap(state.getData()).withScope(AccountConstants.class).withKey(AccountConstants.OPTION_CREATE_APIKEY_KIND)
                 .withDefault(CREDENTIAL_TYPE.get()).as(String.class);
 
-        if (shouldCreateCredentials(account)) {
+        if (shouldCreateCredentials(account, state)) {
             if (createApiKey || CREATE_CREDENTIAL.get()) {
                 List<Credential> creds = ProcessHelpers.createOneChild(getObjectManager(), processManager, account, Credential.class, CREDENTIAL.ACCOUNT_ID,
                         account.getId(), CREDENTIAL.KIND, apiKeyKind);
@@ -58,7 +58,7 @@ public class AccountCreate extends AbstractDefaultProcessHandler {
         return new HandlerResult(result);
     }
 
-    public boolean shouldCreateCredentials(Account account) {
+    public boolean shouldCreateCredentials(Account account, ProcessState state) {
         return ACCOUNT_KIND_CREDENTIALS.get().contains(account.getKind());
     }
 

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/agent/AgentCreate.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/agent/AgentCreate.java
@@ -7,15 +7,23 @@ import io.cattle.platform.core.constants.AccountConstants;
 import io.cattle.platform.core.constants.AgentConstants;
 import io.cattle.platform.core.constants.CredentialConstants;
 import io.cattle.platform.core.dao.AccountDao;
+import io.cattle.platform.core.dao.InstanceDao;
 import io.cattle.platform.core.model.Account;
 import io.cattle.platform.core.model.Agent;
 import io.cattle.platform.engine.handler.HandlerResult;
 import io.cattle.platform.engine.process.ProcessInstance;
 import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.json.JsonMapper;
 import io.cattle.platform.object.util.DataAccessor;
 import io.cattle.platform.process.base.AbstractDefaultProcessHandler;
+import io.cattle.platform.util.type.CollectionUtils;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -27,8 +35,15 @@ public class AgentCreate extends AbstractDefaultProcessHandler {
 
     private static final DynamicBooleanProperty CREATE_ACCOUNT = ArchaiusUtil.getBoolean("process.agent.create.create.account");
 
+    @Inject
+    JsonMapper jsonMapper;
+
+    @Inject
     AccountDao accountDao;
 
+    @Inject
+    InstanceDao instanceDao;
+    
     @Override
     public HandlerResult handle(ProcessState state, ProcessInstance process) {
         Agent agent = (Agent) state.getResource();
@@ -43,13 +58,28 @@ public class AgentCreate extends AbstractDefaultProcessHandler {
         DataAccessor.fromMap(state.getData()).withScope(AccountConstants.class).withKey(AccountConstants.OPTION_CREATE_APIKEY_KIND).set(
                 CredentialConstants.KIND_AGENT_API_KEY);
 
-        Account account = createAccountObj(agent);
+        List<? extends String> roles =
+                DataAccessor.fromDataFieldOf(agent).withKey(AgentConstants.DATA_REQUESTED_ROLES).withDefault(Collections.EMPTY_LIST)
+                        .asList(jsonMapper, String.class);
+        sortRoles(roles);
+
+        String primaryRole = getPrimaryRole(roles); // note null is an acceptable value 
+        Account account = createPrimaryAccount(agent, primaryRole);
         create(account, state.getData());
 
-        return new HandlerResult(AGENT.ACCOUNT_ID, account.getId());
+        Map<String, Object> data = new HashMap<>();
+        data.put(AgentConstants.FIELD_ACCOUNT_ID, account.getId());
+
+        List<? extends String> secondaryRoles = getSecondaryRoles(roles);
+        List<Long> authedRoleAccounts = createSecondaryAccounts(agent, secondaryRoles, state);
+        if (!authedRoleAccounts.isEmpty()) {
+            data.put(AgentConstants.FIELD_AUTHORIZED_ROLE_ACCOUNTS, authedRoleAccounts);
+        }
+
+        return new HandlerResult(data);
     }
 
-    protected Account createAccountObj(Agent agent) {
+    protected Account createPrimaryAccount(Agent agent, String role) {
         if (agent.getAccountId() != null) {
             return getObjectManager().loadResource(Account.class, agent.getAccountId());
         }
@@ -58,17 +88,99 @@ public class AgentCreate extends AbstractDefaultProcessHandler {
         Account account = accountDao.findByUuid(uuid);
 
         if (account == null) {
-            Object obj = DataAccessor.fromDataFieldOf(agent).withKey(AgentConstants.DATA_ACCOUNT_DATA).get();
-            if (obj == null) {
-                obj = new HashMap<>();
-            }
+            Object data = createAccountDataWithActAsValue(role);
             account = getObjectManager().create(Account.class,
                     ACCOUNT.UUID, uuid,
-                    ACCOUNT.DATA, obj,
+                    ACCOUNT.DATA, data,
                     ACCOUNT.KIND, "agent");
         }
 
         return account;
+    }
+
+    protected List<Long> createSecondaryAccounts(Agent agent, List<? extends String> roles, ProcessState state) {
+        if (roles.isEmpty()) {
+            return new ArrayList<Long>();
+        }
+
+        List<Long> authedRoleAccountIds = DataAccessor.fieldLongList(agent, AgentConstants.FIELD_AUTHORIZED_ROLE_ACCOUNTS);
+        if (authedRoleAccountIds != null && !authedRoleAccountIds.isEmpty()) {
+            return authedRoleAccountIds;
+        }
+
+        authedRoleAccountIds = new ArrayList<Long>();
+        for (String role : roles) {
+            String uuid = getAccountUuid(agent, role);
+            Account account = accountDao.findByUuid(uuid);
+
+            Map<String, Object> data = createAccountDataWithActAsValue(role);
+            data.put(AccountConstants.DATA_AGENT_OWNER_ID, agent.getId());
+
+            if (account == null) {
+                account = getObjectManager().create(Account.class,
+                        ACCOUNT.UUID, uuid,
+                        ACCOUNT.DATA, data,
+                        ACCOUNT.KIND, "agent");
+            }
+            create(account, state.getData());
+            authedRoleAccountIds.add(account.getId());
+        }
+
+        return authedRoleAccountIds;
+    }
+
+    Map<String, Object> createAccountDataWithActAsValue(String r) {
+        if ("environment".equals(r)) {
+            return CollectionUtils.asMap(AccountConstants.DATA_ACT_AS_RESOURCE_ACCOUNT, true);
+        } else if ("environmentAdmin".equals(r)) {
+            return CollectionUtils.asMap(AccountConstants.DATA_ACT_AS_RESOURCE_ADMIN_ACCOUNT, true);
+        }
+        return new HashMap<>();
+    }
+
+    private void sortRoles(List<? extends String> roles) {
+        Collections.sort(roles, new Comparator<String>() {
+            @Override
+            public int compare(String lhs, String rhs) {
+                if (lhs.equals(rhs)) {
+                    return 0;
+                }
+
+                if ("agent".equals(lhs)) {
+                    return -1;
+                } else if ("agent".equals(rhs)) {
+                    return 1;
+                }
+
+                if ("environmentAdmin".equals(lhs)) {
+                    return -1;
+                } else if ("environmentAdmin".equals(rhs)) {
+                    return 1;
+                }
+
+                return 0;
+            }
+        });
+    }
+
+    private String getPrimaryRole(List<? extends String> roles) {
+        if (roles.isEmpty()) {
+            return null;
+        }
+        return roles.get(0);
+    }
+
+    private List<? extends String> getSecondaryRoles(List<? extends String> roles) {
+        if (roles.isEmpty()) {
+            return roles;
+        } else if (roles.size() == 1){
+            return new ArrayList<String>();
+        }
+        return roles.subList(1, roles.size());
+    }
+
+    protected String getAccountUuid(Agent agent, String role) {
+        return "agentAccount" + agent.getId() + "-" + role;
     }
 
     protected String getAccountUuid(Agent agent) {
@@ -78,10 +190,4 @@ public class AgentCreate extends AbstractDefaultProcessHandler {
     public AccountDao getAccountDao() {
         return accountDao;
     }
-
-    @Inject
-    public void setAccountDao(AccountDao accountDao) {
-        this.accountDao = accountDao;
-    }
-
 }

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/agent/AgentRemove.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/agent/AgentRemove.java
@@ -1,6 +1,9 @@
 package io.cattle.platform.process.agent;
 
+import java.util.List;
+
 import io.cattle.platform.agent.util.AgentUtils;
+import io.cattle.platform.core.constants.AgentConstants;
 import io.cattle.platform.core.constants.StoragePoolConstants;
 import io.cattle.platform.core.model.Account;
 import io.cattle.platform.core.model.Agent;
@@ -8,6 +11,7 @@ import io.cattle.platform.core.model.StoragePool;
 import io.cattle.platform.engine.handler.HandlerResult;
 import io.cattle.platform.engine.process.ProcessInstance;
 import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.object.util.DataAccessor;
 import io.cattle.platform.process.common.handler.AbstractObjectProcessHandler;
 import io.github.ibuildthecloud.gdapi.factory.SchemaFactory;
 
@@ -41,6 +45,7 @@ public class AgentRemove extends AbstractObjectProcessHandler {
                 continue;
             }
 
+            
             for (Object obj : objectManager.children(agent, clz)) {
                 if (obj instanceof StoragePool) {
                     StoragePool sp = (StoragePool)obj;
@@ -54,6 +59,11 @@ public class AgentRemove extends AbstractObjectProcessHandler {
         }
 
         deactivateThenScheduleRemove(objectManager.loadResource(Account.class, agent.getAccountId()), state.getData());
+
+        List<Long> authedRoleAccountIds = DataAccessor.fieldLongList(agent, AgentConstants.FIELD_AUTHORIZED_ROLE_ACCOUNTS);
+        for (Long accountId : authedRoleAccountIds) {
+            deactivateThenScheduleRemove(objectManager.loadResource(Account.class, accountId), state.getData());
+        }
 
         return null;
     }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/AccountConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/AccountConstants.java
@@ -38,6 +38,7 @@ public class AccountConstants {
     public static final String FIELD_ORCHESTRATION = "orchestration";
 
     public static final String DATA_ACT_AS_RESOURCE_ACCOUNT = "actAsResourceAccount";
+    public static final String DATA_AGENT_OWNER_ID = "agentOwnerId";
 
     public static final String DATA_ACT_AS_RESOURCE_ADMIN_ACCOUNT = "actAsResourceAdminAccount";
 

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/AgentConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/AgentConstants.java
@@ -11,8 +11,11 @@ public class AgentConstants {
     public static final String STATE_RECONNECTED = "reconnected";
     public static final String ID_REF = "agentId";
 
+    public static final String FIELD_ACCOUNT_ID = "accountId";
+    public static final String FIELD_AUTHORIZED_ROLE_ACCOUNTS = "authorizedRoleAccountIds";
+    
     public static final String DATA_AGENT_RESOURCES_ACCOUNT_ID = "agentResourcesAccountId";
-    public static final String DATA_ACCOUNT_DATA = "accountData";
+    public static final String DATA_REQUESTED_ROLES = "requestedRoles";
 
     public static final String PROCESS_ACTIVATE = "agent.activate";
     public static final String PROCESS_RECONNECT = "agent.reconnect";

--- a/resources/content/schema/base/agent.json
+++ b/resources/content/schema/base/agent.json
@@ -15,6 +15,10 @@
         "uri": {
             "type": "string",
             "unique": true
+        },
+        "authorizedRoleAccountIds": {
+            "type": "array[reference[account]]",
+            "nullable": true
         }
     },
     "resourceActions" : {

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -1479,6 +1479,7 @@ def test_agent_auth(admin_user_client, user_client, project_client):
         'uri': 'r',
         'accountId': 'r',
         'data': 'r',
+        'authorizedRoleAccountIds': 'r',
     })
 
 


### PR DESCRIPTION
Expands the functionality of the io.rancher.container.agent.role label
to allow a comma delimited list of roles.
