### PR TITLE
Set resourceId on scheduling events

### DIFF
--- a/code/iaas/simple-allocator/src/main/java/io/cattle/platform/simple/allocator/SimpleAllocator.java
+++ b/code/iaas/simple-allocator/src/main/java/io/cattle/platform/simple/allocator/SimpleAllocator.java
@@ -239,7 +239,7 @@ public class SimpleAllocator extends AbstractAllocator implements Allocator, Nam
             return null;
         }
 
-        return newEvent(SCHEDULER_RELEASE_EVENT, resourceRequests);
+        return newEvent(SCHEDULER_RELEASE_EVENT, resourceRequests, resource.getClass().getSimpleName(), ObjectUtils.getId(resource));
     }
 
     EventVO<Map<String, Object>> buildEvent(String eventName, AllocationAttempt attempt) {
@@ -248,16 +248,17 @@ public class SimpleAllocator extends AbstractAllocator implements Allocator, Nam
             return null;
         }
 
-        return newEvent(eventName, resourceRequests);
+        return newEvent(eventName, resourceRequests, "instance", attempt.getInstances().get(0).getId());
     }
 
-    EventVO<Map<String, Object>> newEvent(String eventName, List<ResourceRequest> resourceRequests) {
+    EventVO<Map<String, Object>> newEvent(String eventName, List<ResourceRequest> resourceRequests, String resourceType, Object resourceId) {
         Map<String, Object> eventData = new HashMap<String, Object>();
         Map<String, Object> reqData = new HashMap<>();
         reqData.put(RESOURCE_REQUESTS, resourceRequests);
         eventData.put(SCHEDULER_REQUEST_DATA_NAME, reqData);
         EventVO<Map<String, Object>> schedulerEvent = EventVO.<Map<String, Object>> newEvent(eventName).withData(eventData);
-        schedulerEvent.setResourceType(SCHEDULER_REQUEST_DATA_NAME);
+        schedulerEvent.setResourceType(resourceType);
+        schedulerEvent.setResourceId(resourceId.toString());
         return schedulerEvent;
     }
 


### PR DESCRIPTION
Without it set, the event framework in the scheduler was locking on ""
and thus all events were locking on the same key and causing events to
drop.

Changed how resouceType because it impacts the actual id in the event
because it is transformed into obfuscated form
(i<resourceType abbreviation><id>).