### PR TITLE
Only allow include of a single resource

### DIFF
--- a/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/request/handler/ParseCollectionAttributes.java
+++ b/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/request/handler/ParseCollectionAttributes.java
@@ -54,7 +54,7 @@ public class ParseCollectionAttributes extends AbstractApiRequestHandler {
         }
 
         if (links.size() > 0) {
-            request.setInclude(new Include(links));
+            request.setInclude(new Include(links.subList(0, 1)));
         }
     }
 


### PR DESCRIPTION
Using multiple resources has a multiplicative effect, which can be
disastrous.