### PR TITLE
Changes to Cattle for SAML integration

### DIFF
--- a/code/framework/schema/src/main/java/io/cattle/platform/schema/processor/AuthSchemaAdditionsPostProcessor.java
+++ b/code/framework/schema/src/main/java/io/cattle/platform/schema/processor/AuthSchemaAdditionsPostProcessor.java
@@ -1,0 +1,41 @@
+package io.cattle.platform.schema.processor;
+
+import io.cattle.platform.archaius.util.ArchaiusUtil;
+import io.cattle.platform.util.type.Priority;
+import io.github.ibuildthecloud.gdapi.factory.SchemaFactory;
+import io.github.ibuildthecloud.gdapi.factory.impl.AbstractSchemaPostProcessor;
+import io.github.ibuildthecloud.gdapi.factory.impl.SchemaPostProcessor;
+import io.github.ibuildthecloud.gdapi.model.Field;
+import io.github.ibuildthecloud.gdapi.model.impl.FieldImpl;
+import io.github.ibuildthecloud.gdapi.model.impl.SchemaImpl;
+import com.netflix.config.DynamicStringListProperty;
+
+public class AuthSchemaAdditionsPostProcessor extends AbstractSchemaPostProcessor implements SchemaPostProcessor, Priority {
+
+    private static final DynamicStringListProperty AUTH_SERVICE_EXTERNAL_ID_TYPES = ArchaiusUtil.getList("auth.service.external.id.types");
+
+    
+    @Override
+    public SchemaImpl postProcess(SchemaImpl schema, SchemaFactory factory) {
+      if(schema.getId().equals("projectMember")) {
+            FieldImpl field = getField(schema, "externalIdType");
+            if(field != null){
+                field.getOptions().addAll(AUTH_SERVICE_EXTERNAL_ID_TYPES.get());
+            }
+        }
+        return schema;
+    }
+
+    @Override
+    public int getPriority() {
+        return Priority.DEFAULT + 1;
+    }
+
+    protected FieldImpl getField(SchemaImpl schema, String name) {
+        Field field = schema.getResourceFields().get(name);
+        if (field instanceof FieldImpl) {
+            return (FieldImpl) field;
+        }
+        return null;
+    }
+}

