### PR TITLE
validate scale on service.update

### DIFF
--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceCreateValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceCreateValidationFilter.java
@@ -364,6 +364,24 @@ public class ServiceCreateValidationFilter extends AbstractDefaultResourceManage
         List<Map<String, Object>> launchConfigs = populateLaunchConfigs(service, request);
         validateLaunchConfigNames(service, serviceName, launchConfigs);
         validateLaunchConfigsCircularRefs(service, serviceName, launchConfigs);
+        validateLaunchConfigScale(service, request);
+    }
+
+    protected void validateLaunchConfigScale(Service service, ApiRequest request) {
+        Map<String, Object> data = CollectionUtils.toMap(request.getRequestObject());
+        Object newLaunchConfig = data.get(ServiceConstants.FIELD_LAUNCH_CONFIG);
+        if (newLaunchConfig == null) {
+            return;
+        }
+
+        Object launchConfig = DataAccessor.field(service, ServiceConstants.FIELD_LAUNCH_CONFIG,
+                Object.class);
+
+        if (launchConfig == null) {
+            return;
+        }
+
+        ServiceDiscoveryUtil.validateScaleSwitch(newLaunchConfig, launchConfig);
     }
 
 

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/util/ServiceDiscoveryUtil.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/util/ServiceDiscoveryUtil.java
@@ -18,6 +18,7 @@ import io.cattle.platform.object.util.DataAccessor;
 import io.cattle.platform.object.util.DataUtils;
 import io.cattle.platform.servicediscovery.api.resource.ServiceDiscoveryConfigItem;
 import io.cattle.platform.util.type.CollectionUtils;
+import io.github.ibuildthecloud.gdapi.validation.ValidationErrorCodes;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -432,5 +433,26 @@ public class ServiceDiscoveryUtil {
             healthCheck.setResponseTimeout(2000);
             launchConfig.put(InstanceConstants.FIELD_HEALTH_CHECK, healthCheck);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static void validateScaleSwitch(Object newLaunchConfig, Object currentLaunchConfig) {
+        if (isGlobalService((Map<Object, Object>) currentLaunchConfig) != isGlobalService((Map<Object, Object>) newLaunchConfig)) {
+            ValidationErrorCodes.throwValidationError(ValidationErrorCodes.INVALID_OPTION,
+                    "Switching from global scale to fixed (and vice versa)");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    protected static boolean isGlobalService(Map<Object, Object> launchConfig) {
+        // set labels
+        Object labelsObj = launchConfig.get(InstanceConstants.FIELD_LABELS);
+        if (labelsObj == null) {
+            return false;
+
+        }
+        Map<String, String> labels = (Map<String, String>) labelsObj;
+        String globalService = labels.get(ServiceConstants.LABEL_SERVICE_GLOBAL);
+        return Boolean.valueOf(globalService);
     }
 }


### PR DESCRIPTION
allowing to update service.launchConfig.ports lets user update other launch config fields like labels (there seem to be no way to disable update for embedded fields of launchConfig). For now, added a check for scale validation on the update (global scale is passed via service.launchConfig.labels). We should think on how to disable it in the future.

https://github.com/rancher/rancher/issues/6812