### PR TITLE
Cattle changes to launch api-filter-proxy service to run as a proxy to cattle

### DIFF
--- a/code/framework/server/src/main/java/io/cattle/platform/server/context/ServerContext.java
+++ b/code/framework/server/src/main/java/io/cattle/platform/server/context/ServerContext.java
@@ -7,9 +7,7 @@ import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.util.Collections;
-
 import org.apache.commons.lang.StringUtils;
-
 import com.netflix.config.DynamicIntProperty;
 import com.netflix.config.DynamicStringProperty;
 

--- a/code/implementation/docker/machine/src/main/java/io/cattle/platform/docker/machine/launch/ApiFilterProxyLauncher.java
+++ b/code/implementation/docker/machine/src/main/java/io/cattle/platform/docker/machine/launch/ApiFilterProxyLauncher.java
@@ -1,0 +1,228 @@
+package io.cattle.platform.docker.machine.launch;
+
+import io.cattle.platform.archaius.util.ArchaiusUtil;
+import io.cattle.platform.core.model.Credential;
+import io.cattle.platform.json.JsonMapper;
+import io.cattle.platform.lock.definition.LockDefinition;
+import io.cattle.platform.service.launcher.GenericServiceLauncher;
+import io.cattle.platform.util.type.InitializationTask;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.apache.http.client.fluent.Request;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.config.DynamicBooleanProperty;
+import com.netflix.config.DynamicStringProperty;
+
+public class ApiFilterProxyLauncher extends GenericServiceLauncher implements InitializationTask {
+
+    private static final DynamicStringProperty API_FILTER_PROXY_BINARY = ArchaiusUtil.getString("api.filter.proxy.executable");
+    private static final DynamicStringProperty API_FILTER_PROXY_CONFIG = ArchaiusUtil.getString("api.filter.proxy.config");
+    private static final DynamicBooleanProperty API_FILTER_PROXY_LAUNCH = ArchaiusUtil.getBoolean("api.filter.proxy.execute");
+    private static final DynamicStringProperty API_FILTER_PROXY_PORT = ArchaiusUtil.getString("api.filter.proxy.http.port");
+
+    private static final Logger log = LoggerFactory.getLogger(ApiFilterProxyLauncher.class);
+
+    public static class PreFilter {
+        String name;
+        String endpoint;
+        String secretToken;
+        String[] methods;
+        String[] paths;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getEndpoint() {
+            return endpoint;
+        }
+
+        public void setEndpoint(String endpoint) {
+            this.endpoint = endpoint;
+        }
+
+        public String getSecretToken() {
+            return secretToken;
+        }
+
+        public void setSecretToken(String secretToken) {
+            this.secretToken = secretToken;
+        }
+
+        public String[] getPaths() {
+            return paths;
+        }
+
+        public void setPaths(String[] paths) {
+            this.paths = paths;
+        }
+
+        public String[] getMethods() {
+            return methods;
+        }
+
+        public void setMethods(String[] methods) {
+            this.methods = methods;
+        }
+
+        public PreFilter() {
+        }
+    }
+
+    public static class Destination {
+        String destinationURL;
+        String[] paths;
+
+        public String getDestinationURL() {
+            return destinationURL;
+        }
+
+        public void setDestinationURL(String destinationURL) {
+            this.destinationURL = destinationURL;
+        }
+
+        public String[] getPaths() {
+            return paths;
+        }
+
+        public void setPaths(String[] paths) {
+            this.paths = paths;
+        }
+
+        public Destination() {
+        }
+    }
+
+    public static class ConfigFileFields {
+        PreFilter[] preFilters;
+        Destination[] destinations;
+
+        public PreFilter[] getPrefilters() {
+            return preFilters;
+        }
+
+        public void setPrefilters(PreFilter[] filters) {
+            preFilters = filters;
+        }
+
+        public Destination[] getDestinations() {
+            return destinations;
+        }
+
+        public void setDestinations(Destination[] destinations) {
+            this.destinations = destinations;
+        }
+
+        public ConfigFileFields() {
+        }
+    }
+
+    @Inject
+    JsonMapper jsonMapper;
+
+    @Override
+    protected boolean shouldRun() {
+        return API_FILTER_PROXY_LAUNCH.get();
+    }
+
+    @Override
+    protected String binaryPath() {
+        return API_FILTER_PROXY_BINARY.get();
+    }
+
+    @Override
+    protected List<DynamicStringProperty> getReloadSettings() {
+        List<DynamicStringProperty> list = new ArrayList<DynamicStringProperty>();
+        list.add(API_FILTER_PROXY_CONFIG);
+        return list;
+    }
+
+    @Override
+    protected void prepareProcess(ProcessBuilder pb) throws IOException {
+        List<String> args = pb.command();
+        args.add("--config");
+        prepareConfigFile();
+        args.add("config.json");
+        args.add("--listen");
+        String listen = API_FILTER_PROXY_PORT.get();
+        args.add(":" + listen);
+        String cattleProxyAddress = "http://localhost:" + getCattleProxiedPort();
+        args.add("--cattle-url");
+        args.add(cattleProxyAddress);
+    }
+
+    protected void prepareConfigFile() throws IOException {
+        File configFile = new File("config.json");
+
+        String proxyConfig = API_FILTER_PROXY_CONFIG.get();
+        ConfigFileFields configEntries = new ConfigFileFields();
+        FileOutputStream fos;
+        if(proxyConfig != null) {
+            configEntries = jsonMapper.readValue(proxyConfig, ConfigFileFields.class);
+            fos = new FileOutputStream(configFile.getAbsoluteFile());
+            jsonMapper.writeValue(fos, configEntries);
+        } else {
+            //initialize with a default empty config
+            fos = new FileOutputStream(configFile.getAbsoluteFile());
+            jsonMapper.writeValue(fos, configEntries);
+        }
+    }
+
+    @Override
+    protected void setEnvironment(Map<String, String> env) {
+        Credential cred = getCredential();
+        env.put("CATTLE_ACCESS_KEY", cred.getPublicValue());
+        env.put("CATTLE_SECRET_KEY", cred.getSecretValue());
+        String cattleProxyAddress = "http://localhost:" + getCattleProxiedPort();
+        env.put("CATTLE_URL", cattleProxyAddress);
+    }
+
+
+    private String getCattleProxiedPort() {
+        //it is assumed that when api.filter.proxy.execute=true, WSP is always ON and cattle is listening on proxied-port/8081. 
+        //The case where WSP is OFF but filter-proxy is ON is not valid.
+        String port = System.getenv("CATTLE_HTTP_PROXIED_PORT");
+        return port == null ? System.getProperty("cattle.http.proxied.port", "8081") : port;
+    }
+
+    @Override
+    protected LockDefinition getLock() {
+        return null;
+    }
+
+    @Override
+    protected boolean isReady() {
+        return true;
+    }
+
+    @Override
+    public void reload() {
+        if (!shouldRun()) {
+            return;
+        }
+
+        try {
+            prepareConfigFile();
+            StringBuilder apiProxyUrl = new StringBuilder();
+            apiProxyUrl.append("http://localhost:").append(API_FILTER_PROXY_PORT.get()).append("/v1-api-filter-proxy/reload");
+            Request.Post(apiProxyUrl.toString()).execute();
+        } catch (IOException e) {
+            log.info("Failed to reload api proxy service: {}", e.getMessage());
+        }
+    }
+
+}

