### PR TITLE
Fix bug reading data fields instead of column

### DIFF
--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceStart.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/instance/InstanceStart.java
@@ -192,7 +192,7 @@ public class InstanceStart extends AbstractDefaultProcessHandler {
 
     protected void waitForDependenciesStart(Instance instance) {
         List<Long> instancesIds = DataAccessor.fieldLongList(instance, DockerInstanceConstants.FIELD_VOLUMES_FROM);
-        Long networkFromId = DataAccessor.fieldLong(instance, DockerInstanceConstants.FIELD_NETWORK_CONTAINER_ID);
+        Long networkFromId = instance.getNetworkContainerId();
         if (networkFromId != null) {
             instancesIds.add(networkFromId);
         }


### PR DESCRIPTION
The end result of this is that the instance dependency wait logic would never actually work for `--net=container:foo` because we were reading the `networkContainerId` from the wrong place.