### PR TITLE
new state transition between agent.reconnecting and agent.active

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ target
 tests/integration*/.idea/
 tests/integration*/.tox/
 tests/integration*/MANIFEST
+tests/integration-v1/.cache/
+tests/integration/.cache/
 .venv
 .idea
 *.iml

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/impl/AllocatorDaoImpl.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/impl/AllocatorDaoImpl.java
@@ -25,6 +25,7 @@ import io.cattle.platform.allocator.exception.FailedToAllocate;
 import io.cattle.platform.allocator.service.AllocationAttempt;
 import io.cattle.platform.allocator.service.AllocationCandidate;
 import io.cattle.platform.allocator.util.AllocatorUtils;
+import io.cattle.platform.core.constants.AgentConstants;
 import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.constants.HealthcheckConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
@@ -495,7 +496,9 @@ public class AllocatorDaoImpl extends AbstractJooqDao implements AllocatorDao {
                 .leftOuterJoin(AGENT)
                     .on(AGENT.ID.eq(HOST.AGENT_ID))
                 .where(
-                    AGENT.ID.isNull().or(AGENT.STATE.eq(CommonStatesConstants.ACTIVE))
+                        AGENT.ID.isNull()
+                                .or(AGENT.STATE.in(CommonStatesConstants.ACTIVE,
+                                        AgentConstants.STATE_FINISHING_RECONNECT, AgentConstants.STATE_RECONNECTED))
                 .and(HOST.REMOVED.isNull())
                 .and(HOST.ACCOUNT_ID.eq(accountId))
                 .and(HOST.STATE.in(CommonStatesConstants.ACTIVE, CommonStatesConstants.UPDATING_ACTIVE)))

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/impl/AgentQualifierAuthorizationProvider.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/impl/AgentQualifierAuthorizationProvider.java
@@ -44,7 +44,9 @@ public class AgentQualifierAuthorizationProvider implements AuthorizationProvide
             CommonStatesConstants.ACTIVE,
             AgentConstants.STATE_RECONNECTING,
             AgentConstants.STATE_DISCONNECTED,
-            AgentConstants.STATE_DISCONNECTING
+            AgentConstants.STATE_DISCONNECTING,
+            AgentConstants.STATE_FINISHING_RECONNECT,
+            AgentConstants.STATE_RECONNECTED
     ));
     private static final Set<String> DISCONNECTED = new HashSet<String>(Arrays.asList(
             AgentConstants.STATE_DISCONNECTED,

--- a/code/iaas/config-item/common/src/main/java/io/cattle/platform/configitem/version/dao/impl/ConfigItemStatusDaoImpl.java
+++ b/code/iaas/config-item/common/src/main/java/io/cattle/platform/configitem/version/dao/impl/ConfigItemStatusDaoImpl.java
@@ -443,7 +443,9 @@ public class ConfigItemStatusDaoImpl extends AbstractJooqDao implements ConfigIt
                 .leftOuterJoin(INSTANCE)
                 .on(INSTANCE.AGENT_ID.eq(AGENT.ID))
                 .where(CONFIG_ITEM_STATUS.REQUESTED_VERSION.ne(CONFIG_ITEM_STATUS.APPLIED_VERSION)
-                        .and(AGENT.STATE.in(CommonStatesConstants.ACTIVE, CommonStatesConstants.ACTIVATING, AgentConstants.STATE_RECONNECTING))
+                        .and(AGENT.STATE.in(CommonStatesConstants.ACTIVE, CommonStatesConstants.ACTIVATING,
+                                AgentConstants.STATE_RECONNECTING, AgentConstants.STATE_FINISHING_RECONNECT,
+                                AgentConstants.STATE_RECONNECTED))
                         .and(INSTANCE.STATE.isNull().or(INSTANCE.STATE.eq(InstanceConstants.STATE_RUNNING))))
                 .orderBy(AGENT.AGENT_GROUP_ID.asc(), AGENT.ID.asc())
                 .limit(BATCH_SIZE.get())
@@ -474,7 +476,9 @@ public class ConfigItemStatusDaoImpl extends AbstractJooqDao implements ConfigIt
                 .on(INSTANCE.AGENT_ID.eq(AGENT.ID))
                 .where(CONFIG_ITEM_STATUS.SOURCE_VERSION.isNotNull()
                         .and(CONFIG_ITEM_STATUS.SOURCE_VERSION.ne(CONFIG_ITEM.SOURCE_VERSION))
-                        .and(AGENT.STATE.in(CommonStatesConstants.ACTIVE, CommonStatesConstants.ACTIVATING, AgentConstants.STATE_RECONNECTING))
+                        .and(AGENT.STATE.in(CommonStatesConstants.ACTIVE, CommonStatesConstants.ACTIVATING,
+                                AgentConstants.STATE_RECONNECTING, AgentConstants.STATE_FINISHING_RECONNECT,
+                                AgentConstants.STATE_RECONNECTED))
                         .and(INSTANCE.STATE.isNull().or(INSTANCE.STATE.eq(InstanceConstants.STATE_RUNNING))))
                 .orderBy(AGENT.AGENT_GROUP_ID.asc(), AGENT.ID.asc())
                 .limit(BATCH_SIZE.get())

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/agent/AgentActivate.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/agent/AgentActivate.java
@@ -114,8 +114,11 @@ public class AgentActivate extends AbstractDefaultProcessHandler {
                 }
             }
         }