--- a/code/implementation/docker/machine/src/main/java/io/cattle/platform/docker/machine/launch/TraefikLauncher.java
+++ b/code/implementation/docker/machine/src/main/java/io/cattle/platform/docker/machine/launch/TraefikLauncher.java
@@ -37,6 +37,8 @@ public class TraefikLauncher extends GenericServiceLauncher implements Initializ
             "HTTP_PROXY",
             "HTTPS_PROXY"
     };
+    private static final DynamicBooleanProperty API_FILTER_PROXY_LAUNCH = ArchaiusUtil.getBoolean("api.filter.proxy.execute");
+    private static final DynamicStringProperty API_FILTER_PROXY_PORT = ArchaiusUtil.getString("api.filter.proxy.http.port");
 
     private static final Logger log = LoggerFactory.getLogger(TraefikLauncher.class);
 
@@ -52,7 +54,7 @@ public class TraefikLauncher extends GenericServiceLauncher implements Initializ
         "    url = \"http://%s\"\n" +
         "  [backends.cattle]\n" +
         "    [backends.cattle.servers.server1]\n" +
-        "    url = \"http://localhost:8081\"\n" +
+        "    url = \"http://localhost:%s\"\n" +
         "\n" +
         "[frontends]\n" +
         "  [frontends.wspfront]\n" +
@@ -87,7 +89,12 @@ public class TraefikLauncher extends GenericServiceLauncher implements Initializ
             }
         }
 
-        String content = String.format(CONFIG, ACCESS_LOG.get(), host);
+        String port = "8081";
+        if (API_FILTER_PROXY_LAUNCH.get()) {
+            port = API_FILTER_PROXY_PORT.get();
+        }
+
+        String content = String.format(CONFIG, ACCESS_LOG.get(), host, port);
         if (written.equals(content)) {
             return true;
         }

