### PR TITLE
removed unneeded check + selector container/link queries optimization

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/SelectorInstancePostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/SelectorInstancePostListener.java
@@ -1,6 +1,6 @@
 package io.cattle.platform.servicediscovery.process;
 
-import static io.cattle.platform.core.model.tables.ServiceTable.SERVICE;
+import static io.cattle.platform.core.model.tables.ServiceTable.*;
 import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
 import io.cattle.platform.core.model.Instance;
@@ -18,6 +18,8 @@ import io.cattle.platform.servicediscovery.api.dao.ServiceExposeMapDao;
 import io.cattle.platform.servicediscovery.deployment.impl.lock.ServiceInstanceLock;
 import io.cattle.platform.servicediscovery.service.ServiceDiscoveryService;
 import io.cattle.platform.util.type.Priority;
+import io.github.ibuildthecloud.gdapi.condition.Condition;
+import io.github.ibuildthecloud.gdapi.condition.ConditionType;
 
 import java.util.List;
 
@@ -43,7 +45,7 @@ public class SelectorInstancePostListener extends AbstractObjectProcessLogic imp
     public HandlerResult handle(ProcessState state, ProcessInstance process) {
         final Instance instance = (Instance) state.getResource();
         List<Service> services = objectManager.find(Service.class, SERVICE.ACCOUNT_ID, instance.getAccountId(),
-                SERVICE.REMOVED, null);
+                SERVICE.REMOVED, null, SERVICE.SELECTOR_CONTAINER, new Condition(ConditionType.NOTNULL));
 
         for (final Service service : services) {
             if (sdService.isSelectorContainerMatch(service.getSelectorContainer(), instance)) {

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/SelectorInstancePostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/SelectorInstancePostListener.java
@@ -46,9 +46,6 @@ public class SelectorInstancePostListener extends AbstractObjectProcessLogic imp
                 SERVICE.REMOVED, null);
 
         for (final Service service : services) {
-            if (sdService.isServiceInstance(service, instance)) {
-                continue;
-            }
             if (sdService.isSelectorContainerMatch(service.getSelectorContainer(), instance)) {
                 lockManager.lock(new ServiceInstanceLock(service, instance), new LockCallbackNoReturn() {
                     @Override

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/SelectorServiceCreatePostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/SelectorServiceCreatePostListener.java
@@ -31,6 +31,8 @@ import javax.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.google.common.base.Strings;
+
 public class SelectorServiceCreatePostListener extends AbstractObjectProcessLogic implements ProcessPostListener,
         Priority {
 
@@ -120,6 +122,9 @@ public class SelectorServiceCreatePostListener extends AbstractObjectProcessLogi
     }
 
     protected void registerInstances(final Service service) {
+        if (Strings.isNullOrEmpty(service.getSelectorContainer())) {
+            return;
+        }
         List<Instance> instances = objectManager.find(Instance.class, INSTANCE.ACCOUNT_ID, service.getAccountId(),
                 INSTANCE.REMOVED, null);
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/ServiceDiscoveryService.java
@@ -35,8 +35,6 @@ public interface ServiceDiscoveryService extends AnnotatedEventListener {
 
     boolean isSelectorContainerMatch(String selector, Instance instance);
 
-    boolean isServiceInstance(Service service, Instance instance);
-
     List<String> getServiceActiveStates();
 
     boolean isGlobalService(Service service);

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/service/impl/ServiceDiscoveryServiceImpl.java
@@ -4,7 +4,6 @@ import static io.cattle.platform.core.model.tables.ServiceIndexTable.*;
 import static io.cattle.platform.core.model.tables.ServiceTable.*;
 import static io.cattle.platform.core.model.tables.StackTable.*;
 import static io.cattle.platform.core.model.tables.SubnetTable.*;
-
 import io.cattle.platform.allocator.service.AllocatorService;
 import io.cattle.platform.configitem.events.ConfigUpdate;
 import io.cattle.platform.configitem.model.Client;
@@ -31,7 +30,6 @@ import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.core.model.Network;
 import io.cattle.platform.core.model.Service;
 import io.cattle.platform.core.model.ServiceConsumeMap;
-import io.cattle.platform.core.model.ServiceExposeMap;
 import io.cattle.platform.core.model.ServiceIndex;
 import io.cattle.platform.core.model.Stack;
 import io.cattle.platform.core.model.Subnet;
@@ -424,12 +422,6 @@ public class ServiceDiscoveryServiceImpl implements ServiceDiscoveryService {
         }
 
         return SelectorUtils.isSelectorMatch(selector, instanceLabels);
-    }
-
-    @Override
-    public boolean isServiceInstance(Service service, Instance instance) {
-        ServiceExposeMap map = exposeMapDao.getServiceInstanceMap(service, instance);
-        return map != null && !map.getState().equalsIgnoreCase(CommonStatesConstants.REMOVING);
     }
 
     @Override


### PR DESCRIPTION
this check is not needed as underlying exposeMapDao.createServiceInstanceMap(service, instance, false) will check if the instance->service map already exists