### PR TITLE
Allow host resource fields on create

### DIFF
--- a/code/iaas/agent-server/src/main/java/io/cattle/platform/agent/server/resource/impl/AgentResourcesMonitor.java
+++ b/code/iaas/agent-server/src/main/java/io/cattle/platform/agent/server/resource/impl/AgentResourcesMonitor.java
@@ -263,6 +263,8 @@ public class AgentResourcesMonitor implements AnnotatedEventListener {
                     if (memory != null) {
                         updates.put(HostConstants.FIELD_MEMORY, memory);
                     }
+                } else {
+                    updates.remove(HostConstants.FIELD_MEMORY);
                 }
 
                 if (host.getMilliCpu() == null) {
@@ -270,6 +272,8 @@ public class AgentResourcesMonitor implements AnnotatedEventListener {
                     if (cpu != null) {
                         updates.put(HostConstants.FIELD_MILLI_CPU, cpu);
                     }
+                } else {
+                    updates.remove(HostConstants.FIELD_MILLI_CPU);
                 }
 
                 if (host.getLocalStorageMb() == null) {
@@ -277,6 +281,8 @@ public class AgentResourcesMonitor implements AnnotatedEventListener {
                     if (storage != null) {
                         updates.put(HostConstants.FIELD_LOCAL_STORAGE_MB, storage);
                     }
+                } else {
+                    updates.remove(HostConstants.FIELD_LOCAL_STORAGE_MB);
                 }
 
                 if (updates.size() > 0) {

--- a/code/implementation/simulator/agent-connection/src/main/java/io/cattle/platform/agent/connection/simulator/impl/SimulatorPingProcessor.java
+++ b/code/implementation/simulator/agent-connection/src/main/java/io/cattle/platform/agent/connection/simulator/impl/SimulatorPingProcessor.java
@@ -2,6 +2,7 @@ package io.cattle.platform.agent.connection.simulator.impl;
 
 import io.cattle.platform.agent.connection.simulator.AgentConnectionSimulator;
 import io.cattle.platform.agent.connection.simulator.AgentSimulatorEventProcessor;
+import io.cattle.platform.core.constants.HostConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
 import io.cattle.platform.core.model.Agent;
 import io.cattle.platform.eventing.model.Event;
@@ -108,6 +109,24 @@ public class SimulatorPingProcessor implements AgentSimulatorEventProcessor {
             host.put(ObjectMetaDataManager.KIND_FIELD, "sim");
             host.put(ObjectMetaDataManager.TYPE_FIELD, "host");
             host.put(ObjectMetaDataManager.NAME_FIELD, "testhost-" + io.cattle.platform.util.resource.UUID.randomUUID());
+
+            Long cpu = DataAccessor.fromDataFieldOf(agent).withScope(AgentConnectionSimulator.class)
+                    .withKey(HostConstants.FIELD_MILLI_CPU).as(jsonMapper, Long.class);
+            if (cpu != null) {
+                host.put(HostConstants.FIELD_MILLI_CPU, cpu);
+            }
+
+            Long mem = DataAccessor.fromDataFieldOf(agent).withScope(AgentConnectionSimulator.class)
+                    .withKey(HostConstants.FIELD_MEMORY).as(jsonMapper, Long.class);
+            if (mem != null) {
+                host.put(HostConstants.FIELD_MEMORY, mem);
+            }
+
+            Long storage = DataAccessor.fromDataFieldOf(agent).withScope(AgentConnectionSimulator.class)
+                    .withKey(HostConstants.FIELD_LOCAL_STORAGE_MB).as(jsonMapper, Long.class);
+            if (storage != null) {
+                host.put(HostConstants.FIELD_LOCAL_STORAGE_MB, storage);
+            }
 
             if (addPhysicalHost) {
                 host.put("physicalHostUuid", physicalHostUuid);

--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -266,9 +266,9 @@
         "host.publicEndpoints" : "r",
         "host.agentIpAddress" : "r",
         "host.instanceIds" : "r",
-        "host.localStorageMb" : "ru",
-        "host.memory" : "ru",
-        "host.milliCpu" : "ru",
+        "host.localStorageMb" : "cru",
+        "host.memory" : "cru",
+        "host.milliCpu" : "cru",
 
         "addLabelInput" : "cr",
         "addLabelInput.key" : "cr",

--- a/tests/integration/cattletest/core/test_machines.py
+++ b/tests/integration/cattletest/core/test_machines.py
@@ -406,21 +406,53 @@ def machine_context(admin_user_client, service_client,  # NOQA
 
 
 @pytest.mark.nonparallel
+def test_host_resource_field_overrides(super_client, machine_context,
+                                       update_ping_settings):
+    client = machine_context.client
+    name = random_str()
+    host = client.create_host(hostname=name, fooConfig={}, milliCpu=1200,
+                              memory=2200, localStorageMb=3200)
+    agent, host, machine = register_host_through_agent(client, host,
+                                                       machine_context,
+                                                       super_client)
+    assert host.milliCpu == 1200
+    assert host.memory == 2200
+    assert host.localStorageMb == 3200
+
+
+@pytest.mark.nonparallel
 def test_host_lifecycle(super_client, machine_context, update_ping_settings):
     client = machine_context.client
     name = random_str()
     host = client.create_host(hostname=name, fooConfig={})
+    agent, host, machine = register_host_through_agent(client, host,
+                                                       machine_context,
+                                                       super_client)
+    assert host.physicalHostId == machine.id
+    assert host.agentId == agent.id
+    assert host.agentId == machine.agentId
+    assert host.data.fields.reportedUuid == machine.externalId
+    assert host.milliCpu == 1000
+    assert host.memory == 2000
+    assert host.localStorageMb == 3000
+    assert machine.name == name
+
+    host = machine_context.client.wait_success(host.deactivate())
+    host = machine_context.client.wait_success(host.remove())
+    assert host.state == 'removed'
+    machine = machine_context.client.wait_success(machine)
+    assert machine.state == 'removed'
+
+
+def register_host_through_agent(client, host, machine_context, super_client):
     host = wait_for_condition(client, host,
                               lambda x: x.physicalHostId is not None)
     machine = host.physicalHost()
     machine = machine_context.client.wait_success(machine)
-
     assert machine.state == 'active'
     assert machine.fooConfig is not None
-
     external_id = super_client.reload(machine).externalId
     assert external_id is not None
-
     # Create an agent with the externalId specified. The agent simulator will
     # mimic how the go-machine-service would use this external_id to bootstrap
     # an agent onto the physical host with the proper PHYSICAL_HOST_UUID set.
@@ -433,53 +465,39 @@ def test_host_lifecycle(super_client, machine_context, update_ping_settings):
     account_id = get_plain_id(super_client, machine_context.project)
     data[scope]['agentResourcesAccountId'] = account_id
     data['agentResourcesAccountId'] = account_id
-
+    # Set host resource fields
+    data[scope]['milliCpu'] = 1000
+    data[scope]['memory'] = 2000
+    data[scope]['localStorageMb'] = 3000
     agent = super_client.create_agent(uri=uri, data=data)
     agent = super_client.wait_success(agent)
-
     wait_for(lambda: len(agent.hosts()) == 1)
     hosts = agent.hosts()
-
     assert len(hosts) == 1
     host = hosts[0].physicalHost()
     assert host.kind == 'machine'
     assert machine.accountId == host.accountId
     assert machine.uuid == host.uuid
-
     # Need to force a ping because they cause physical hosts to be created
     # under non-machine use cases. Ensures the machine isnt overridden
     ping = one(super_client.list_task, name='agent.ping')
     ping.execute()
     time.sleep(.1)  # The ping needs time to execute
-
     agent = super_client.reload(agent)
     hosts = agent.hosts()
     assert len(hosts) == 1
     host = hosts[0]
     physical_hosts = host.physicalHost()
     assert physical_hosts.id == machine.id
-
     machine = machine_context.client.wait_success(machine)
     host = machine_context.client.wait_success(host)
-
     agent = super_client.wait_success(agent)
     assert agent.state == 'active'
-
     host = machine_context.client.wait_success(machine_context
                                                .client.reload(host))
     host = super_client.reload(host)
     machine = super_client.reload(machine)
-    assert host.physicalHostId == machine.id
-    assert host.agentId == agent.id
-    assert host.agentId == machine.agentId
-    assert host.data.fields.reportedUuid == machine.externalId
-    assert machine.name == name
-
-    host = machine_context.client.wait_success(host.deactivate())
-    host = machine_context.client.wait_success(host.remove())
-    assert host.state == 'removed'
-    machine = machine_context.client.wait_success(machine)
-    assert machine.state == 'removed'
+    return agent, host, machine
 
 
 @pytest.mark.nonparallel


### PR DESCRIPTION
This lets the user set the milliCpu, localStorageMb, and memory fields
when creating a host via our machine integration.

The current agent backpopulate logic copies ALL fields over on the
first sync. So, this change also makes sure the relevant fields are removed
from the update map if they are already set on the host.