### PR TITLE
A bunch of fixes for upgrade code

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/ServiceConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/ServiceConstants.java
@@ -101,7 +101,6 @@ public class ServiceConstants {
     public static final String PROCESS_SERVICE_EXPOSE_MAP_REMOVE = "serviceexposemap.remove";
     public static final String PROCESS_SERVICE_UPGRADE = "service." + ACTION_SERVICE_UPGRADE;
     public static final String PROCESS_SERVICE_ROLLBACK = "service." + ACTION_SERVICE_ROLLBACK;
-    public static final String PROCESS_SERVICE_CANCEL_UPGRADE = "service.cancelupgrade";
     public static final String PROCESS_SERVICE_FINISH_UPGRADE = "service.finishupgrade";
     public static final String PROCESS_SERVICE_RESTART = "service." + ACTION_SERVICE_RESTART;
     public static final String PROCESS_SERVICE_INDEX_REMOVE = "serviceindex.remove";

--- a/tests/integration-v1/cattletest/core/test_svc_upgrade.py
+++ b/tests/integration-v1/cattletest/core/test_svc_upgrade.py
@@ -172,7 +172,7 @@ def test_rollback_regular_upgrade(context, client, super_client):
                              toServiceId=service2.id,
                              finalScale=4)
     time.sleep(1)
-    svc = client.wait_success(svc.cancelupgrade())
+    svc = wait_state(client, svc.cancelupgrade(), 'canceled-upgrade')
     assert svc.state == 'canceled-upgrade'
     svc = client.wait_success(svc.rollback(), DEFAULT_TIMEOUT)
     assert svc.state == 'active'

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -698,7 +698,7 @@ def test_validate_service_scaleup_scaledown(client, context):
     image_uuid = context.image_uuid
     launch_config = {"imageUuid": image_uuid}
 
-    service = client.create_service(name=random_str(),
+    service = client.create_service(name="scaleup",
                                     stackId=env.id,
                                     launchConfig=launch_config,
                                     scale=2)

--- a/tests/integration/cattletest/core/test_svc_upgrade.py
+++ b/tests/integration/cattletest/core/test_svc_upgrade.py
@@ -172,7 +172,7 @@ def test_rollback_regular_upgrade(context, client, super_client):
                              toServiceId=service2.id,
                              finalScale=4)
     time.sleep(1)
-    svc = client.wait_success(svc.cancelupgrade())
+    svc = wait_state(client, svc.cancelupgrade(), 'canceled-upgrade')
     assert svc.state == 'canceled-upgrade'
     svc = client.wait_success(svc.rollback(), DEFAULT_TIMEOUT)
     assert svc.state == 'active'


### PR DESCRIPTION
@ibuildthecloud this PR has some fixes in upgrade code I came over while debugging the issue you saw when Rollback for service with invalid health port was stuck in Rolling-Back state.

1) removed infinite wait and catching timeout exceptions from the upgrade code. Don't recall the exact reason it was added in the first place, may be it was there to handle the case when service.reconcile was timing out. It was introduced initially by rolling upgrade, and the same logic was utilized by in service upgrade later. Anyway, I just let upgrade fail now and retry when timeout issue is hit.

2) rollback should be cancelled by upgrade process, and vice versa.

The problem that you saw, was caused by the combination of 2 things above. Upgrade process was stuck in an infinite loop, and rollback could never get a hold of it.

3) Fixed this issue: https://github.com/rancher/rancher/issues/5826 by waiting for the healthy state before stopping the instances in startFirst=true scenario