--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/request/handler/GenericWhitelistedProxy.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/request/handler/GenericWhitelistedProxy.java
@@ -89,6 +89,9 @@ public class GenericWhitelistedProxy extends AbstractResponseGenerator {
     private static final Executor EXECUTOR;
     private static final Executor NO_REDIRECT_EXECUTOR;
 
+    private List<String> allowedPaths;
+    private boolean noAuthProxy = false;
+
     static {
         LayeredConnectionSocketFactory ssl = null;
         try {
@@ -214,6 +217,22 @@ public class GenericWhitelistedProxy extends AbstractResponseGenerator {
             throw new ClientVisibleException(ResponseCodes.FORBIDDEN);
         }
 
+        boolean matchesAllowedPath = false;
+
+        if(isNoAuthProxy()) {
+            if (uri.getPath() != null && allowedPaths != null) {
+                for(String path : allowedPaths) {
+                    if(uri.getPath().startsWith(path)) {
+                        matchesAllowedPath = true;
+                    }
+                }
+
+            }
+            if(!matchesAllowedPath){
+                return;
+            }
+        }
+
         Request temp;
         String method = servletRequest.getMethod();
         if (servletRequest instanceof ProxyPreFilter.Request) {
@@ -336,4 +355,19 @@ public class GenericWhitelistedProxy extends AbstractResponseGenerator {
         return false;
     }
 
+    public List<String> getAllowedPaths() {
+        return allowedPaths;
+    }
+
+    public void setAllowedPaths(List<String> allowedPaths) {
+        this.allowedPaths = allowedPaths;
+    }
+
+    public boolean isNoAuthProxy() {
+        return noAuthProxy;
+    }
+
+    public void setNoAuthProxy(String noAuthProxy) {
+        this.noAuthProxy = Boolean.parseBoolean(noAuthProxy);
+    }
 }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/SecurityConstants.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/SecurityConstants.java
@@ -30,6 +30,7 @@ public class SecurityConstants {
     public static final DynamicLongProperty TOKEN_EXPIRY_MILLIS = ArchaiusUtil.getLong("api.auth.jwt.token.expiry");
     public static final String HAS_LOGGED_IN = "hasLoggedIn";
     public static final String AUTH_ENABLER = "api.auth.enabler";
+    public static final DynamicStringProperty AUTH_ENABLER_SETTING = ArchaiusUtil.getString(AUTH_ENABLER);
     public static final List<String> INTERNAL_AUTH_PROVIDERS = Collections.unmodifiableList(
             Arrays.asList(new String[] {AzureConstants.CONFIG, ADConstants.CONFIG, OpenLDAPConstants.CONFIG, LocalAuthConstants.CONFIG}));
 }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/external/ExternalServiceAuthProvider.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/external/ExternalServiceAuthProvider.java
@@ -279,19 +279,6 @@ public class ExternalServiceAuthProvider {
         return tokenUtil.getIdentities();
     }
 
-    public List<Identity> savedIdentities() {
-        List<String> ids = tokenUtil.fromCommaSeparatedString(ServiceAuthConstants.ALLOWED_IDENTITIES.get());
-        List<Identity> identities = new ArrayList<>();
-        if (ids.isEmpty()) {
-            return identities;
-        }
-        for(String id: ids){
-            String[] split = id.split(":", 2);
-            identities.add(getIdentity(split[1], split[0]));
-        }
-        return identities;
-    }
-
     public boolean isConfigured() {
         if (SecurityConstants.AUTH_PROVIDER.get() != null
                 && !SecurityConstants.NO_PROVIDER.equalsIgnoreCase(SecurityConstants.AUTH_PROVIDER.get())

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/external/ExternalServiceTokenUtil.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/external/ExternalServiceTokenUtil.java
@@ -42,6 +42,11 @@ public class ExternalServiceTokenUtil extends AbstractTokenUtil {
         return ServiceAuthConstants.USER_TYPE.get();
     }
 
+
+    public String identitySeparator() {
+        return ServiceAuthConstants.IDENTITY_SEPARATOR.get();
+    }
+
     @Override
     public boolean createAccount() {
         return true;
@@ -52,7 +57,7 @@ public class ExternalServiceTokenUtil extends AbstractTokenUtil {
         if (idList == null || idList.isEmpty()) {
             return false;
         }
-        List<String> whitelistedValues = fromCommaSeparatedString(ServiceAuthConstants.ALLOWED_IDENTITIES.get());
+        List<String> whitelistedValues = fromSeparatedString(ServiceAuthConstants.ALLOWED_IDENTITIES.get(), identitySeparator());
 
         for (String id : idList) {
             for (String whiteId: whitelistedValues){
@@ -64,12 +69,12 @@ public class ExternalServiceTokenUtil extends AbstractTokenUtil {
         return false;
     }
 
-    public List<String> fromCommaSeparatedString(String string) {
-        if (StringUtils.isEmpty(string)) {
+    public List<String> fromSeparatedString(String identities, String identitySeparator) {
+        if (StringUtils.isEmpty(identities)) {
             return new ArrayList<>();
         }
         List<String> strings = new ArrayList<>();
-        String[] splitted = string.split(",");
+        String[] splitted = identities.split(identitySeparator);
         for (String aSplitted : splitted) {
             String element = aSplitted.trim();
             strings.add(element);

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/external/ServiceAuthConstants.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/external/ServiceAuthConstants.java
@@ -17,6 +17,7 @@ public class ServiceAuthConstants {
     public static final String ACCESSMODE_SETTING = "api.auth.access.mode";
     public static final String ALLOWED_IDENTITIES_SETTING = "api.auth.allowed.identities";
     public static final String USERTYPE_SETTING = "api.auth.user.type";
+    public static final String IDENTITY_SEPARATOR_SETTING = "api.auth.external.provider.identity.separator";
     public static final String EXTERNAL_AUTH_PROVIDER_SETTING = "api.auth.external.provider.configured";
     public static final String JWT_CREATION_FAILED = "FailedToMakeJWT";
     public static final String NO_IDENTITY_LOOKUP_SETTING = "api.auth.external.provider.no.identity.lookup";
@@ -24,6 +25,7 @@ public class ServiceAuthConstants {
     public static final DynamicStringProperty ACCESS_MODE = ArchaiusUtil.getString(ACCESSMODE_SETTING);
     public static final DynamicStringProperty ALLOWED_IDENTITIES = ArchaiusUtil.getString(ALLOWED_IDENTITIES_SETTING);
     public static final DynamicStringProperty USER_TYPE = ArchaiusUtil.getString(USERTYPE_SETTING);
+    public static final DynamicStringProperty IDENTITY_SEPARATOR = ArchaiusUtil.getString(IDENTITY_SEPARATOR_SETTING);
     public static final DynamicBooleanProperty IS_EXTERNAL_AUTH_PROVIDER = ArchaiusUtil.getBoolean(EXTERNAL_AUTH_PROVIDER_SETTING);
     public static final DynamicBooleanProperty NO_IDENTITY_LOOKUP_SUPPORTED = ArchaiusUtil.getBoolean(NO_IDENTITY_LOOKUP_SETTING);
 

--- a/code/implementation/docker/machine/pom.xml
+++ b/code/implementation/docker/machine/pom.xml
@@ -39,5 +39,10 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.cattle</groupId>
+            <artifactId>cattle-iaas-auth-logic</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/iaas-api/defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/iaas-api/defaults.properties
@@ -11,6 +11,7 @@ api.request.handler.list=\
     BodyParserRequestHandler,\
     ConfigurableRequestOptionsParser,\
     RequestReRouterHandler,\
+    NoAuthenticationProxy,\
     ApiAuthenticator,\
     GenericWhitelistedProxy,\
     AddClientIpHeader,\

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/iaas-api/spring-iaas-api-context.xml
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/iaas-api/spring-iaas-api-context.xml
@@ -519,8 +519,17 @@
 	
     <bean id="TokenAccountLookup" class="io.cattle.platform.iaas.api.auth.integration.internal.rancher.TokenAccountLookup" />
 
+    <bean id="NoAuthenticationProxy" class="io.cattle.platform.iaas.api.request.handler.GenericWhitelistedProxy" >
+        <property name="noAuthProxy" value="true"/>
+        <property name="allowedPaths">
+           <list>
+               <value>/v1-auth/saml/</value>
+           </list>
+        </property>
+    </bean>
 
-    <bean class="io.cattle.platform.iaas.api.request.handler.GenericWhitelistedProxy" />
+    <bean class="io.cattle.platform.iaas.api.request.handler.GenericWhitelistedProxy"/>
+
 
     <bean class="io.cattle.platform.iaas.api.auth.integration.ldap.ad.ADIdentityProvider" >
         <property name="executorService" ref="CoreExecutorService" />

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/types/spring-types-context.xml
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/types/spring-types-context.xml
@@ -22,6 +22,8 @@
         <property name="suffix" value="Record" />
     </bean>
 
+    <bean class="io.cattle.platform.schema.processor.AuthSchemaAdditionsPostProcessor" />
+
     <extension:discover class="io.github.ibuildthecloud.gdapi.factory.impl.SchemaPostProcessor" />
 
 </beans>

--- a/resources/content/cattle-global.properties
+++ b/resources/content/cattle-global.properties
@@ -90,3 +90,5 @@ db.maxtotal=1000
 
 db.cattle.mysql.validationquery=SELECT 1
 db.cattle.hsqldb.validationquery=SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS
+
+auth.service.external.id.types=github_user,github_group,github_team,shibboleth_user,shibboleth_group

--- a/resources/content/schema/base/projectMember.json
+++ b/resources/content/schema/base/projectMember.json
@@ -19,9 +19,6 @@
       "type" : "enum",
       "default" : "rancher_id",
       "options" : [
-        "github_user",
-        "github_org",
-        "github_team",
         "rancher_id",
         "ldap_user",
         "ldap_group",


### PR DESCRIPTION
Changes include:

1) Added two instances of GenericWhitelistedProxy - first one will run before APIAuthenticator to allow some configured paths to be proxied through unauthenticated. The second instance will run after APIAuthenticator and perform default checks after auth is passed.

2) Added AuthSchemaAdditionsPostProcessor to include externalIdTypes (from cattle-global.properties) github_user/github_group/github_team/shibboleth_user/shibboleth_group in
schema

3) Change to separate allowedIdentities using provider's separator instead of always separating with a comma

4) Changes to call reload API for rancher-auth-service, when auth config changes