-
-        return new HandlerResult();
+        HandlerResult result = new HandlerResult();
+        if (process.getName().equalsIgnoreCase(AgentConstants.PROCESS_RECONNECT)) {
+            result.shouldDelegate(true);
+        }
+        return result;
     }
 
     @Override

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/generic/ActivateByDefault.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/generic/ActivateByDefault.java
@@ -26,7 +26,6 @@ public class ActivateByDefault extends AbstractObjectProcessLogic implements Pro
         } else if (DataAccessor.fieldBool(state.getResource(), "activateOnCreate")) {
             result.shouldDelegate(true);
         }
-
         return result;
     }
 

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/AgentConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/AgentConstants.java
@@ -7,6 +7,8 @@ public class AgentConstants {
     public static final String STATE_RECONNECTING = "reconnecting";
     public static final String STATE_DISCONNECTED = "disconnected";
     public static final String STATE_DISCONNECTING = "disconnecting";
+    public static final String STATE_FINISHING_RECONNECT = "finishing-reconnect";
+    public static final String STATE_RECONNECTED = "reconnected";
     public static final String ID_REF = "agentId";
 
     public static final String DATA_AGENT_RESOURCES_ACCOUNT_ID = "agentResourcesAccountId";
@@ -17,6 +19,7 @@ public class AgentConstants {
     public static final String PROCESS_DEACTIVATE = "agent.deactivate";
     public static final String PROCESS_DECONNECT = "agent.disconnect";
     public static final String PROCESS_REMOVE = "agent.remove";
+    public static final String PROCESS_FINISH_RECONNECT = "agent.finishreconnect";
 
     public static final String REMOVE_OPTION = "remove";
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServicesReconcilePostTrigger.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServicesReconcilePostTrigger.java
@@ -34,7 +34,8 @@ public class ServicesReconcilePostTrigger extends AbstractObjectProcessLogic imp
                 HostConstants.PROCESS_ACTIVATE,
                 LabelConstants.PROCESS_HOSTLABELMAP_CREATE,
                 LabelConstants.PROCESS_HOSTLABELMAP_REMOVE,
-                AgentConstants.PROCESS_RECONNECT
+                AgentConstants.PROCESS_RECONNECT,
+                AgentConstants.PROCESS_FINISH_RECONNECT
         };
     }
 

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/process/spring-process-context.xml
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/process/spring-process-context.xml
@@ -366,12 +366,13 @@
 
     <!-- Agent -->
     <process:defaultProcesses resourceType="agent" exclude="agent.deactivate,agent.remove" />
-    <process:process name="agent.remove" resourceType="agent" start="disconnecting,disconnected,requested,inactive,registering,updating-active,updating-inactive"
+    <process:process name="agent.remove" resourceType="agent" start="disconnecting,disconnected,requested,inactive,registering,updating-active,updating-inactive,reconnected,finishing-reconnect"
                                             transitioning="removing" done="removed" />
-    <process:process name="agent.deactivate" resourceType="agent" start="disconnecting,disconnected,active,activating,reconnecting,updating-active,updating-inactive"
+    <process:process name="agent.deactivate" resourceType="agent" start="disconnecting,disconnected,active,activating,reconnecting,updating-active,updating-inactive,reconnected,finishing-reconnect"
                                             transitioning="deactivating" done="inactive" />
-    <process:process name="agent.reconnect" resourceType="agent" start="disconnecting,disconnected,active,activating" transitioning="reconnecting" done="active" />
-    <process:process name="agent.disconnect" resourceType="agent" start="reconnecting,active" transitioning="disconnecting" done="disconnected" />
+    <process:process name="agent.reconnect" resourceType="agent" start="disconnecting,disconnected,active,activating" transitioning="reconnecting" done="reconnected" delegate="agent.finishreconnect" />
+    <process:process name="agent.finishreconnect" resourceType="agent" start="reconnected,reconnecting" transitioning="finishing-reconnect" done="active" />
+    <process:process name="agent.disconnect" resourceType="agent" start="reconnecting,active,reconnected,finishing-reconnect" transitioning="disconnecting" done="disconnected" />
 
 
     <!-- Credential -->


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/6013

@ibuildthecloud we use reconnecting state as a transition state when agent going down, and when it is coming back up. As we use agent.reconnect as one of the triggers for service reconcile, but hosts in "Reconnecting" state are not considered as available for allocation, so it is possible that the host might be skipped by global service allocator.

Added "follow up"/"delegate" state "finishUpgrade". "delegate" directive in spring-process-context.xml didn't seem to take affect, so setting this flag explicitly in one of the existing handlers