### PR TITLE
network_from_container_uuid to metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ target
 tests/integration*/.idea/
 tests/integration*/.tox/
 tests/integration*/MANIFEST
+tests/integration-v1/.cache/
+tests/integration/.cache/
 .venv
 .idea
 *.iml

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/MetaDataInfoDao.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/MetaDataInfoDao.java
@@ -39,7 +39,7 @@ public interface MetaDataInfoDao {
         }
     }
 
-    List<ContainerMetaData> getContainersData(long accountId);
+    List<ContainerMetaData> getManagedContainersData(long accountId);
 
     List<String> getPrimaryIpsOnInstanceHost(long hostId);
 
@@ -48,4 +48,7 @@ public interface MetaDataInfoDao {
     List<HostMetaData> getInstanceHostMetaData(long accountId, long instanceId);
 
     List<NetworkMetaData> getNetworksMetaData(long accountId);
+
+    List<ContainerMetaData> getNetworkFromContainersData(long accountId,
+            Map<Long, String> instanceIdToUUID);
 }

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/metadata/common/ContainerMetaData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/metadata/common/ContainerMetaData.java
@@ -22,6 +22,7 @@ public class ContainerMetaData {
     private Long serviceId;
     private HostMetaData hostMetaData;
     private String dnsPrefix;
+    private Long instanceId;
 
     protected String name;
     String uuid;
@@ -45,6 +46,7 @@ public class ContainerMetaData {
     Long memory_reservation;
     Long milli_cpu_reservation;
     String network_uuid;
+    String network_from_container_uuid;
 
     public ContainerMetaData(ContainerMetaData that) {
         this.name = that.name;
@@ -71,6 +73,7 @@ public class ContainerMetaData {
         this.hostMetaData = that.hostMetaData;
         this.dnsPrefix = that.dnsPrefix;
         this.network_uuid = that.network_uuid;
+        this.network_from_container_uuid = that.network_from_container_uuid;
     }
 
 
@@ -125,6 +128,7 @@ public class ContainerMetaData {
 
     @SuppressWarnings("unchecked")
     public void setInstanceAndHostMetadata(Instance instance, HostMetaData hostMetaData) {
+        this.instanceId = instance.getId();
         this.hostMetaData = hostMetaData;
         this.name = instance.getName();
         this.uuid = instance.getUuid();
@@ -320,4 +324,18 @@ public class ContainerMetaData {
     public void setNetwork_uuid(String network_uuid) {
         this.network_uuid = network_uuid;
     }
+
+    public Long getInstanceId() {
+        return instanceId;
+    }
+
+
+    public String getNetwork_from_container_uuid() {
+        return network_from_container_uuid;
+    }
+
+    public void setNetwork_from_container_uuid(String network_from_container_uuid) {
+        this.network_from_container_uuid = network_from_container_uuid;
+    }
+
 }

--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/ServiceMetadataInfoFactory.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/impl/ServiceMetadataInfoFactory.java
@@ -76,7 +76,12 @@ public class ServiceMetadataInfoFactory extends AbstractAgentBaseContextFactory 
             return;
         }
         long agentHostId = hostMap.getHostId();
-        List<ContainerMetaData> containersMD = metaDataInfoDao.getContainersData(account.getId());
+        List<ContainerMetaData> containersMD = metaDataInfoDao.getManagedContainersData(account.getId());
+        Map<Long, String> instanceIdToUuid = new HashMap<>();
+        for (ContainerMetaData containerMd : containersMD) {
+            instanceIdToUuid.put(containerMd.getInstanceId(), containerMd.getUuid());
+        }
+        containersMD.addAll(metaDataInfoDao.getNetworkFromContainersData(account.getId(), instanceIdToUuid));
         Map<String, StackMetaData> stackNameToStack = new HashMap<>();
         Map<Long, Map<String, ServiceMetaData>> serviceIdToServiceLaunchConfigs = new HashMap<>();
         List<? extends Service> allSvcs = objectManager.find(Service.class, SERVICE.ACCOUNT_ID,


### PR DESCRIPTION
Capturing info about network_from container id helps to retrieve networking information for a child container. 

https://github.com/rancher/rancher/issues/6326

@vincent99 @ibuildthecloud API police, please review the field name