### PR TITLE
Fix whitelist proxy

### DIFF
--- a/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/servlet/ApiRequestFilterDelegate.java
+++ b/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/servlet/ApiRequestFilterDelegate.java
@@ -84,7 +84,6 @@ public class ApiRequestFilterDelegate {
                 }
                 apiRequest.setSchemaFactory(defaultFactory);
                 schemaUrl = ApiContext.getUrlBuilder().resourceCollection(Schema.class);
-                apiRequest.setVersion(null);
             } else {
                 schemaUrl = ApiContext.getUrlBuilder().resourceCollection(Schema.class);
             }

--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/request/handler/GenericWhitelistedProxy.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/request/handler/GenericWhitelistedProxy.java
@@ -178,7 +178,7 @@ public class GenericWhitelistedProxy extends AbstractResponseGenerator implement
     @SuppressWarnings("unchecked")
     @Override
     protected void generate(final ApiRequest request) throws IOException {
-        if (request.getVersion() == null || !ALLOW_PROXY.get())
+        if (!ALLOW_PROXY.get())
             return;
 
         if (!"proxy".equals(request.getType())) {

--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/request/handler/GenericWhitelistedProxy.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/request/handler/GenericWhitelistedProxy.java
@@ -7,6 +7,7 @@ import io.cattle.platform.iaas.api.servlet.filter.ProxyPreFilter;
 import io.cattle.platform.object.ObjectManager;
 import io.cattle.platform.object.meta.ObjectMetaDataManager;
 import io.cattle.platform.object.util.DataAccessor;
+import io.cattle.platform.util.type.Named;
 import io.github.ibuildthecloud.gdapi.condition.Condition;
 import io.github.ibuildthecloud.gdapi.condition.ConditionType;
 import io.github.ibuildthecloud.gdapi.exception.ClientVisibleException;
@@ -70,7 +71,7 @@ import com.netflix.config.DynamicBooleanProperty;
 import com.netflix.config.DynamicStringListProperty;
 
 
-public class GenericWhitelistedProxy extends AbstractResponseGenerator {
+public class GenericWhitelistedProxy extends AbstractResponseGenerator implements Named {
 
     public static final String ALLOWED_HOST = GenericWhitelistedProxy.class.getName() + "allowed.host";
     public static final String SET_HOST_CURRENT_HOST = GenericWhitelistedProxy.class.getName() + "set_host_current_host";
@@ -91,6 +92,7 @@ public class GenericWhitelistedProxy extends AbstractResponseGenerator {
 
     private List<String> allowedPaths;
     private boolean noAuthProxy = false;
+    private String name;
 
     static {
         LayeredConnectionSocketFactory ssl = null;
@@ -138,6 +140,11 @@ public class GenericWhitelistedProxy extends AbstractResponseGenerator {
 
     @Inject
     ObjectManager objectManager;
+
+    public GenericWhitelistedProxy(String name) {
+        super();
+        this.name = name;
+    }
 
     protected boolean isAllowed(HttpServletRequest servletRequest, String host) {
         boolean allowHost = Boolean.TRUE.equals(servletRequest.getAttribute(ALLOWED_HOST));
@@ -369,5 +376,14 @@ public class GenericWhitelistedProxy extends AbstractResponseGenerator {
 
     public void setNoAuthProxy(String noAuthProxy) {
         this.noAuthProxy = Boolean.parseBoolean(noAuthProxy);
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
     }
 }

--- a/code/packaging/app-config/src/main/java/io/cattle/platform/app/IaasApiConfig.java
+++ b/code/packaging/app-config/src/main/java/io/cattle/platform/app/IaasApiConfig.java
@@ -708,7 +708,7 @@ public class IaasApiConfig {
 
     @Bean
     GenericWhitelistedProxy NoAuthenticationProxy() {
-        GenericWhitelistedProxy proxy = new GenericWhitelistedProxy();
+        GenericWhitelistedProxy proxy = new GenericWhitelistedProxy("NoAuthenticationProxy");
         proxy.setNoAuthProxy("true");
         proxy.setAllowedPaths(Arrays.asList(
                 "/v1-auth/saml",
@@ -718,7 +718,7 @@ public class IaasApiConfig {
 
     @Bean
     GenericWhitelistedProxy GenericWhitelistedProxy() {
-        return new GenericWhitelistedProxy();
+        return new GenericWhitelistedProxy("GenericWhitelistedProxy");
     }
 
     @Bean

--- a/code/packaging/app/src/main/webapp/WEB-INF/web.xml
+++ b/code/packaging/app/src/main/webapp/WEB-INF/web.xml
@@ -70,9 +70,8 @@
     </filter>
     <filter-mapping>
     	<filter-name>WebhookService</filter-name>
-        <url-pattern>/v1-webhooks/receivers/*</url-pattern>
+        <url-pattern>/v1-webhooks/*</url-pattern>
         <filter-name>WebhookService</filter-name>
-        <url-pattern>/v1-webhooks/endpoint</url-pattern>
     </filter-mapping>
 
     <filter>


### PR DESCRIPTION
Make GenericWhitelistedProxy name aware so that when ApiRequestFilterDelegate loads 
the list of handlers and orders it based on the api.request.handler.list property, the
NoAuthenticationProxy will be properly recognized.

Also, sneak in:
- A tweak to the url pattern for webhooks to make it catch everything under and including /v1-webhooks
- Some seemingly unneeded sets and checks of apiRequest.version