### PR TITLE
Provide access and secret keys when getting client

### DIFF
--- a/tests/integration/cattletest/core/test_local_auth.py
+++ b/tests/integration/cattletest/core/test_local_auth.py
@@ -31,7 +31,8 @@ def turn_on_off_local_auth(request, admin_user_client):
         admin_user_client.create_localAuthConfig(enabled=None,
                                                  username=username,
                                                  password=password)
-        assert from_env().valid()
+        # Proves auth is off because keys are invalid and would be reject
+        assert from_env(access_key='bad_key', secret_key='bad_key2').valid()
 
     request.addfinalizer(fin)
 


### PR DESCRIPTION
This fin() method started erroring out because when no keys are found
in the environment variables, a tuple with two None values are passed
to the requests library.

I don't know how this ever worked. My best guess is that up until now,
CATTLE_ACCESS_KEY and CATTLE_SECRET_KEY were being found as env vars
and being used.

This change is actually a better test of auth being off because we
don't want previously valid keys to be used when affirming that auth
has been switched off.