### PR TITLE
Increase memory pools for eclipse

### DIFF
--- a/tools/eclipse/Cattle.launch
+++ b/tools/eclipse/Cattle.launch
@@ -17,5 +17,5 @@
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="io.cattle.platform.launcher.Main"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="cattle-app"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-XX:MaxPermSize=64m&#10;-Xmx256m&#10;&#10;-DXdb.cattle.database=mysql&#10;-DXdb.cattle.mysql.name=cattle_base&#10;&#10;-Didempotent.checks=false&#10;-Dcattle.http.port=8080&#10;-Dlogback.log.dir=../../../runtime/eclipse/logs/&#10;-Ddb.cattle.home=../../../runtime/eclipse/db/"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-XX:MaxPermSize=256m&#10;-Xmx1024m&#10;&#10;-DXdb.cattle.database=mysql&#10;-DXdb.cattle.mysql.name=cattle_base&#10;&#10;-Didempotent.checks=false&#10;-Dcattle.http.port=8080&#10;-Dlogback.log.dir=../../../runtime/eclipse/logs/&#10;-Ddb.cattle.home=../../../runtime/eclipse/db/"/>
 </launchConfiguration>


### PR DESCRIPTION
I've never seen eclipse survive a run with the default values