### PR TITLE
project upgrade action should be available for project owners/admins only

### DIFF
--- a/resources/content/schema/base/project.json
+++ b/resources/content/schema/base/project.json
@@ -22,6 +22,11 @@
         "capability" : "owner"
       }
     },
+    "upgrade" : {
+      "attributes" : {
+        "capability" : "owner"
+      }
+    },
     "delete" : {
       "attributes" : {
         "capability" : "owner"


### PR DESCRIPTION
Added the capability to do project upgrade for owner only. 
Admins can also upgrade any project.

https://github.com/rancher/rancher/issues/6684