### PR TITLE
wait for sidekick allocation first

### DIFF
--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/impl/AllocatorDaoImpl.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/impl/AllocatorDaoImpl.java
@@ -436,7 +436,8 @@ public class AllocatorDaoImpl extends AbstractJooqDao implements AllocatorDao {
                                         AgentConstants.STATE_FINISHING_RECONNECT, AgentConstants.STATE_RECONNECTED))
                 .and(HOST.REMOVED.isNull())
                 .and(HOST.ACCOUNT_ID.eq(accountId))
-                .and(HOST.STATE.in(CommonStatesConstants.ACTIVE, CommonStatesConstants.UPDATING_ACTIVE)))
+                                .and(HOST.STATE.in(CommonStatesConstants.ACTIVATING, CommonStatesConstants.ACTIVE,
+                                        CommonStatesConstants.UPDATING_ACTIVE)))
                 .fetchInto(Host.class);
     }
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/DeploymentUnit.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/DeploymentUnit.java
@@ -323,8 +323,28 @@ public class DeploymentUnit {
     }
 
     public void waitForStart(){
-        for (DeploymentUnitInstance instance : getDeploymentUnitInstances()) {
+        // sort based on dependencies
+        List<String> sortedLCs = new ArrayList<>();
+        for (String lc : launchConfigToInstance.keySet()) {
+            sortSidekicks(sortedLCs, lc);
+        }
+
+        List<DeploymentUnitInstance> sortedInstances = new ArrayList<>();
+        for (String lc : sortedLCs) {
+            sortedInstances.add(launchConfigToInstance.get(lc));
+        }
+        for (DeploymentUnitInstance instance : sortedInstances) {
             instance.waitForStart();
+        }
+    }
+
+    protected void sortSidekicks(List<String> sorted, String lc) {
+        List<String> sidekicks = getSidekickRefs(service, lc);
+        for (String sidekick : sidekicks) {
+            sortSidekicks(sorted, sidekick);
+        }
+        if (!sorted.contains(lc)) {
+            sorted.add(lc);
         }
     }
 
@@ -728,4 +748,5 @@ public class DeploymentUnit {
 
         return toReturn;
     }
+
 }


### PR DESCRIPTION
Contains 2 fixes:

1) When wait for deployment unit start, sort instances based on their sidekick dependencies, and always evaluate sidekicks first.

2) Global deployment planner - consider hosts in Activating state for allocation. As service.reconcile can be triggered by host.activate, and we want this host to be picked up for allocation.

https://github.com/rancher/rancher/issues/7148