### PR TITLE
link external volume template to volume by name

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/DeploymentUnit.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/DeploymentUnit.java
@@ -358,8 +358,8 @@ public class DeploymentUnit {
         Volume volume = null;
         if (template.getExternal()) {
             // external volume should exist, otherwise fail
-            volume = context.objectManager.findOne(Volume.class, VOLUME.ACCOUNT_ID, service.getAccountId(),
-                    VOLUME.REMOVED, null, VOLUME.VOLUME_TEMPLATE_ID, template.getId(), VOLUME.STACK_ID, stack.getId());
+            volume = context.objectManager.findAny(Volume.class, VOLUME.ACCOUNT_ID, service.getAccountId(),
+                    VOLUME.REMOVED, null, VOLUME.NAME, template.getName());
             if (volume == null) {
                 throw new ServiceInstanceAllocateException("Failed to locate volume for instance of deployment unit ["
                         + uuid + "]", null, null);


### PR DESCRIPTION
@ibuildthecloud please let me know if it is a correct fix. if the volumeTemplate external, we just locate the volume having name=volumeTemplate.name. Otherwise user would have to:

* create volume template
* create external volume from the template

which is not the correct flow for external volume

@joshwget if the flow above is correct, then there is probably nothing you should change on the compose side. Volume existence validation is done in the services code.