--- a/code/implementation/host-api/src/main/java/io/cattle/host/api/proxy/launch/ProxyLauncher.java
+++ b/code/implementation/host-api/src/main/java/io/cattle/host/api/proxy/launch/ProxyLauncher.java
@@ -1,7 +1,6 @@
 package io.cattle.host.api.proxy.launch;
 
 import static io.cattle.platform.server.context.ServerContext.*;
-
 import io.cattle.platform.archaius.util.ArchaiusUtil;
 import io.cattle.platform.core.model.Credential;
 import io.cattle.platform.host.service.HostApiService;
@@ -26,10 +25,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.netflix.config.DynamicBooleanProperty;
+import com.netflix.config.DynamicStringProperty;
 
 public class ProxyLauncher extends NoExceptionRunnable implements InitializationTask, Runnable {
 
     private static final DynamicBooleanProperty TRAEFIK_LAUNCH = ArchaiusUtil.getBoolean("traefik.execute");
+    private static final DynamicBooleanProperty API_FILTER_PROXY_LAUNCH = ArchaiusUtil.getBoolean("api.filter.proxy.execute");
+    private static final DynamicStringProperty API_FILTER_PROXY_PORT = ArchaiusUtil.getString("api.filter.proxy.http.port");
     private static final int WAIT = 2000;
     private static final Logger log = LoggerFactory.getLogger(ProxyLauncher.class);
 
@@ -142,8 +144,12 @@ public class ProxyLauncher extends NoExceptionRunnable implements Initialization
     private String getProxiedPort() {
         // To match the functionality in the Jetty Main class, need to get value this way as opposed
         // to using ArchaiusUtils
-        String port = System.getenv("CATTLE_HTTP_PROXIED_PORT");
-        return port == null ? System.getProperty("cattle.http.proxied.port", "8081") : port;
+        if (API_FILTER_PROXY_LAUNCH.get()) {
+            return API_FILTER_PROXY_PORT.get();
+        } else {
+            String port = System.getenv("CATTLE_HTTP_PROXIED_PORT");
+            return port == null ? System.getProperty("cattle.http.proxied.port", "8081") : port;
+        }
     }
 
     private String getProxyPort() {

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/process/defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/process/defaults.properties
@@ -122,3 +122,6 @@ api.auth.local.validate.timeout.milliseconds=10000
 webhook.service.executable=webhook-service
 webhook.service.execute=false
 
+api.filter.proxy.executable=api-filter-proxy
+api.filter.proxy.execute=false
+api.filter.proxy.http.port=8083

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/process/spring-process-context.xml
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/process/spring-process-context.xml
@@ -545,6 +545,7 @@
     <bean class="io.cattle.platform.docker.machine.launch.AuthServiceLauncher" />
     <bean class="io.cattle.platform.docker.machine.launch.TraefikLauncher" />
     <bean class="io.cattle.platform.docker.machine.launch.WebhookServiceLauncher" />
+    <bean class="io.cattle.platform.docker.machine.launch.ApiFilterProxyLauncher" />
     
     <process:defaultProcesses resourceType="externalHandler" />
     <process:defaultProcesses resourceType="externalHandlerProcess" />

--- a/resources/content/cattle-global.properties
+++ b/resources/content/cattle-global.properties
@@ -21,6 +21,7 @@ service.package.govc.url=https://github.com/vmware/govmomi/releases/download/v0.
 service.package.telemetry.url=https://github.com/rancher/telemetry/releases/download/v0.4.0/telemetry.tar.xz
 service.package.auth.service.url=https://github.com/rancher/rancher-auth-service/releases/download/v0.2.0/rancher-auth-service.tar.xz
 service.package.webhook.service.url=https://github.com/rancher/webhook-service/releases/download/v0.8.0/webhook-service.tar.xz
+service.package.api.filter.proxy.url=
 
 ####################
 # Machine Drivers  #


### PR DESCRIPTION
Cattle will launch api-filter-proxy service to run as a proxy to cattle when either:
a) The env variable CATTLE_LAUNCH_API_FILTER_PROXY is set to true
OR
b) JVM param `-Dlaunch.api.filter.proxy=true` is present in the java VM args

In Single Node rancher setup -  this will be the port assignments for cattle, websocket-proxy(ws-proxy) and api-filter-proxy processes:

case1
	Cattle 				8080
	No ws-proxy			-
	No api-filter-proxy		-

case2
	Cattle 				8081
	Yes ws-proxy			8080
	No api-filter-proxy		-

case3
	Cattle 				8082
	Yes ws-proxy			8080
	Yes api-filter-proxy		8081

case4
	Cattle 				8081
	No ws-proxy			-
	Yes api-filter-proxy		8080
