### PR TITLE
Schedule reconcile even when service is updating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ target
 tests/integration*/.idea/
 tests/integration*/.tox/
 tests/integration*/MANIFEST
+tests/integration-v1/.cache/
+tests/integration/.cache/
 .venv
 .idea
 *.iml

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceStart.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceStart.java
@@ -321,8 +321,10 @@ public class InstanceStart extends AbstractDefaultProcessHandler {
         String chainProcess = InstanceConstants.SYSTEM_CONTAINER_NETWORK_AGENT.equalsIgnoreCase(instance
                 .getSystemContainer()) ? InstanceConstants.PROCESS_REMOVE : InstanceConstants.PROCESS_ERROR;
         if (InstanceCreate.isCreateStart(state) && !ContainerEventCreate.isNativeDockerStart(state) ) {
+            HashMap<String, Object> data = new HashMap<String, Object>();
+            data.put(InstanceConstants.PROCESS_DATA_ERROR, true);
             getObjectProcessManager().scheduleProcessInstance(InstanceConstants.PROCESS_STOP, instance,
-                    ProcessUtils.chainInData(new HashMap<String, Object>(), InstanceConstants.PROCESS_STOP,
+                    ProcessUtils.chainInData(data, InstanceConstants.PROCESS_STOP,
                             chainProcess));
         } else {
             getObjectProcessManager().scheduleProcessInstance(InstanceConstants.PROCESS_STOP, instance, null);

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
@@ -58,6 +58,8 @@ public class InstanceConstants {
 
     public static final String PROCESS_DATA_NO_OP = "containerNoOpEvent";
 
+    public static final String PROCESS_DATA_ERROR = "errorState";
+
     public static final String REMOVE_OPTION = "remove";
 
     public static final String PROCESS_CREATE = "instance.create";

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/ServiceConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/ServiceConstants.java
@@ -148,6 +148,8 @@ public class ServiceConstants {
 
     public static final String SERVICE_INDEX_DU_STRATEGY = "deploymentUnitBased";
 
+    public static final String PROCESS_DATA_SERVICE_RECONCILE = "reconcileState";
+
     public static boolean isSystem(Stack stack) {
         return stack.getSystem() || DataAccessor.fieldBool(stack, FIELD_SYSTEM)|| DataAccessor.fieldBool(stack, "isSystem");
     }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentManagerImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentManagerImpl.java
@@ -423,7 +423,9 @@ public class DeploymentManagerImpl implements DeploymentManager {
             @Override
             public void run() {
                 final Service service = objectMgr.loadResource(Service.class, client.getResourceId());
-                if (service != null && service.getState().equalsIgnoreCase(CommonStatesConstants.ACTIVE)) {
+                if (service != null
+                        && (service.getState().equalsIgnoreCase(CommonStatesConstants.ACTIVE) || service.getState()
+                                .equalsIgnoreCase(CommonStatesConstants.UPDATING_ACTIVE))) {
                     activity.run(service, "service.trigger", "Re-evaluating state", new Runnable() {
                         @Override
                         public void run() {

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/DefaultDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/DefaultDeploymentUnitInstance.java
@@ -100,14 +100,16 @@ public class DefaultDeploymentUnitInstance extends DeploymentUnitInstance implem
     }
 
     public static void removeInstance(Instance instance, ObjectProcessManager objectProcessManager) {
+        HashMap<String, Object> data = new HashMap<String, Object>();
+        data.put(ServiceConstants.PROCESS_DATA_SERVICE_RECONCILE, true);
         if (!(instance.getState().equals(CommonStatesConstants.REMOVED) || instance.getState().equals(
                 CommonStatesConstants.REMOVING))) {
             try {
                 objectProcessManager.scheduleStandardProcessAsync(StandardProcess.REMOVE, instance,
-                        null);
+                        data);
             } catch (ProcessCancelException e) {
                 objectProcessManager.scheduleProcessInstanceAsync(InstanceConstants.PROCESS_STOP,
-                        instance, ProcessUtils.chainInData(new HashMap<String, Object>(),
+                        instance, ProcessUtils.chainInData(data,
                                 InstanceConstants.PROCESS_STOP, InstanceConstants.PROCESS_REMOVE));
             }
         }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServicesReconcileTrigger.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServicesReconcileTrigger.java
@@ -40,7 +40,8 @@ public class ServicesReconcileTrigger extends AbstractObjectProcessHandler {
             services.add((Service) state.getResource());
         } else {
             if (state.getResource() instanceof Instance) {
-                if (state.getData().containsKey("errorState")) {
+                if (state.getData().containsKey(InstanceConstants.PROCESS_DATA_ERROR)
+                        || state.getData().containsKey(ServiceConstants.PROCESS_DATA_SERVICE_RECONCILE)) {
                     return null;
                 }
             }

--- a/tests/integration/cattletest/core/test_svc_scale_policy.py
+++ b/tests/integration/cattletest/core/test_svc_scale_policy.py
@@ -167,7 +167,7 @@ def test_service_affinity_rules_w_policy(super_client, new_context):
     svc = client.wait_success(svc)
     assert svc.state == "inactive"
 
-    svc = client.wait_success(svc.activate(), 120)
+    svc = wait_state(client, svc.activate(), 'active')
     assert svc.state == "active"
 
     assert svc.currentScale == 1
@@ -187,7 +187,7 @@ def test_service_affinity_rules_w_policy(super_client, new_context):
     # deactivate and remove host
     host = client.wait_success(host.deactivate())
     client.wait_success(host.remove())
-    # make sure that the serivce gets stcuk in activa
+    # make sure that the service gets stuck in activating state
     wait_for(lambda: client.reload(svc).state == 'updating-active')
     # shouldn't become active at this point
     try:


### PR DESCRIPTION
Don't reject reconcile request when the service is in updating-active state. It makes it race condition prone for this scenario:

* service reconcile is finished, but the state of the service wasn't updated yet
* during this time, instance gets stopped/removed
* but the reconcile request gets rejected as service wasn't put into active state

So we end up having degraded service in active state.