### PR TITLE
Revert "CI Containerize DB"

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -6,23 +6,23 @@ ENV DAPPER_SOURCE /usr/src/cattle
 ENV DAPPER_OUTPUT dist
 WORKDIR ${DAPPER_SOURCE}
 
-# MySQL
-ENV MYSQL_VERSION 5.5
-ENV MYSQL_HOST 127.0.0.1
-ENV MYSQL_TCP_PORT 13306
-
-# Postgres
-ENV PGSQL_VERSION 9.6
-ENV PGPASSWORD cattle
-ENV PGUSER cattle
-ENV PGDATABASE cattle
-
 # Install Java and Python
 RUN apt-get update && \
     apt-get install -y --no-install-recommends openjdk-7-jdk maven python-pip  && \
     # Hack to work around overlay issue && \
     pip uninstall -y py >/dev/null >/dev/null 2>&1 || true && \
     pip install --upgrade pip==6.0.3 tox==1.8.1 virtualenv==12.0.4
+
+# Install MySQL
+RUN DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y mysql-server
+
+# Install Postgres
+ENV PGSQL_VERSION 9.6
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+    apt-get install -y wget && \
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql-${PGSQL_VERSION}
 
 # Build Tools
 ENV BUILD_TOOLS_VERSION 0.3.1
