### PR TITLE
Throw 409 on STATE_CHANGE exception

### DIFF
--- a/code/framework/api/src/main/java/io/cattle/platform/api/resource/jooq/AbstractJooqResourceManager.java
+++ b/code/framework/api/src/main/java/io/cattle/platform/api/resource/jooq/AbstractJooqResourceManager.java
@@ -417,6 +417,10 @@ public abstract class AbstractJooqResourceManager extends AbstractObjectResource
                 ((ProcessExecutionExitException) t).getExitReason() == ExitReason.PROCESS_ALREADY_IN_PROGRESS) {
             log.info("Process in progress : {}", t.getMessage());
             throw new ClientVisibleException(ResponseCodes.CONFLICT);
+        } else if (t instanceof ProcessExecutionExitException &&
+                ((ProcessExecutionExitException) t).getExitReason() == ExitReason.STATE_CHANGED) {
+            log.info("State changed: {}", t.getMessage());
+            throw new ClientVisibleException(ResponseCodes.CONFLICT);
         } else if (t instanceof FailedToAcquireLockException) {
             log.info("Failed to lock : {}", t.getMessage());
             throw new ClientVisibleException(ResponseCodes.CONFLICT);

--- a/tests/integration-v1/requirements.txt
+++ b/tests/integration-v1/requirements.txt
@@ -1,5 +1,5 @@
 cattle==0.5.3
-gdapi-python==0.5.3
+git+https://github.com/rancher/gdapi-python.git@31d74507d96c8f053a08bda129cc63f96ca60161
 websocket-client==0.23.0
 PyJWT==1.4.0
 

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,5 +1,5 @@
 cattle==0.5.3
-git+https://github.com/rancher/gdapi-python.git@6e5031dde7b7da0a91efa9204a0a392f44854b0d
+git+https://github.com/rancher/gdapi-python.git@31d74507d96c8f053a08bda129cc63f96ca60161
 websocket-client==0.23.0
 PyJWT==1.4.0
 


### PR DESCRIPTION
This combination of changes would prevent the 500 exception and subsequent test failure seen here: https://drone.rancher.io/rancher/cattle/1980/1

```
...
>       service = wait_state(client, service.deactivate(), 'inactive')
core/test_svc_discovery.py:1352: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../.tox/py27/local/lib/python2.7/site-packages/gdapi.py:235: in <lambda>
    *args, **kw)
../.tox/py27/local/lib/python2.7/site-packages/gdapi.py:401: in action
    return self._post(url, data=self._to_dict(*args, **kw))
../.tox/py27/local/lib/python2.7/site-packages/gdapi.py:64: in wrapped
    return fn(*args, **kw)
../.tox/py27/local/lib/python2.7/site-packages/gdapi.py:275: in _post
    self._error(r.text)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <cattle.Client object at 0x7f87693d7e50>
text = '{"id":"7e23eaff-5352-4a05-878f-b6f974a854a8","type":"error","links":{},"actions":{},"status":500,"code":"Internal Server Error","message":"Internal Server Error","detail":null,"baseType":"error"}'
    def _error(self, text):
>       raise ApiError(self._unmarshall(text))
E       ApiError: (ApiError(...), "Internal Server Error : Internal Server Error\n{'id': u'7e23eaff-5352-4a05-878f-b6f974a854a8', 'message': u'Internal Server Error', 'code': u'Internal Server Error', 'links': {}, 'baseType': u'error', 'type': u'error', 'status': 500, 'detail': None, 'actions': {}}")
../.tox/py27/local/lib/python2.7/site-packages/gdapi.py:255: ApiError

...

2017-01-16 19:03:41,516 ERROR [3c57ead1-a13b-42c2-b256-444ee8832abc:4171] [instance:199] [instance.start->(InstanceStart)] [] [cutorService-17] [i.c.p.process.instance.InstanceStart] Failed to Storage for instance [199] 
2017-01-16 19:04:02,147 ERROR [:] [] [] [] [ecutorService-7] [o.a.c.m.context.NoExceptionRunnable ] Uncaught exception org.jooq.exception.DataChangedException: Database record has been changed
	at org.jooq.impl.UpdatableRecordImpl.checkIfChanged(UpdatableRecordImpl.java:550) ~[jooq-3.3.0.jar:na]
	at org.jooq.impl.UpdatableRecordImpl.storeUpdate0(UpdatableRecordImpl.java:291) ~[jooq-3.3.0.jar:na]
	at org.jooq.impl.UpdatableRecordImpl.access$200(UpdatableRecordImpl.java:90) ~[jooq-3.3.0.jar:na]
	at org.jooq.impl.UpdatableRecordImpl$3.operate(UpdatableRecordImpl.java:260) ~[jooq-3.3.0.jar:na]
	at org.jooq.impl.RecordDelegate.operate(RecordDelegate.java:123) ~[jooq-3.3.0.jar:na]
	at org.jooq.impl.UpdatableRecordImpl.storeUpdate(UpdatableRecordImpl.java:255) ~[jooq-3.3.0.jar:na]
	at org.jooq.impl.UpdatableRecordImpl.update(UpdatableRecordImpl.java:149) ~[jooq-3.3.0.jar:na]
	at io.cattle.platform.object.impl.JooqObjectManager.persistRecord(JooqObjectManager.java:223) ~[cattle-framework-object-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.object.impl.JooqObjectManager.setFieldsInternal(JooqObjectManager.java:130) ~[cattle-framework-object-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.object.impl.JooqObjectManager$3.execute(JooqObjectManager.java:118) ~[cattle-framework-object-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.idempotent.Idempotent.change(Idempotent.java:88) ~[cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.object.impl.JooqObjectManager.setFields(JooqObjectManager.java:115) ~[cattle-framework-object-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.object.impl.JooqObjectManager.setFields(JooqObjectManager.java:110) ~[cattle-framework-object-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.object.impl.AbstractObjectManager.setFields(AbstractObjectManager.java:139) ~[cattle-framework-object-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.activity.impl.ActivityLogImpl.close(ActivityLogImpl.java:81) ~[cattle-activity-log-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.activity.impl.EntryImpl.close(EntryImpl.java:23) ~[cattle-activity-log-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.activity.ActivityService.run(ActivityService.java:48) ~[cattle-activity-log-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.servicediscovery.deployment.impl.DeploymentManagerImpl$5.run(DeploymentManagerImpl.java:502) ~[cattle-iaas-service-discovery-server-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.configitem.version.impl.ConfigItemStatusManagerImpl$1.doWithLock(ConfigItemStatusManagerImpl.java:92) ~[cattle-config-item-common-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl$4.doWithLock(AbstractLockManagerImpl.java:50) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.LockManagerImpl.doLock(LockManagerImpl.java:33) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl.tryLock(AbstractLockManagerImpl.java:25) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl.tryLock(AbstractLockManagerImpl.java:47) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.configitem.version.impl.ConfigItemStatusManagerImpl.runUpdateForEvent(ConfigItemStatusManagerImpl.java:85) ~[cattle-config-item-common-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.servicediscovery.deployment.impl.DeploymentManagerImpl.serviceUpdate(DeploymentManagerImpl.java:495) ~[cattle-iaas-service-discovery-server-0.5.0-SNAPSHOT.jar:na]
	at sun.reflect.GeneratedMethodAccessor1689.invoke(Unknown Source) ~[na:na]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.7.0_121]
	at java.lang.reflect.Method.invoke(Method.java:606) ~[na:1.7.0_121]
	at io.cattle.platform.eventing.annotation.MethodInvokingListener$1.doWithLockNoResult(MethodInvokingListener.java:76) ~[cattle-framework-eventing-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.LockCallbackNoReturn.doWithLock(LockCallbackNoReturn.java:7) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.LockCallbackNoReturn.doWithLock(LockCallbackNoReturn.java:3) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl$3.doWithLock(AbstractLockManagerImpl.java:40) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.LockManagerImpl.doLock(LockManagerImpl.java:33) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl.lock(AbstractLockManagerImpl.java:13) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl.lock(AbstractLockManagerImpl.java:37) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.eventing.annotation.MethodInvokingListener.onEvent(MethodInvokingListener.java:72) ~[cattle-framework-eventing-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.eventing.impl.AbstractThreadPoolingEventService$2.doRun(AbstractThreadPoolingEventService.java:141) ~[cattle-framework-eventing-0.5.0-SNAPSHOT.jar:na]
	at org.apache.cloudstack.managed.context.NoExceptionRunnable.runInContext(NoExceptionRunnable.java:15) ~[cattle-framework-managed-context-0.5.0-SNAPSHOT.jar:na]
	at org.apache.cloudstack.managed.context.ManagedContextRunnable$1.run(ManagedContextRunnable.java:49) [cattle-framework-managed-context-0.5.0-SNAPSHOT.jar:na]
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext$1.call(DefaultManagedContext.java:55) [cattle-framework-managed-context-0.5.0-SNAPSHOT.jar:na]
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.callWithContext(DefaultManagedContext.java:108) [cattle-framework-managed-context-0.5.0-SNAPSHOT.jar:na]
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.runWithContext(DefaultManagedContext.java:52) [cattle-framework-managed-context-0.5.0-SNAPSHOT.jar:na]
	at org.apache.cloudstack.managed.context.ManagedContextRunnable.run(ManagedContextRunnable.java:46) [cattle-framework-managed-context-0.5.0-SNAPSHOT.jar:na]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_121]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_121]
	at java.lang.Thread.run(Thread.java:745) [na:1.7.0_121]
2017-01-16 19:04:47,568 ERROR [:] [] [] [] [TaskScheduler-2] [i.c.p.a.s.ping.impl.PingMonitorImpl ] Failed to get ping from agent [166] count [3] 
2017-01-16 19:04:52,570 ERROR [:] [] [] [] [TaskScheduler-2] [i.c.p.a.s.ping.impl.PingMonitorImpl ] Failed to get ping from agent [166] count [4] 
2017-01-16 19:04:57,571 ERROR [:] [] [] [] [TaskScheduler-1] [i.c.p.a.s.ping.impl.PingMonitorImpl ] Failed to get ping from agent [166] count [5] 
2017-01-16 19:05:02,587 ERROR [:] [] [] [] [TaskScheduler-1] [i.c.p.a.s.ping.impl.PingMonitorImpl ] Failed to get ping from agent [166] count [6] 
2017-01-16 19:05:07,588 ERROR [:] [] [] [] [TaskScheduler-1] [i.c.p.a.s.ping.impl.PingMonitorImpl ] Failed to get ping from agent [166] count [7] 
2017-01-16 19:05:12,608 ERROR [:] [] [] [] [TaskScheduler-1] [i.c.p.a.s.ping.impl.PingMonitorImpl ] Failed to get ping from agent [166] count [8] 
2017-01-16 19:05:17,609 ERROR [:] [] [] [] [TaskScheduler-1] [i.c.p.a.s.ping.impl.PingMonitorImpl ] Failed to get ping from agent [166] count [9] 
2017-01-16 19:05:21,343 ERROR [64fc130d-be11-4c01-b89b-ed4ed56220c8:12] [account:6] [account.create] [] [ecutorService-3] [o.a.c.m.context.NoExceptionRunnable ] Uncaught exception org.jooq.exception.DataChangedException: Database record has been changed
	at org.jooq.impl.UpdatableRecordImpl.checkIfChanged(UpdatableRecordImpl.java:550) ~[jooq-3.3.0.jar:na]
	at org.jooq.impl.UpdatableRecordImpl.storeUpdate0(UpdatableRecordImpl.java:291) ~[jooq-3.3.0.jar:na]
	at org.jooq.impl.UpdatableRecordImpl.access$200(UpdatableRecordImpl.java:90) ~[jooq-3.3.0.jar:na]
	at org.jooq.impl.UpdatableRecordImpl$3.operate(UpdatableRecordImpl.java:260) ~[jooq-3.3.0.jar:na]
	at org.jooq.impl.RecordDelegate.operate(RecordDelegate.java:123) ~[jooq-3.3.0.jar:na]
	at org.jooq.impl.UpdatableRecordImpl.storeUpdate(UpdatableRecordImpl.java:255) ~[jooq-3.3.0.jar:na]
	at org.jooq.impl.UpdatableRecordImpl.update(UpdatableRecordImpl.java:149) ~[jooq-3.3.0.jar:na]
	at io.cattle.platform.object.impl.JooqObjectManager.persistRecord(JooqObjectManager.java:223) ~[cattle-framework-object-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.object.impl.JooqObjectManager.setFieldsInternal(JooqObjectManager.java:130) ~[cattle-framework-object-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.object.impl.JooqObjectManager$3.execute(JooqObjectManager.java:118) ~[cattle-framework-object-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.idempotent.Idempotent.change(Idempotent.java:88) ~[cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.object.impl.JooqObjectManager.setFields(JooqObjectManager.java:115) ~[cattle-framework-object-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.object.impl.JooqObjectManager.setFields(JooqObjectManager.java:110) ~[cattle-framework-object-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.object.impl.AbstractObjectManager.setFields(AbstractObjectManager.java:139) ~[cattle-framework-object-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.activity.impl.ActivityLogImpl.close(ActivityLogImpl.java:81) ~[cattle-activity-log-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.activity.impl.EntryImpl.close(EntryImpl.java:23) ~[cattle-activity-log-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.activity.ActivityService.run(ActivityService.java:48) ~[cattle-activity-log-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.servicediscovery.deployment.impl.DeploymentManagerImpl$5.run(DeploymentManagerImpl.java:502) ~[cattle-iaas-service-discovery-server-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.configitem.version.impl.ConfigItemStatusManagerImpl$1.doWithLock(ConfigItemStatusManagerImpl.java:92) ~[cattle-config-item-common-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl$4.doWithLock(AbstractLockManagerImpl.java:50) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.LockManagerImpl.doLock(LockManagerImpl.java:33) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl.tryLock(AbstractLockManagerImpl.java:25) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl.tryLock(AbstractLockManagerImpl.java:47) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.configitem.version.impl.ConfigItemStatusManagerImpl.runUpdateForEvent(ConfigItemStatusManagerImpl.java:85) ~[cattle-config-item-common-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.servicediscovery.deployment.impl.DeploymentManagerImpl.serviceUpdate(DeploymentManagerImpl.java:495) ~[cattle-iaas-service-discovery-server-0.5.0-SNAPSHOT.jar:na]
	at sun.reflect.GeneratedMethodAccessor1689.invoke(Unknown Source) ~[na:na]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.7.0_121]
	at java.lang.reflect.Method.invoke(Method.java:606) ~[na:1.7.0_121]
	at io.cattle.platform.eventing.annotation.MethodInvokingListener$1.doWithLockNoResult(MethodInvokingListener.java:76) ~[cattle-framework-eventing-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.LockCallbackNoReturn.doWithLock(LockCallbackNoReturn.java:7) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.LockCallbackNoReturn.doWithLock(LockCallbackNoReturn.java:3) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl$3.doWithLock(AbstractLockManagerImpl.java:40) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.LockManagerImpl.doLock(LockManagerImpl.java:33) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl.lock(AbstractLockManagerImpl.java:13) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl.lock(AbstractLockManagerImpl.java:37) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.eventing.annotation.MethodInvokingListener.onEvent(MethodInvokingListener.java:72) ~[cattle-framework-eventing-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.eventing.impl.AbstractThreadPoolingEventService$2.doRun(AbstractThreadPoolingEventService.java:141) ~[cattle-framework-eventing-0.5.0-SNAPSHOT.jar:na]
	at org.apache.cloudstack.managed.context.NoExceptionRunnable.runInContext(NoExceptionRunnable.java:15) ~[cattle-framework-managed-context-0.5.0-SNAPSHOT.jar:na]
	at org.apache.cloudstack.managed.context.ManagedContextRunnable$1.run(ManagedContextRunnable.java:49) [cattle-framework-managed-context-0.5.0-SNAPSHOT.jar:na]
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext$1.call(DefaultManagedContext.java:55) [cattle-framework-managed-context-0.5.0-SNAPSHOT.jar:na]
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.callWithContext(DefaultManagedContext.java:108) [cattle-framework-managed-context-0.5.0-SNAPSHOT.jar:na]
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.runWithContext(DefaultManagedContext.java:52) [cattle-framework-managed-context-0.5.0-SNAPSHOT.jar:na]
	at org.apache.cloudstack.managed.context.ManagedContextRunnable.run(ManagedContextRunnable.java:46) [cattle-framework-managed-context-0.5.0-SNAPSHOT.jar:na]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_121]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_121]
	at java.lang.Thread.run(Thread.java:745) [na:1.7.0_121]
2017-01-16 19:05:22,610 ERROR [:] [] [] [] [TaskScheduler-1] [i.c.p.a.s.ping.impl.PingMonitorImpl ] Failed to get ping from agent [166] count [10] 
2017-01-16 19:05:25,608 ERROR [c57c1bd7-5664-4a98-942e-69d0b96522ab:11490] [service:193] [service.deactivate] [] [tp107525988-140] [c.p.e.p.i.DefaultProcessInstanceImpl] Exiting with code [STATE_CHANGED] : STATE_CHANGED 
2017-01-16 19:05:25,613 ERROR [:] [] [] [] [tp107525988-140] [i.g.i.g.r.handler.ExceptionHandler  ] Exception in API for request [http://localhost:8081/v1/services/1s193/]. Error id: [7e23eaff-5352-4a05-878f-b6f974a854a8]. io.cattle.platform.engine.process.ProcessInstanceException: io.cattle.platform.engine.process.impl.ProcessExecutionExitException: STATE_CHANGED
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl.executeWithProcessInstanceLock(DefaultProcessInstanceImpl.java:171) ~[cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl$1.doWithLock(DefaultProcessInstanceImpl.java:116) ~[cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl$1.doWithLock(DefaultProcessInstanceImpl.java:113) ~[cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl$3.doWithLock(AbstractLockManagerImpl.java:40) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.LockManagerImpl.doLock(LockManagerImpl.java:33) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl.lock(AbstractLockManagerImpl.java:13) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.lock.impl.AbstractLockManagerImpl.lock(AbstractLockManagerImpl.java:37) ~[cattle-framework-lock-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.process.impl.DefaultProcessInstanceImpl.execute(DefaultProcessInstanceImpl.java:113) ~[cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.engine.manager.impl.DefaultProcessManager.scheduleProcessInstance(DefaultProcessManager.java:69) ~[cattle-framework-engine-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.object.process.impl.DefaultObjectProcessManager.scheduleProcessInstance(DefaultObjectProcessManager.java:50) ~[cattle-framework-object-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.object.process.impl.DefaultObjectProcessManager.scheduleProcessInstance(DefaultObjectProcessManager.java:55) ~[cattle-framework-object-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.api.resource.AbstractObjectResourceManager$1.run(AbstractObjectResourceManager.java:398) ~[cattle-framework-api-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.api.resource.AbstractObjectResourceManager.scheduleProcess(AbstractObjectResourceManager.java:414) ~[cattle-framework-api-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.api.resource.AbstractObjectResourceManager.scheduleProcess(AbstractObjectResourceManager.java:395) ~[cattle-framework-api-0.5.0-SNAPSHOT.jar:na]
	at io.cattle.platform.api.resource.AbstractObjectResourceManager.resourceActionInternal(AbstractObjectResourceManager.java:380) ~[cattle-framework-api-0.5.0-SNAPSHOT.jar:na]
at io.github.ibuildthecloud.gdapi.request.resource.impl.AbstractBaseResourceManager.resourceAction(AbstractBaseResourceManager.java:414) ~[cattle-framework-java-server-0.5.0-
```