### PR TITLE
Revert "Noop deployment unit when image is rancher/none

### DIFF
--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/SelectorServiceCreateValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/SelectorServiceCreateValidationFilter.java
@@ -5,7 +5,6 @@ import io.cattle.platform.core.constants.ServiceConstants;
 import io.cattle.platform.core.model.Service;
 import io.cattle.platform.iaas.api.filter.common.AbstractDefaultResourceManagerFilter;
 import io.cattle.platform.object.ObjectManager;
-import io.cattle.platform.servicediscovery.api.util.ServiceDiscoveryUtil;
 import io.cattle.platform.util.type.CollectionUtils;
 import io.github.ibuildthecloud.gdapi.exception.ValidationErrorException;
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
@@ -49,8 +48,8 @@ public class SelectorServiceCreateValidationFilter extends AbstractDefaultResour
 
     protected void validateImage(Map<String, Object> primaryLaunchConfig, boolean isSelector) {
         if (!isSelector && primaryLaunchConfig != null) {
-            Object imageUuid = primaryLaunchConfig.get(InstanceConstants.FIELD_IMAGE_UUID);
-            if (ServiceDiscoveryUtil.isNoopImage(imageUuid)) {
+            Object image = primaryLaunchConfig.get(InstanceConstants.FIELD_IMAGE_UUID);
+            if (image == null || image.toString().equalsIgnoreCase(ServiceConstants.IMAGE_NONE)) {
                 throw new ValidationErrorException(ValidationErrorCodes.INVALID_OPTION,
                         "Image is required when " + ServiceConstants.FIELD_SELECTOR_CONTAINER
                                 + " is not passed in");

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceCreateValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceCreateValidationFilter.java
@@ -291,7 +291,7 @@ public class ServiceCreateValidationFilter extends AbstractDefaultResourceManage
             Map<String, Object> launchConfig = (Map<String, Object>)data.get(ServiceConstants.FIELD_LAUNCH_CONFIG);
             if (launchConfig.get(InstanceConstants.FIELD_IMAGE_UUID) != null) {
                 Object imageUuid = launchConfig.get(InstanceConstants.FIELD_IMAGE_UUID);
-                if (!ServiceDiscoveryUtil.isNoopImage(imageUuid)) {
+                if (imageUuid != null && !imageUuid.toString().equalsIgnoreCase(ServiceConstants.IMAGE_NONE)) {
                     String fullImageName = ExternalTemplateInstanceFilter.getImageUuid(imageUuid.toString(), storageService);
                     launchConfig.put(InstanceConstants.FIELD_IMAGE_UUID, fullImageName);
                     data.put(ServiceConstants.FIELD_LAUNCH_CONFIG, launchConfig);
@@ -311,7 +311,7 @@ public class ServiceCreateValidationFilter extends AbstractDefaultResourceManage
                 Map<String, Object> slc = (Map<String, Object>) slcObj;
                 if (slc.get(InstanceConstants.FIELD_IMAGE_UUID) != null) {
                     Object imageUuid = slc.get(InstanceConstants.FIELD_IMAGE_UUID);
-                    if (imageUuid != null && !ServiceDiscoveryUtil.isNoopImage(imageUuid.toString())) {
+                    if (imageUuid != null && !imageUuid.toString().equalsIgnoreCase(ServiceConstants.IMAGE_NONE)) {
                         String fullImageName = ExternalTemplateInstanceFilter.getImageUuid(imageUuid.toString(), storageService);
                         slc.put(InstanceConstants.FIELD_IMAGE_UUID, fullImageName);
                     }

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceUpgradeValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/ServiceUpgradeValidationFilter.java
@@ -196,7 +196,7 @@ public class ServiceUpgradeValidationFilter extends AbstractDefaultResourceManag
             }
 
             if (service.getSelectorContainer() == null
-                    && ServiceDiscoveryUtil.isNoopImage(imageUuid)) {
+                    && StringUtils.equalsIgnoreCase(ServiceConstants.IMAGE_NONE, imageUuid.toString())) {
                 it.remove();
             }
             else {

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/util/ServiceDiscoveryUtil.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/util/ServiceDiscoveryUtil.java
@@ -315,11 +315,9 @@ public class ServiceDiscoveryUtil {
         Object imageUUID = ServiceDiscoveryUtil.getLaunchConfigDataAsMap(service,
                 ServiceConstants.PRIMARY_LAUNCH_CONFIG_NAME).get(
                 InstanceConstants.FIELD_IMAGE_UUID);
-        return isNoopImage(imageUUID);
-    }
-
-    public static boolean isNoopImage(Object imageUUID) {
-        return imageUUID == null || ServiceConstants.IMAGE_NONE.equals(imageUUID);
+        return service.getSelectorContainer() != null
+                && (imageUUID == null || imageUUID.toString().toLowerCase()
+                        .contains(ServiceConstants.IMAGE_NONE));
     }
 
     public static void upgradeServiceConfigs(Service service, InServiceUpgradeStrategy strategy, boolean rollback) {

--- a/tests/integration-v1/cattletest/core/test_svc_selectors.py
+++ b/tests/integration-v1/cattletest/core/test_svc_selectors.py
@@ -153,7 +153,7 @@ def test_service_mixed_selector_based_wo_image(client, context):
     container1 = client.wait_success(container1)
     assert container1.state == "running"
 
-    launch_config = {"imageUuid": "rancher/none"}
+    launch_config = {"imageUuid": "sim:rancher/none:latest"}
     service = client.create_service(name=random_str(),
                                     environmentId=env.id,
                                     launchConfig=launch_config,

--- a/tests/integration-v1/cattletest/core/test_svc_upgrade.py
+++ b/tests/integration-v1/cattletest/core/test_svc_upgrade.py
@@ -90,26 +90,21 @@ def test_in_service_upgrade_primary(context, client, super_client):
 
 
 def test_in_service_upgrade_inactive(context, client, super_client):
-    lc = {'labels': {'foo': "bar"}, 'imageUuid': context.image_uuid}
     env, svc, up_svc = _insvc_upgrade(context,
                                       client, super_client, True,
                                       activate=False,
-                                      launchConfig=lc,
+                                      launchConfig={'labels': {'foo': "bar"}},
                                       startFirst=True)
     _validate_upgrade(super_client, svc, up_svc, primary='1',
                       secondary1='0', secondary2='0')
 
 
 def test_in_service_upgrade_all(context, client, super_client):
-    image_uuid = context.image_uuid
-    secondary = [{'name': "secondary1", 'labels': {'foo': "bar"},
-                  'imageUuid': image_uuid},
-                 {'name': "secondary2", 'labels': {'foo': "bar"},
-                  'imageUuid': image_uuid}]
-    lc = {'labels': {'foo': "bar"}, 'imageUuid': image_uuid}
+    secondary = [{'name': "secondary1", 'labels': {'foo': "bar"}},
+                 {'name': "secondary2", 'labels': {'foo': "bar"}}]
     env, svc, up_svc = _insvc_upgrade(context, client,
                                       super_client, True,
-                                      launchConfig=lc,
+                                      launchConfig={'labels': {'foo': "bar"}},
                                       secondaryLaunchConfigs=secondary,
                                       batchSize=3,
                                       intervalMillis=100)
@@ -118,8 +113,7 @@ def test_in_service_upgrade_all(context, client, super_client):
 
 
 def test_in_service_upgrade_one_secondary(context, client, super_client):
-    secondary = [{'name': "secondary1", 'labels': {'foo': "bar"},
-                  'imageUuid': context.image_uuid}]
+    secondary = [{'name': "secondary1", 'labels': {'foo': "bar"}}]
     env, svc, upgraded_svc = _insvc_upgrade(context, client,
                                             super_client, True,
                                             secondaryLaunchConfigs=secondary,
@@ -130,8 +124,7 @@ def test_in_service_upgrade_one_secondary(context, client, super_client):
 
 
 def test_in_service_upgrade_mix(context, client, super_client):
-    secondary = [{'name': "secondary1", 'labels': {'foo': "bar"},
-                  'imageUuid': context.image_uuid}]
+    secondary = [{'name': "secondary1", 'labels': {'foo': "bar"}}]
     env, svc, up_svc = _insvc_upgrade(context, client, super_client, True,
                                       launchConfig={'labels': {'foo': "bar"}},
                                       secondaryLaunchConfigs=secondary,

--- a/tests/integration/cattletest/core/test_svc_selectors.py
+++ b/tests/integration/cattletest/core/test_svc_selectors.py
@@ -158,7 +158,7 @@ def _create_stack(client):
     return env
 
 
-def test_service_mixed_selector_based_wo_image(client, context):
+def test_service_mixed_selector_based_wo_image(client, context, super_client):
     env = _create_stack(client)
     image_uuid = context.image_uuid
 
@@ -169,7 +169,7 @@ def test_service_mixed_selector_based_wo_image(client, context):
     container1 = client.wait_success(container1)
     assert container1.state == "running"
 
-    launch_config = {"imageUuid": "rancher/none"}
+    launch_config = {"imageUuid": "sim:rancher/none:latest"}
     service = client.create_service(name=random_str(),
                                     stackId=env.id,
                                     launchConfig=launch_config,

--- a/tests/integration/cattletest/core/test_svc_upgrade.py
+++ b/tests/integration/cattletest/core/test_svc_upgrade.py
@@ -90,26 +90,21 @@ def test_in_service_upgrade_primary(context, client, super_client):
 
 
 def test_in_service_upgrade_inactive(context, client, super_client):
-    lc = {'labels': {'foo': "bar"}, 'imageUuid': context.image_uuid}
     env, svc, up_svc = _insvc_upgrade(context,
                                       client, super_client, True,
                                       activate=False,
-                                      launchConfig=lc,
+                                      launchConfig={'labels': {'foo': "bar"}},
                                       startFirst=True)
     _validate_upgrade(super_client, svc, up_svc, primary='1',
                       secondary1='0', secondary2='0')
 
 
 def test_in_service_upgrade_all(context, client, super_client):
-    image_uuid = context.image_uuid
-    secondary = [{'name': "secondary1", 'labels': {'foo': "bar"},
-                  'imageUuid': image_uuid},
-                 {'name': "secondary2", 'labels': {'foo': "bar"},
-                  'imageUuid': image_uuid}]
-    lc = {'labels': {'foo': "bar"}, 'imageUuid': image_uuid}
+    secondary = [{'name': "secondary1", 'labels': {'foo': "bar"}},
+                 {'name': "secondary2", 'labels': {'foo': "bar"}}]
     env, svc, up_svc = _insvc_upgrade(context, client,
                                       super_client, True,
-                                      launchConfig=lc,
+                                      launchConfig={'labels': {'foo': "bar"}},
                                       secondaryLaunchConfigs=secondary,
                                       batchSize=3,
                                       intervalMillis=100)
@@ -118,8 +113,7 @@ def test_in_service_upgrade_all(context, client, super_client):
 
 
 def test_in_service_upgrade_one_secondary(context, client, super_client):
-    secondary = [{'name': "secondary1", 'labels': {'foo': "bar"},
-                  'imageUuid': context.image_uuid}]
+    secondary = [{'name': "secondary1", 'labels': {'foo': "bar"}}]
     env, svc, upgraded_svc = _insvc_upgrade(context, client,
                                             super_client, True,
                                             secondaryLaunchConfigs=secondary,
@@ -130,8 +124,7 @@ def test_in_service_upgrade_one_secondary(context, client, super_client):
 
 
 def test_in_service_upgrade_mix(context, client, super_client):
-    secondary = [{'name': "secondary1", 'labels': {'foo': "bar"},
-                  'imageUuid': context.image_uuid}]
+    secondary = [{'name': "secondary1", 'labels': {'foo': "bar"}}]
     env, svc, up_svc = _insvc_upgrade(context, client, super_client, True,
                                       launchConfig={'labels': {'foo': "bar"}},
                                       secondaryLaunchConfigs=secondary,


### PR DESCRIPTION
disregard container selector presence

This reverts commit e003df37653fcb245f960e2129a4c033750a866d.
https://github.com/rancher/rancher/issues/7097