### PR TITLE
Run host label sync on host.activate not create

### DIFF
--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/host/HostLabelReconcile.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/host/HostLabelReconcile.java
@@ -22,7 +22,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 @Named
-public class HostCreateUpdate extends AbstractObjectProcessHandler implements Priority {
+public class HostLabelReconcile extends AbstractObjectProcessHandler implements Priority {
 
     @Inject
     GenericMapDao mapDao;
@@ -35,7 +35,7 @@ public class HostCreateUpdate extends AbstractObjectProcessHandler implements Pr
 
     @Override
     public String[] getProcessNames() {
-        return new String[] { HostConstants.PROCESS_CREATE, HostConstants.PROCESS_UPDATE };
+        return new String[] { HostConstants.PROCESS_ACTIVATE, HostConstants.PROCESS_UPDATE };
     }
 
     @Override


### PR DESCRIPTION
This allows labels to sync up properly for go-machine-service created
hosts, where the create and activate process are disjointed.

addresses https://github.com/rancher/rancher/issues/6379