### PR TITLE
Fix for instance.restore/selector based service

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
@@ -30,6 +30,7 @@ import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.Network;
 import io.cattle.platform.core.model.Service;
 import io.cattle.platform.core.model.ServiceConsumeMap;
+import io.cattle.platform.core.model.ServiceExposeMap;
 import io.cattle.platform.core.model.ServiceIndex;
 import io.cattle.platform.core.model.Stack;
 import io.cattle.platform.core.model.Subnet;
@@ -426,7 +427,8 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
 
     @Override
     public boolean isServiceInstance(Service service, Instance instance) {
-        return exposeMapDao.getServiceInstanceMap(service, instance) != null;
+        ServiceExposeMap map = exposeMapDao.getServiceInstanceMap(service, instance);
+        return map != null && !map.getState().equalsIgnoreCase(CommonStatesConstants.REMOVING);
     }
 
     @Override


### PR DESCRIPTION
An attempt to fix test_service_add_instance_selector, instance.restore case: https://drone.rancher.io/rancher/cattle/1270/3