### PR TITLE
Remove service instance on failed start

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/DeploymentUnitInstance.java
@@ -57,6 +57,8 @@ public abstract class DeploymentUnitInstance {
 
     protected abstract void removeUnitInstance();
 
+    public abstract boolean isTransitioning();
+
     public abstract void stop();
 
     protected DeploymentUnitInstance(DeploymentServiceContext context, String uuid, Service service,

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentManagerImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/DeploymentManagerImpl.java
@@ -23,6 +23,7 @@ import io.cattle.platform.lock.LockCallbackNoReturn;
 import io.cattle.platform.lock.LockManager;
 import io.cattle.platform.lock.definition.LockDefinition;
 import io.cattle.platform.object.ObjectManager;
+import io.cattle.platform.object.meta.ObjectMetaDataManager;
 import io.cattle.platform.object.process.ObjectProcessManager;
 import io.cattle.platform.object.process.StandardProcess;
 import io.cattle.platform.object.resource.ResourceMonitor;
@@ -92,6 +93,8 @@ public class DeploymentManagerImpl implements DeploymentManager {
     ActivityService actvtyService;
     @Inject
     GenericResourceDao rscDao;
+    @Inject
+    ObjectMetaDataManager objMetaDataMgr;
 
     @Override
     public boolean isHealthy(Service service) {
@@ -464,5 +467,6 @@ public class DeploymentManagerImpl implements DeploymentManager {
         final public IdFormatter idFormatter = idFrmt;
         final public LockManager lockMgr = lockManager;
         final public GenericResourceDao resourceDao = rscDao;
+        final public ObjectMetaDataManager objectMetaDataManager = objMetaDataMgr;
     }
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/DefaultDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/DefaultDeploymentUnitInstance.java
@@ -266,7 +266,6 @@ public class DefaultDeploymentUnitInstance extends DeploymentUnitInstance implem
 
     @Override
     public void waitForAllocate() {
-
         try {
             if (this.instance != null) {
                 if (context.objectManager.find(InstanceHostMap.class, INSTANCE_HOST_MAP.INSTANCE_ID,
@@ -378,6 +377,14 @@ public class DefaultDeploymentUnitInstance extends DeploymentUnitInstance implem
             context.objectProcessManager.scheduleStandardProcessAsync(StandardProcess.CREATE, exposeMap,
                     null);
         }
+    }
+
+    @Override
+    public boolean isTransitioning() {
+        if (this.instance == null) {
+            return false;
+        }
+        return context.objectMetaDataManager.isTransitioningState(Instance.class, this.instance.getState());
     }
 }
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/ExternalDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/ExternalDeploymentUnitInstance.java
@@ -152,4 +152,9 @@ public class ExternalDeploymentUnitInstance extends DeploymentUnitInstance {
     public void scheduleCreate() {
         return;
     }
+
+    @Override
+    public boolean isTransitioning() {
+        return false;
+    }
 }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/6803

"stop" container.events are coming for managed containers from host that is going down (wasn't the case before, but it's ok). So the containers are marked as stopped, then service.reconcile tries to start them again, on the same host, and it is stuck in Starting state forever. 

Changed instance.start to remove the container that fails to start, if it is a service container. That is to give service.reconcile a chance to recreate this container on another available non-disconnected host.

@ibuildthecloud let me know if you think it makes sense