### PR TITLE
WIP: scale policy db upgrade

### DIFF
--- a/code/implementation/sample-setup/src/main/java/io/cattle/platform/sample/data/SampleDataStartupV14.java
+++ b/code/implementation/sample-setup/src/main/java/io/cattle/platform/sample/data/SampleDataStartupV14.java
@@ -1,0 +1,39 @@
+package io.cattle.platform.sample.data;
+
+import static io.cattle.platform.core.model.tables.ServiceTable.*;
+import io.cattle.platform.core.constants.ServiceConstants;
+import io.cattle.platform.core.model.Account;
+import io.cattle.platform.core.model.Service;
+import io.cattle.platform.object.util.DataAccessor;
+import io.github.ibuildthecloud.gdapi.condition.Condition;
+import io.github.ibuildthecloud.gdapi.condition.ConditionType;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SampleDataStartupV14 extends AbstractSampleData {
+
+    @Override
+    protected String getName() {
+        return "sampleDataVersion14";
+    }
+
+    @Override
+    protected void populatedData(Account system, List<Object> toCreate) {
+        List<Service> services = objectManager
+                .find(Service.class, SERVICE.REMOVED, new Condition(ConditionType.NULL));
+        for (Service service : services) {
+            if (DataAccessor.field(service,
+                    ServiceConstants.FIELD_SCALE_POLICY, Object.class) == null) {
+                continue;
+            }
+            Integer lockedScale = DataAccessor.fieldInteger(service,
+                    ServiceConstants.FIELD_LOCKED_SCALE);
+            Map<String, Object> data = new HashMap<>();
+            data.put(ServiceConstants.FIELD_SCALE, lockedScale);
+            objectManager.setFields(service, data);
+        }
+    }
+
+}

--- a/code/packaging/app-config/src/main/java/io/cattle/platform/app/SystemServicesConfig.java
+++ b/code/packaging/app-config/src/main/java/io/cattle/platform/app/SystemServicesConfig.java
@@ -98,6 +98,7 @@ import io.cattle.platform.sample.data.SampleDataStartupV10;
 import io.cattle.platform.sample.data.SampleDataStartupV11;
 import io.cattle.platform.sample.data.SampleDataStartupV12;
 import io.cattle.platform.sample.data.SampleDataStartupV13;
+import io.cattle.platform.sample.data.SampleDataStartupV14;
 import io.cattle.platform.sample.data.SampleDataStartupV3;
 import io.cattle.platform.sample.data.SampleDataStartupV5;
 import io.cattle.platform.sample.data.SampleDataStartupV6;
@@ -634,6 +635,11 @@ public class SystemServicesConfig {
     @Bean
     SampleDataStartupV13 SampleDataStartupV13() {
         return new SampleDataStartupV13();
+    }
+
+    @Bean
+    SampleDataStartupV14 SampleDataStartupV14() {
+        return new SampleDataStartupV14();
     }
 
     @Bean


### PR DESCRIPTION
DB migration part for https://github.com/rancher/rancher/issues/6832

As we've finally decided to get rid of scale policy from RAncher completely (including API and backend logic), we had to ensure that:

1) existing services having scale policy will continue to work
2) It is possible to upgrade from scale policy to scale (example - etcd upgrade as a part of k8s upgrade)

The cleaner way for it will be - transform lockedScale set by scalePolicy code, to scale on the upgrade


https://github.com/rancher/rancher/issues/7264