@@ -32,6 +32,18 @@ RUN mkdir /tmp/build-tools && \
     curl -sSL -o build-tools.tar.gz https://github.com/rancherio/build-tools/archive/v${BUILD_TOOLS_VERSION}.tar.gz && \
     tar -xzvf build-tools.tar.gz && cp ./build-tools-${BUILD_TOOLS_VERSION}/bin/* /usr/local/bin && \
     rm -rf /tmp/build-tools
+
+# Setup MySQL
+ENV CATTLE_DB_CATTLE_MYSQL_PORT 13306
+RUN sed -i  -e "0,/3306/! {0,/3306/ s/3306/${CATTLE_DB_CATTLE_MYSQL_PORT}/}" \
+    -e 's/^#\(max_connections.*\)/\1/;s/100$/1000/' \
+    -e '/^log_error.*$/a innodb_flush_log_at_trx_commit = 0' \
+    -e '/^max_connections.*$/a sql_mode = ONLY_FULL_GROUP_BY' /etc/mysql/my.cnf
+
+# Setup Postgres
+RUN sed -i -e 's/^#\(max_connections.*\)/\1/;s/\<100\>/1000/' \
+    -e 's/^#\(fsync.*\)/\1/;s/\<on\>/off/' /etc/postgresql/${PGSQL_VERSION}/main/postgresql.conf && \
+    sed -i -e 's/^#\(local.*\)/\1/;s/\<peer\>/trust/' /etc/postgresql/${PGSQL_VERSION}/main/pg_hba.conf
 
 # Cache Maven stuff
 RUN apt-get install -y git && \

--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/manager/HaConfigManager.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/manager/HaConfigManager.java
@@ -83,7 +83,7 @@ public class HaConfigManager extends AbstractNoOpResourceManager {
         data.put("enabled", HA_ENABLED.get());
         data.put("clusterSize", HA_CLUSTER_SIZE.get());
 
-        if ("localhost".equals(host) || "127.0.0.1".equals(host)) {
+        if ("localhost".equals(host)) {
             try {
                 data.put("dbSize", dbSize());
             } catch (NumberFormatException | IOException e) {

--- a/scripts/ci
+++ b/scripts/ci
@@ -71,36 +71,6 @@ gist()
     exit $result
 }
 
-install_mysql_cmd_aliases()
-{
-    cat >/usr/local/bin/mysql <<EOF
-[ -t 0 ] && tty=-it
-docker run \$tty --rm --link ci-mysql:mysql mysql:$MYSQL_VERSION mysql -h mysql "\$@"
-EOF
-    chmod +x /usr/local/bin/mysql
-
-    cat >/usr/local/bin/mysqldump <<EOF
-[ -t 0 ] && tty=-it
-docker run \$tty --rm --link ci-mysql:mysql mysql:$MYSQL_VERSION mysqldump -h mysql "\$@"
-EOF
-    chmod +x /usr/local/bin/mysqldump
-}
-
-install_pgsql_cmd_aliases()
-{
-    cat >/usr/local/bin/psql <<EOF
-[ -t 0 ] && tty=-it
-docker run \$tty --rm -e PGDATABASE -e PGHOST=pg -e PGUSER -e PGPASSWORD  --link ci-pgsql:pg postgres:$PGSQL_VERSION psql "\$@"
-EOF
-    chmod +x /usr/local/bin/psql
-
-    cat >/usr/local/bin/pg_dump <<EOF
-[ -t 0 ] && tty=-it
-docker run \$tty --rm -e PGDATABASE -e PGHOST=pg -e PGUSER -e PGPASSWORD --link ci-pgsql:pg postgres:$PGSQL_VERSION pg_dump "\$@"
-EOF
-    chmod +x /usr/local/bin/pg_dump
-}
-
 set_up_agent() {
     # Wait for completion now to ensure that images are pulled
     ./test-warm
@@ -114,12 +84,16 @@ set_up_agent() {
 tear_down() {
     echo Shutting down agent...
     set +e
-    docker stop $(docker ps -q --filter=name=r) &>> /dev/null
-    docker rm -fv $(docker ps -a -q --filter=name=r) &>> /dev/null
+    docker stop $(docker ps -q) &>> /dev/null
+    docker rm -fv $(docker ps -a -q) &>> /dev/null
     set -e
 
     echo Shutting down server...
     pkill java
+    case $DB in
+        mysql ) service mysql stop ;;
+        pgsql ) service postgresql stop ;;
+    esac
 }
 
 test_failed()
@@ -146,11 +120,6 @@ do
     export RUNTIME_DIR=$(pwd)/../runtime/ci-$DB/
 
     # Bootstrap Database
-    set +e
-    docker stop ci-$DB &>> /dev/null
-    docker rm ci-$DB &>> /dev/null
-    set -e
-
     case $DB in
 
         h2 )
@@ -159,32 +128,15 @@ do
         mysql )
 
             export CATTLE_DB_CATTLE_DATABASE=mysql
-            : ${CATTLE_DB_CATTLE_MYSQL_PORT:=$MYSQL_TCP_PORT}
-            : ${CATTLE_DB_CATTLE_MYSQL_HOST:=$MYSQL_HOST}
-            export CATTLE_DB_CATTLE_MYSQL_HOST
+            : ${CATTLE_DB_CATTLE_MYSQL_PORT:=13306}
             export CATTLE_DB_CATTLE_MYSQL_PORT
-            docker run --name ci-$DB -p $CATTLE_DB_CATTLE_MYSQL_PORT:3306 \
-                -e MYSQL_DATABASE=cattle \
-                -e MYSQL_USER=cattle \
-                -e MYSQL_PASSWORD=cattle \
-                -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
-                -d mysql:$MYSQL_VERSION \
-                --innodb-flush-log-at-trx-commit=0 \
-                --max-connections=1000 \
-                --sql-mode=ONLY_FULL_GROUP_BY
-            install_mysql_cmd_aliases
+            run ./mysql --clean
             ;;
 
         pgsql )
 
             export CATTLE_DB_CATTLE_DATABASE=postgres
-            docker run --name ci-$DB -p 5432:5432 \
-                -e POSTGRES_USER=$PGUSER \
-                -e POSTGRES_PASSWORD=$PGPASSWORD \
-                -d postgres:$PGSQL_VERSION \
-                -c max_connections=1000 \
-                -c fsync=off
-            install_pgsql_cmd_aliases
+            run ./pgsql --clean
             ;;
 
         * )

--- a/scripts/mysql
+++ b/scripts/mysql
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)
+
+service mysql start
+
+set +e
+for ((i=0;i<60;i++))
+do
+    if mysqladmin status 2> /dev/null; then
+        break
+    else
+        sleep 1
+    fi
+done
+set -e
+
+if [ "$1" = "--clean" ]; then
+    echo "Cleaning Database"
+    mysql -e 'DROP DATABASE IF EXISTS cattle; DROP DATABASE IF EXISTS cattle_base;'
+fi
+
+# If the for loop times out... something went wrong and this will fail
+db_exists=$(mysql -uroot -e 'SHOW DATABASES LIKE "cattle";'|wc -l)
+if [ $db_exists -eq 0 ]; then
+    echo "Setting up Database"
+    mysql < ../resources/content/db/mysql/create_db_and_user_dev.sql
+fi

--- a/scripts/pgsql
+++ b/scripts/pgsql
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+service postgresql start
+
+set +e
+for ((i=0;i<60;i++))
+do
+    if su postgres -c "/usr/lib/postgresql/$PGSQL_VERSION/bin/pg_ctl status -s -D /var/lib/postgresql/$PGSQL_VERSION/main" &>> /dev/null; then
+        break
+    else
+        sleep 1
+    fi
+done
+set -e
+
+if [ "$1" = "--clean" ]; then
+    su postgres -c "psql << EOF
+DROP DATABASE IF EXISTS cattle;
+DROP ROLE IF EXISTS cattle;
+EOF"
+fi
+
+# If the for loop times out... something went wrong and this will fail
+# Check for cattle db and create it if it doesn't exist
+su postgres -c "psql cattle -c ''" || \
+    su postgres -c "psql << EOF
+CREATE ROLE cattle WITH LOGIN PASSWORD 'cattle';
+CREATE DATABASE cattle OWNER cattle;
+EOF"

--- a/tests/integration-v1/cattletest/core/test_ha_config.py
+++ b/tests/integration-v1/cattletest/core/test_ha_config.py
@@ -18,7 +18,7 @@ def test_ha_config(admin_user_client):
     ha_config = find_one(admin_user_client.list_ha_config)
     assert not ha_config.enabled
 
-    assert ha_config.dbHost in ['localhost', '127.0.0.1']
+    assert ha_config.dbHost == 'localhost'
     assert ha_config.dbSize > 0
 
 

--- a/tests/integration/cattletest/core/test_ha_config.py
+++ b/tests/integration/cattletest/core/test_ha_config.py
@@ -18,7 +18,7 @@ def test_ha_config(admin_user_client):
     ha_config = find_one(admin_user_client.list_ha_config)
     assert not ha_config.enabled
 
-    assert ha_config.dbHost in ['localhost', '127.0.0.1']
+    assert ha_config.dbHost == 'localhost'
     assert ha_config.dbSize > 0
 
 


### PR DESCRIPTION
Reverts rancher/cattle#2100

@dx9 This PR has an unfortunate side effect that is uses the `docker-proxy` for DB communication.  And we all know the `docker-proxy` is a highly effective dual-ISDN line.  Basically it's killing the CPU on the drone boxes.  So we can probably reconfigure docker to `--userland-proxy=false` but that isn't the default and then just becomes the pain for anybody else.

The fix for this is really just to not use `localhost:XXXX`.  If you just lookup the containers IP from `docker inspect` and do CONTAINER_IP:3306 then it won't use the `docker-proxy`.  I think if you even use the hosts local IP (whatever is on eth0) it ends up bypassing the proxy too.