### PR TITLE
Fix a potential blocking issue if executor under water

### DIFF
--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/identity/IdentityManager.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/identity/IdentityManager.java
@@ -26,6 +26,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import javax.inject.Inject;
 import org.apache.cloudstack.managed.context.ManagedContext;
@@ -79,12 +81,12 @@ public class IdentityManager extends AbstractNoOpResourceManager {
      * make N requests one for each Passed in identity.
      */
     private List<Identity> refreshIdentities(final Set<Identity> identities) {
-        final Collection<Callable<Identity>> identitiesToGet = new ArrayList<>();
+        final Collection<Future<Identity>> identitiesToGet = new ArrayList<>();
         final List<Identity> identitiesToReturn = new ArrayList<>();
         final ApiContext context = ApiContext.getContext();
         final ManagedContext managedContext = new DefaultManagedContext();
         for (final Identity identity : identities) {
-            identitiesToGet.add(new Callable<Identity>() {
+            identitiesToGet.add(executorService.submit(new Callable<Identity>() {
                 @Override
                 public Identity call() throws Exception {
                     try {
@@ -100,15 +102,18 @@ public class IdentityManager extends AbstractNoOpResourceManager {
                         return null;
                     }
                 }
-            });
+            }));
 
         }
         try {
-            for (Future<Identity> future:executorService.invokeAll(identitiesToGet)){
-                Identity newIdentity = future.get();
+            for (Future<Identity> future : identitiesToGet) {
+                Identity newIdentity = future.get(10, TimeUnit.SECONDS);
                 authorize(newIdentity);
                 identitiesToReturn.add(newIdentity);
             }
+        } catch (TimeoutException e) {
+            logger.error("Timeout when getting an identities.", e);
+            throw new RuntimeException(e);
         } catch (InterruptedException e) {
             logger.error("Interrupted when getting and Identities.", e);
             throw new RuntimeException(e);


### PR DESCRIPTION
I got a issue if a docker service on a host restart or if some services (rancher/scheduler  ? other rancher service ) die / restart.

UI is then not responding ( the endpoint /v2-beta/identities  is not responding).  

I detected that it come from IdentityManager linked to the fact that the executor is under water (process 10 task when it receives 20 more...).  
To be able to access the UI, I fixed the IdentityManager not to wait for refresh issue.

This is related to https://github.com/rancher/rancher/issues/6995 
