### PR TITLE
Changes to fix the group sync of OpenLDAP

### DIFF
--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPConfig.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPConfig.java
@@ -30,17 +30,19 @@ public class OpenLDAPConfig implements Configurable, LDAPConfig {
     private final String groupSearchField;
     private final String groupObjectClass;
     private final String groupNameField;
+    private final String groupDNField;
     private final String userMemberAttribute;
     private final String groupMemberMappingAttribute;
     private final long connectionTimeout;
+    private final String groupMemberUserAttribute;
 
     public OpenLDAPConfig(String server, Integer port, Integer userDisabledBitMask, String loginDomain, String domain,
                           Boolean enabled, String accessMode, String serviceAccountUsername,
                           String serviceAccountPassword, Boolean tls, String userSearchField, String userLoginField,
-                          String userObjectClass, String userNameField, String userEnabledAttribute, String
-                                  groupSearchField,
-                          String groupObjectClass, String groupNameField, String userMemberAttribute, String
-                                  groupMemberMappingAttribute, long connectionTimeout) {
+                          String userObjectClass, String userNameField, String userEnabledAttribute, 
+                          String groupSearchField, String groupObjectClass, String groupNameField, 
+                          String userMemberAttribute, String groupMemberMappingAttribute, 
+                          long connectionTimeout, String groupDNField, String groupMemberUserAttribute) {
         this.server = server;
         this.port = port;
         this.userDisabledBitMask = userDisabledBitMask;
@@ -62,6 +64,8 @@ public class OpenLDAPConfig implements Configurable, LDAPConfig {
         this.userMemberAttribute = userMemberAttribute;
         this.groupMemberMappingAttribute = groupMemberMappingAttribute;
         this.connectionTimeout = connectionTimeout;
+        this.groupDNField = groupDNField;
+        this.groupMemberUserAttribute = groupMemberUserAttribute;
     }
 
     @Field(required = true, nullable = false, minLength = 1)
@@ -164,7 +168,7 @@ public class OpenLDAPConfig implements Configurable, LDAPConfig {
         return groupNameField;
     }
 
-    @Field(nullable = false, required = true, defaultValue = "gidNumber")
+    @Field(nullable = false, required = true, defaultValue = "memberOf")
     public String getUserMemberAttribute() {
         return userMemberAttribute;
     }
@@ -182,5 +186,17 @@ public class OpenLDAPConfig implements Configurable, LDAPConfig {
     @Override
     public List<Identity> getAllowedIdentities() {
         return new ArrayList<>();
+    }
+    
+    @Override
+    @Field(nullable = false, required = false, defaultValue = "distinguishedName")
+    public String getGroupDNField() {
+        return groupDNField;
+    }
+
+    @Override
+    @Field(nullable = false, required = false, defaultValue = "uid")
+    public String getGroupMemberUserAttribute() {
+        return groupMemberUserAttribute;
     }
 }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPConfigManager.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPConfigManager.java
@@ -122,10 +122,19 @@ public class OpenLDAPConfigManager extends AbstractNoOpResourceManager {
         if (config.getGroupMemberMappingAttribute() != null){
             groupMemberMappingAttribute = config.getGroupMemberMappingAttribute();
         }
+        String groupDNField = currentConfig.getGroupDNField();
+        if (config.getGroupDNField() != null){
+            groupDNField = config.getGroupDNField();
+        }
+        String groupMemberUserAttribute = currentConfig.getGroupMemberUserAttribute();
+        if (config.getGroupMemberUserAttribute() != null){
+            groupMemberUserAttribute = config.getGroupMemberUserAttribute();
+        }
+
         return new OpenLDAPConfig(server, port, userEnabledMaskBit, loginDomain, domain, enabled, accessMode,
                 serviceAccountUsername, serviceAccountPassword, tls, userSearchField, userLoginField, userObjectClass,
                 userNameField, userEnabledAttribute, groupSearchField, groupObjectClass, groupNameField, userMemberAttribute,
-                groupMemberMappingAttribute, config.getConnectionTimeout());
+                groupMemberMappingAttribute, config.getConnectionTimeout(), groupDNField, groupMemberUserAttribute);
     }
 
     @Override
@@ -151,10 +160,13 @@ public class OpenLDAPConfigManager extends AbstractNoOpResourceManager {
         String userObjectClass = OpenLDAPConstants.USER_OBJECT_CLASS.get();
         String userSearchField = OpenLDAPConstants.USER_SEARCH_FIELD.get();
         long connectionTimeout = OpenLDAPConstants.CONNECTION_TIMEOUT.get();
+        String groupDNField = OpenLDAPConstants.GROUP_DN_FIELD.get();
+        String groupMemberUserAttribute = OpenLDAPConstants.GROUP_MEMBER_USER_ATTRIBUTE.get();
+
         return new OpenLDAPConfig(server, port, userEnabledMaskBit, loginDomain, domain, enabled, accessMode,
                 serviceAccountUsername, serviceAccountPassword, tls, userSearchField, userLoginField, userObjectClass,
                 userNameField, userEnabledAttribute, groupSearchField, groupObjectClass, groupNameField, userMemberAttribute,
-                groupMemberMappingAttribute, connectionTimeout);
+                groupMemberMappingAttribute, connectionTimeout, groupDNField, groupMemberUserAttribute);
     }
 
     public OpenLDAPConfig updateCurrentConfig(LDAPConstants config) {
@@ -178,6 +190,8 @@ public class OpenLDAPConfigManager extends AbstractNoOpResourceManager {
         settingsUtils.changeSetting(OpenLDAPConstants.USER_OBJECT_CLASS_SETTING, config.getUserObjectClass());
         settingsUtils.changeSetting(OpenLDAPConstants.USER_SEARCH_FIELD_SETTING, config.getUserSearchField());
         settingsUtils.changeSetting(OpenLDAPConstants.TIMEOUT_SETTING, config.getConnectionTimeout());
+        settingsUtils.changeSetting(OpenLDAPConstants.GROUP_DN_FIELD_SETTING, config.getGroupDNField());
+        settingsUtils.changeSetting(OpenLDAPConstants.GROUP_MEMBER_USER_ATTRIBUTE_SETTING, config.getGroupMemberUserAttribute());
         settingsUtils.changeSetting(SecurityConstants.SECURITY_SETTING, config.getEnabled());
         if (config.getEnabled() != null){
             settingsUtils.changeSetting(SecurityConstants.AUTH_PROVIDER_SETTING, OpenLDAPConstants.CONFIG);

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPConstants.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPConstants.java
@@ -45,6 +45,8 @@ public class OpenLDAPConstants {
     public static final String GROUP_USER_MAPPING_ATTRIBUTE_SETTING = SETTING_BASE + "group.member.mapping.attribute";
     public static final String TLS_SETTING = SETTING_BASE + "tls";
     public static final String TIMEOUT_SETTING = SETTING_BASE + "connection.timeout";
+    public static final String GROUP_DN_FIELD_SETTING = SETTING_BASE + "group.dn.field";
+    public static final String GROUP_MEMBER_USER_ATTRIBUTE_SETTING = SETTING_BASE + "group.member.user.attribute";
 
 
     public static final Set<String> SCOPES = Collections.unmodifiableSet(
@@ -85,4 +87,6 @@ public class OpenLDAPConstants {
 
     public static final DynamicStringProperty USER_MEMBER_ATTRIBUTE = ArchaiusUtil.getString(USER_MEMBER_ATTRIBUTE_SETTING);
     public static final DynamicLongProperty CONNECTION_TIMEOUT = ArchaiusUtil.getLong(TIMEOUT_SETTING);
+    public static final DynamicStringProperty GROUP_DN_FIELD = ArchaiusUtil.getString(GROUP_DN_FIELD_SETTING);
+    public static final DynamicStringProperty GROUP_MEMBER_USER_ATTRIBUTE = ArchaiusUtil.getString(GROUP_MEMBER_USER_ATTRIBUTE_SETTING);
 }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPConstantsConfig.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPConstantsConfig.java
@@ -152,4 +152,14 @@ public class OpenLDAPConstantsConfig extends OpenLDAPConfigurable implements LDA
     public List<Identity> getAllowedIdentities() {
         return new ArrayList<>();
     }
+
+    @Override
+    public String getGroupDNField() {
+        return OpenLDAPConstants.GROUP_DN_FIELD.get();
+    }
+
+    @Override
+    public String getGroupMemberUserAttribute() {
+        return OpenLDAPConstants.GROUP_MEMBER_USER_ATTRIBUTE.get();
+    }
 }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADConfig.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADConfig.java
@@ -30,6 +30,8 @@ public class ADConfig implements Configurable, LDAPConfig {
     private final String groupSearchField;
     private final String groupObjectClass;
     private final String groupNameField;
+    private final String groupDNField;
+    private final String groupMemberUserAttribute;
     private final long connectionTimeout;
     private List<Identity> allowedIdentities;
 
@@ -37,7 +39,8 @@ public class ADConfig implements Configurable, LDAPConfig {
                     Boolean enabled, String accessMode, String serviceAccountUsername,
                     String serviceAccountPassword, Boolean tls, String userSearchField, String userLoginField,
                     String userObjectClass, String userNameField, String userEnabledAttribute, String groupSearchField,
-                    String groupObjectClass, String groupNameField, long connectionTimeout, List<Identity> allowedIdentities) {
+                    String groupObjectClass, String groupNameField, long connectionTimeout, 
+                    List<Identity> allowedIdentities, String groupDNField, String groupMemberUserAttribute) {
         this.server = server;
         this.port = port;
         this.userDisabledBitMask = userDisabledBitMask;
@@ -58,6 +61,8 @@ public class ADConfig implements Configurable, LDAPConfig {
         this.groupNameField = groupNameField;
         this.connectionTimeout = connectionTimeout;
         this.allowedIdentities = allowedIdentities;
+        this.groupDNField = groupDNField;
+        this.groupMemberUserAttribute = groupMemberUserAttribute;
     }
 
     @Field(required = true, nullable = false, minLength = 1)
@@ -193,5 +198,17 @@ public class ADConfig implements Configurable, LDAPConfig {
     @Field(nullable = true)
     public List<Identity> getAllowedIdentities() {
         return allowedIdentities;
+    }
+
+    @Override
+    @Field(nullable = false, required = false, defaultValue = "distinguishedName")
+    public String getGroupDNField() {
+        return groupDNField;
+    }
+
+    @Override
+    @Field(nullable = false, required = false, defaultValue = "distinguishedName")
+    public String getGroupMemberUserAttribute() {
+        return groupMemberUserAttribute;
     }
 }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADConfigManager.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADConfigManager.java
@@ -12,6 +12,7 @@ import io.github.ibuildthecloud.gdapi.factory.SchemaFactory;
 import io.github.ibuildthecloud.gdapi.model.ListOptions;
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 import io.github.ibuildthecloud.gdapi.request.resource.impl.AbstractNoOpResourceManager;
+
 import java.util.List;
 import java.util.Map;
 
@@ -131,10 +132,21 @@ public class ADConfigManager extends AbstractNoOpResourceManager {
                 && (AbstractTokenUtil.isRestrictedAccess(accessModeInConfig) || AbstractTokenUtil.isRequiredAccess(accessModeInConfig))) {
             identities = adIdentityProvider.getIdentities((List<Map<String, String>>) config.get(ADConstants.CONFIG_ALLOWED_IDENTITIES));
         }
+
+        String groupDNField = currentConfig.getGroupDNField();
+        if (config.get(ADConstants.CONFIG_GROUP_DN_FIELD) != null){
+            groupDNField = (String)config.get(ADConstants.CONFIG_GROUP_DN_FIELD);
+        }
+
+        String groupMemberUserAttribute = currentConfig.getGroupMemberUserAttribute();
+        if (config.get(ADConstants.CONFIG_GROUP_MEMBER_USER_ATTRIBUTE) != null){
+            groupMemberUserAttribute = (String)config.get(ADConstants.CONFIG_GROUP_MEMBER_USER_ATTRIBUTE);
+        }
+
         return new ADConfig(server, port, userEnabledMaskBit, loginDomain, domain, enabled, accessMode,
                 serviceAccountUsername, serviceAccountPassword, tls, userSearchField, userLoginField,
                 userObjectClass, userNameField, userEnabledAttribute, groupSearchField, groupObjectClass, groupNameField,
-                (Long)config.get(ADConstants.CONFIG_TIMEOUT), identities);
+                (Long)config.get(ADConstants.CONFIG_TIMEOUT), identities, groupDNField, groupMemberUserAttribute);
     }
 
     @Override
@@ -160,10 +172,13 @@ public class ADConfigManager extends AbstractNoOpResourceManager {
         String groupNameField = ADConstants.GROUP_NAME_FIELD.get();
         long connectionTimeout = ADConstants.CONNECTION_TIMEOUT.get();
         List<Identity> identities = adIdentityProvider.savedIdentities();
+        String groupDNField = ADConstants.GROUP_DN_FIELD.get();
+        String groupMemberUserAttribute = ADConstants.GROUP_MEMBER_USER_ATTRIBUTE.get();
+
         return new ADConfig(server, port, userEnabledMaskBit, loginDomain, domain, enabled, accessMode,
                 serviceAccountUsername, serviceAccountPassword, tls, userSearchField, userLoginField, userObjectClass,
                 userNameField, userEnabledAttribute, groupSearchField, groupObjectClass, groupNameField,
-                connectionTimeout, identities);
+                connectionTimeout, identities, groupDNField, groupMemberUserAttribute);
     }
 
     public ADConfig updateCurrentConfig(Map<String, Object> config) {

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADConstants.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADConstants.java
@@ -43,6 +43,8 @@ public class ADConstants {
     public static final String TLS_SETTING = SETTING_BASE + "tls";
     public static final String TIMEOUT_SETTING = SETTING_BASE + "connection.timeout";
     public static final String ALLOWED_IDENTITIES_SETTING = SETTING_BASE + "allowed.identities";
+    public static final String GROUP_DN_FIELD_SETTING = SETTING_BASE + "group.dn.field";
+    public static final String GROUP_MEMBER_USER_ATTRIBUTE_SETTING = SETTING_BASE + "group.member.user.attribute";
 
     public static final Set<String> SCOPES = Collections.unmodifiableSet(
             new HashSet<>(Arrays.asList(
@@ -82,6 +84,8 @@ public class ADConstants {
     public static final DynamicStringProperty GROUP_OBJECT_CLASS = ArchaiusUtil.getString(GROUP_OBJECT_CLASS_SETTING);
 
     public static final DynamicLongProperty CONNECTION_TIMEOUT = ArchaiusUtil.getLong(TIMEOUT_SETTING);
+    public static final DynamicStringProperty GROUP_DN_FIELD = ArchaiusUtil.getString(GROUP_DN_FIELD_SETTING);
+    public static final DynamicStringProperty GROUP_MEMBER_USER_ATTRIBUTE = ArchaiusUtil.getString(GROUP_MEMBER_USER_ATTRIBUTE_SETTING);
 
     public static final String CONFIG_DOMAIN = "domain";
     public static final String CONFIG_ALLOWED_IDENTITIES = "allowedIdentities";
@@ -102,4 +106,7 @@ public class ADConstants {
     public static final String CONFIG_USER_SEARCH_FIELD = "userSearchField";
     public static final String CONFIG_TIMEOUT = "connectionTimeout";
     public static final String CONFIG_SECURITY = "enabled";
+    public static final String CONFIG_GROUP_DN_FIELD = "groupDNField";
+    public static final String CONFIG_GROUP_MEMBER_USER_ATTRIBUTE = "groupMemberUserAttribute";
+
 }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADConstantsConfig.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADConstantsConfig.java
@@ -152,4 +152,14 @@ public class ADConstantsConfig extends ADConfigurable implements LDAPConstants{
     public List<Identity> getAllowedIdentities() {
         return new ArrayList<>();
     }
+
+    @Override
+    public String getGroupDNField() {
+        return ADConstants.GROUP_DN_FIELD.get();
+    }
+
+    @Override
+    public String getGroupMemberUserAttribute() {
+        return ADConstants.GROUP_MEMBER_USER_ATTRIBUTE.get();
+    }
 }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/interfaces/LDAPConfig.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/interfaces/LDAPConfig.java
@@ -50,4 +50,8 @@ public interface LDAPConfig {
 
     List<Identity> getAllowedIdentities();
 
+    String getGroupDNField();
+
+    String getGroupMemberUserAttribute();
+
 }

--- a/resources/content/schema/admin/admin-auth.json
+++ b/resources/content/schema/admin/admin-auth.json
@@ -181,6 +181,8 @@
         "openldapconfig.userMemberAttribute" : "cr",
         "openldapconfig.groupMemberMappingAttribute" : "cr",
         "openldapconfig.connectionTimeout" : "cr",
+        "openldapconfig.groupDNField" : "cr",
+        "openldapconfig.groupMemberUserAttribute" : "cr",
 
         "password.accountId" : "cr",
 

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -549,7 +549,9 @@ def test_openldap_auth(admin_user_client, user_client, project_client):
         'userSearchField': 'cr',
         'groupMemberMappingAttribute': 'cr',
         'userMemberAttribute': 'cr',
-        'connectionTimeout': 'cr'
+        'connectionTimeout': 'cr',
+        'groupDNField': 'cr',
+        'groupMemberUserAttribute': 'cr'
     })
 
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/3875
https://github.com/rancher/rancher/issues/5629

Added two new properties to be configured in openldapconfig:
groupDNField
groupMemberUserAttribute

These are for admins to set the appropriate fields so that lookup of user's groups works fine.