### PR TITLE
Filter account list on id not account_id

### DIFF
--- a/code/framework/api/src/main/java/io/cattle/platform/api/resource/AbstractObjectResourceManager.java
+++ b/code/framework/api/src/main/java/io/cattle/platform/api/resource/AbstractObjectResourceManager.java
@@ -324,7 +324,11 @@ public abstract class AbstractObjectResourceManager extends AbstractBaseResource
                 return;
             }
 
-            criteria.put(ObjectMetaDataManager.ACCOUNT_FIELD, policy.getAccountId());
+            if ("account".equals(type)) {
+                criteria.put(ObjectMetaDataManager.ID_FIELD, policy.getAccountId());
+            } else {
+                criteria.put(ObjectMetaDataManager.ACCOUNT_FIELD, policy.getAccountId());
+            }
         }
     }
 


### PR DESCRIPTION
When hitting /accounts for yourself we need to look for id field and not
the account_id field as normal.