### PR TITLE
network.hostPorts to false by default

### DIFF
--- a/resources/content/schema/base/network.json
+++ b/resources/content/schema/base/network.json
@@ -14,7 +14,6 @@
         },
         "hostPorts": {
             "type" : "boolean",
-            "default" : "true",
             "nullable": false
         },
         "networkDriverId": {


### PR DESCRIPTION
@ibuildthecloud @joshwget 

I've checked that it is being explicitly passed as "true" in both ipsec and vxlan templates. @ibuildthecloud point if there are any other templates where this flag has to be defined. 