### PR TITLE
Deactivate service before deleting instance

### DIFF
--- a/tests/integration-v1/cattletest/core/test_svc_discovery.py
+++ b/tests/integration-v1/cattletest/core/test_svc_discovery.py
@@ -1346,10 +1346,10 @@ def test_global_service_update_label(new_context):
     instance2_host = instance2.hosts()[0].id
     assert instance2_host == host2.id
 
-    # destroy the instance, reactivate the service and check
-    # both hosts got instances
-    _instance_remove(instance1, client)
+    # deactivate the service, destroy the instance,
+    # reactivate the service,  and check both hosts got instances
     service = wait_state(client, service.deactivate(), 'inactive')
+    _instance_remove(instance1, client)
     service = wait_state(client, service.activate(), 'active')
     instance1 = _validate_compose_instance_start(client, service, env, "1")
     instance2 = _validate_compose_instance_start(client, service, env, "2")

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -1457,10 +1457,10 @@ def test_global_service_update_label(new_context):
     instance2_host = instance2.hosts()[0].id
     assert instance2_host == host2.id
 
-    # destroy the instance, reactivate the service and check
-    # both hosts got instances
-    _instance_remove(instance1, client)
+    # deactivate the service, destroy the instance,
+    # reactivate the service, and check both hosts got instances
     service = wait_state(client, service.deactivate(), 'inactive')
+    _instance_remove(instance1, client)
     service = wait_state(client, service.activate(), 'active')
     instance1 = _validate_compose_instance_start(client, service, env, "1")
     instance2 = _validate_compose_instance_start(client, service, env, "2")


### PR DESCRIPTION
This fixes a race condition where the backend is trying to put the service in a state of 'updating-active' and the api is tring to put it in a state of 'deactivating'. As previously decided, getting a non-200 response in this scenario is ok, so the cattle code doesn't need to change, just the test to avoid the scenario.

See this build failure for an example of the situation: https://drone.rancher.io/rancher/cattle/1980/1