### PR TITLE
Update gdapi-python dependency

### DIFF
--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,5 +1,5 @@
 cattle==0.5.3
-gdapi-python==0.5.3
+git+https://github.com/rancher/gdapi-python.git@6e5031dde7b7da0a91efa9204a0a392f44854b0d
 websocket-client==0.23.0
 PyJWT==1.4.0
 


### PR DESCRIPTION
Contains a fix to retry updates that fail with 409 (conflict) responses.