### PR TITLE
Enable multi-role auth in agents

### DIFF
--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/dao/AgentInstanceDao.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/dao/AgentInstanceDao.java
@@ -1,7 +1,6 @@
 package io.cattle.platform.agent.instance.dao;
 
 import io.cattle.platform.core.model.Agent;
-import io.cattle.platform.core.model.Credential;
 import io.cattle.platform.core.model.Instance;
 
 import java.util.List;
@@ -12,7 +11,7 @@ public interface AgentInstanceDao {
 
     Instance getInstanceByAgent(Agent agent);
 
-    List<? extends Credential> getActivateCredentials(Agent agent);
+    boolean areAllCredentialsActive(Agent agent);
 
     List<Long> getAgentProvider(String providedServiceLabel, long accountId);
 

--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/factory/impl/AgentInstanceBuilderImpl.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/factory/impl/AgentInstanceBuilderImpl.java
@@ -9,6 +9,7 @@ import io.cattle.platform.object.util.DataAccessor;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import com.netflix.config.DynamicStringProperty;
 
@@ -27,17 +28,17 @@ public class AgentInstanceBuilderImpl implements AgentInstanceBuilder {
     boolean accountOwned = true;
     boolean managedConfig = false;
     boolean privileged = false;
-    Map<String, Object> accountData = null;
     AgentInstanceFactoryImpl factory;
     String uri;
     Map<String, Object> params = new HashMap<>();
+    Set<String> requestedRoles;
 
     public AgentInstanceBuilderImpl(AgentInstanceFactoryImpl factory) {
         super();
         this.factory = factory;
     }
 
-    public AgentInstanceBuilderImpl(AgentInstanceFactoryImpl factory, Instance instance, Map<String, Object> accountData) {
+    public AgentInstanceBuilderImpl(AgentInstanceFactoryImpl factory, Instance instance, Set<String> roles) {
         this(factory);
         this.accountId = instance.getAccountId();
         this.zoneId = instance.getZoneId();
@@ -49,7 +50,7 @@ public class AgentInstanceBuilderImpl implements AgentInstanceBuilder {
         }
         this.uri = uriPrefix + ":///instanceId=" + instance.getId();
         this.resourceAccountId = instance.getAccountId();
-        this.accountData = accountData;
+        this.requestedRoles = roles;
     }
 
     @Override
@@ -175,8 +176,8 @@ public class AgentInstanceBuilderImpl implements AgentInstanceBuilder {
         return params;
     }
 
-    public Map<String, Object> getAccountData() {
-        return accountData;
+    public Set<String> getRequestedRoles() {
+        return requestedRoles;
     }
 
     public Long getResourceAccountId() {

--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/serialization/AgentInstanceAuthObjectPostProcessor.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/serialization/AgentInstanceAuthObjectPostProcessor.java
@@ -1,7 +1,10 @@
 package io.cattle.platform.agent.instance.serialization;
 
 import io.cattle.platform.agent.util.AgentUtils;
+import io.cattle.platform.core.constants.AccountConstants;
+import io.cattle.platform.core.constants.AgentConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
+import io.cattle.platform.core.model.Account;
 import io.cattle.platform.core.model.Agent;
 import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.object.ObjectManager;
@@ -9,6 +12,7 @@ import io.cattle.platform.object.serialization.ObjectTypeSerializerPostProcessor
 import io.cattle.platform.object.util.DataAccessor;
 import io.cattle.platform.object.util.DataUtils;
 
+import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -35,12 +39,39 @@ public class AgentInstanceAuthObjectPostProcessor implements ObjectTypeSerialize
             return;
         }
 
-        Map<String, Object> auth = AgentUtils.getAgentAuth(agent, objectManager);
+        List<Long> authedRoleAccountIds = DataAccessor.fieldLongList(agent, AgentConstants.FIELD_AUTHORIZED_ROLE_ACCOUNTS);
+        if (authedRoleAccountIds.isEmpty()) {
+            Map<String, Object> auth = AgentUtils.getAgentAuth(agent, objectManager);
+            setAuthEnvVars(data, auth);
+        } else {
+            // Primary agent account
+            Account account = objectManager.loadResource(Account.class, agent.getAccountId());
+            Map<String, Object> auth = AgentUtils.getAccountScopedAuth(account, objectManager, account.getKind());
+            setAuthEnvVars(data, auth);
+
+            // Secondary authed roles
+            for (Long accountId : authedRoleAccountIds) {
+                account = objectManager.loadResource(Account.class, accountId);
+                String scope = null;
+                if (DataAccessor.fromDataFieldOf(account).withKey(AccountConstants.DATA_ACT_AS_RESOURCE_ACCOUNT).withDefault(false).as(Boolean.class)) {
+                    scope = "ENVIRONMENT";
+                } else if (DataAccessor.fromDataFieldOf(account).withKey(AccountConstants.DATA_ACT_AS_RESOURCE_ADMIN_ACCOUNT).withDefault(false)
+                        .as(Boolean.class)) {
+                    scope = "ENVIRONMENT_ADMIN";
+                }
+                if (scope != null) {
+                    Map<String, Object> secondaryAuth = AgentUtils.getAccountScopedAuth(account, objectManager, scope);
+                    setAuthEnvVars(data, secondaryAuth);
+                }
+            }
+        }
+    }
+
+    void setAuthEnvVars(Map<String, Object> data, Map<String, Object> auth) {
         if (auth != null) {
             Map<String, Object> fields = DataUtils.getWritableFields(data);
             for (Map.Entry<String, Object> entry : auth.entrySet()) {
-                    DataAccessor.fromMap(fields)
-                        .withScopeKey(InstanceConstants.FIELD_ENVIRONMENT).withKey(entry.getKey()).set(entry.getValue());
+                DataAccessor.fromMap(fields).withScopeKey(InstanceConstants.FIELD_ENVIRONMENT).withKey(entry.getKey()).set(entry.getValue());
             }
         }
     }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/internal/rancher/BasicAuthImpl.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/internal/rancher/BasicAuthImpl.java
@@ -91,7 +91,14 @@ public class BasicAuthImpl implements AccountLookup, Priority {
         }
 
         if (shouldSwitch) {
-            Agent agent = objectManager.findAny(Agent.class, AGENT.ACCOUNT_ID, account.getId());
+            Long agentOwnerId = DataAccessor.fromDataFieldOf(account).withKey(AccountConstants.DATA_AGENT_OWNER_ID).as(Long.class);
+            Agent agent = null;
+            if (agentOwnerId != null) {
+                agent = objectManager.findAny(Agent.class, AGENT.ID, agentOwnerId);
+            } else {
+                agent = objectManager.findAny(Agent.class, AGENT.ACCOUNT_ID, account.getId()); 
+            }
+
             if (agent != null) {
                 Long resourceAccId = DataAccessor.fromDataFieldOf(agent)
                         .withKey(AgentConstants.DATA_AGENT_RESOURCES_ACCOUNT_ID)

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/account/AccountCreate.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/account/AccountCreate.java
@@ -55,7 +55,7 @@ public class AccountCreate extends AbstractDefaultProcessHandler {
         String apiKeyKind = DataAccessor.fromMap(state.getData()).withScope(AccountConstants.class).withKey(AccountConstants.OPTION_CREATE_APIKEY_KIND)
                 .withDefault(CREDENTIAL_TYPE.get()).as(String.class);
 
-        if (shouldCreateCredentials(account)) {
+        if (shouldCreateCredentials(account, state)) {
             if (createApiKey || CREATE_CREDENTIAL.get()) {
                 List<Credential> creds = ProcessHelpers.createOneChild(getObjectManager(), processManager, account, Credential.class, CREDENTIAL.ACCOUNT_ID,
                         account.getId(), CREDENTIAL.KIND, apiKeyKind);
@@ -75,8 +75,7 @@ public class AccountCreate extends AbstractDefaultProcessHandler {
         return new HandlerResult(result);
     }
 
-
-    public boolean shouldCreateCredentials(Account account) {
+    public boolean shouldCreateCredentials(Account account, ProcessState state) {
         return ACCOUNT_KIND_CREDENTIALS.get().contains(account.getKind());
     }
 

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/agent/AgentCreate.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/agent/AgentCreate.java
@@ -7,15 +7,23 @@ import io.cattle.platform.core.constants.AccountConstants;
 import io.cattle.platform.core.constants.AgentConstants;
 import io.cattle.platform.core.constants.CredentialConstants;
 import io.cattle.platform.core.dao.AccountDao;
+import io.cattle.platform.core.dao.InstanceDao;
 import io.cattle.platform.core.model.Account;
 import io.cattle.platform.core.model.Agent;
 import io.cattle.platform.engine.handler.HandlerResult;
 import io.cattle.platform.engine.process.ProcessInstance;
 import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.json.JsonMapper;
 import io.cattle.platform.object.util.DataAccessor;
 import io.cattle.platform.process.base.AbstractDefaultProcessHandler;
+import io.cattle.platform.util.type.CollectionUtils;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -27,8 +35,15 @@ public class AgentCreate extends AbstractDefaultProcessHandler {
 
     private static final DynamicBooleanProperty CREATE_ACCOUNT = ArchaiusUtil.getBoolean("process.agent.create.create.account");
 
+    @Inject
+    JsonMapper jsonMapper;
+
+    @Inject
     AccountDao accountDao;
 
+    @Inject
+    InstanceDao instanceDao;
+    
     @Override
     public HandlerResult handle(ProcessState state, ProcessInstance process) {
         Agent agent = (Agent) state.getResource();
@@ -43,13 +58,28 @@ public class AgentCreate extends AbstractDefaultProcessHandler {
         DataAccessor.fromMap(state.getData()).withScope(AccountConstants.class).withKey(AccountConstants.OPTION_CREATE_APIKEY_KIND).set(
                 CredentialConstants.KIND_AGENT_API_KEY);
 
-        Account account = createAccountObj(agent);
+        List<? extends String> roles =
+                DataAccessor.fromDataFieldOf(agent).withKey(AgentConstants.DATA_REQUESTED_ROLES).withDefault(Collections.EMPTY_LIST)
+                        .asList(jsonMapper, String.class);
+        sortRoles(roles);
+
+        String primaryRole = getPrimaryRole(roles); // note null is an acceptable value 
+        Account account = createPrimaryAccount(agent, primaryRole);
         create(account, state.getData());
 
-        return new HandlerResult(AGENT.ACCOUNT_ID, account.getId());
+        Map<String, Object> data = new HashMap<>();
+        data.put(AgentConstants.FIELD_ACCOUNT_ID, account.getId());
+
+        List<? extends String> secondaryRoles = getSecondaryRoles(roles);
+        List<Long> authedRoleAccounts = createSecondaryAccounts(agent, secondaryRoles, state);
+        if (!authedRoleAccounts.isEmpty()) {
+            data.put(AgentConstants.FIELD_AUTHORIZED_ROLE_ACCOUNTS, authedRoleAccounts);
+        }
+
+        return new HandlerResult(data);
     }
 
-    protected Account createAccountObj(Agent agent) {
+    protected Account createPrimaryAccount(Agent agent, String role) {
         if (agent.getAccountId() != null) {
             return getObjectManager().loadResource(Account.class, agent.getAccountId());
         }
@@ -58,17 +88,99 @@ public class AgentCreate extends AbstractDefaultProcessHandler {
         Account account = accountDao.findByUuid(uuid);
 
         if (account == null) {
-            Object obj = DataAccessor.fromDataFieldOf(agent).withKey(AgentConstants.DATA_ACCOUNT_DATA).get();
-            if (obj == null) {
-                obj = new HashMap<>();
-            }
+            Object data = createAccountDataWithActAsValue(role);
             account = getObjectManager().create(Account.class,
                     ACCOUNT.UUID, uuid,
-                    ACCOUNT.DATA, obj,
+                    ACCOUNT.DATA, data,
                     ACCOUNT.KIND, "agent");
         }
 
         return account;
+    }
+
+    protected List<Long> createSecondaryAccounts(Agent agent, List<? extends String> roles, ProcessState state) {
+        if (roles.isEmpty()) {
+            return new ArrayList<Long>();
+        }
+
+        List<Long> authedRoleAccountIds = DataAccessor.fieldLongList(agent, AgentConstants.FIELD_AUTHORIZED_ROLE_ACCOUNTS);
+        if (authedRoleAccountIds != null && !authedRoleAccountIds.isEmpty()) {
+            return authedRoleAccountIds;
+        }
+
+        authedRoleAccountIds = new ArrayList<Long>();
+        for (String role : roles) {
+            String uuid = getAccountUuid(agent, role);
+            Account account = accountDao.findByUuid(uuid);
+
+            Map<String, Object> data = createAccountDataWithActAsValue(role);
+            data.put(AccountConstants.DATA_AGENT_OWNER_ID, agent.getId());
+
+            if (account == null) {
+                account = getObjectManager().create(Account.class,
+                        ACCOUNT.UUID, uuid,
+                        ACCOUNT.DATA, data,
+                        ACCOUNT.KIND, "agent");
+            }
+            create(account, state.getData());
+            authedRoleAccountIds.add(account.getId());
+        }
+
+        return authedRoleAccountIds;
+    }
+
+    Map<String, Object> createAccountDataWithActAsValue(String r) {
+        if ("environment".equals(r)) {
+            return CollectionUtils.asMap(AccountConstants.DATA_ACT_AS_RESOURCE_ACCOUNT, true);
+        } else if ("environmentAdmin".equals(r)) {
+            return CollectionUtils.asMap(AccountConstants.DATA_ACT_AS_RESOURCE_ADMIN_ACCOUNT, true);
+        }
+        return new HashMap<>();
+    }
+
+    private void sortRoles(List<? extends String> roles) {
+        Collections.sort(roles, new Comparator<String>() {
+            @Override
+            public int compare(String lhs, String rhs) {
+                if (lhs.equals(rhs)) {
+                    return 0;
+                }
+
+                if ("agent".equals(lhs)) {
+                    return -1;
+                } else if ("agent".equals(rhs)) {
+                    return 1;
+                }
+
+                if ("environmentAdmin".equals(lhs)) {
+                    return -1;
+                } else if ("environmentAdmin".equals(rhs)) {
+                    return 1;
+                }
+
+                return 0;
+            }
+        });
+    }
+
+    private String getPrimaryRole(List<? extends String> roles) {
+        if (roles.isEmpty()) {
+            return null;
+        }
+        return roles.get(0);
+    }
+
+    private List<? extends String> getSecondaryRoles(List<? extends String> roles) {
+        if (roles.isEmpty()) {
+            return roles;
+        } else if (roles.size() == 1){
+            return new ArrayList<String>();
+        }
+        return roles.subList(1, roles.size());
+    }
+
+    protected String getAccountUuid(Agent agent, String role) {
+        return "agentAccount" + agent.getId() + "-" + role;
     }
 
     protected String getAccountUuid(Agent agent) {
@@ -78,10 +190,4 @@ public class AgentCreate extends AbstractDefaultProcessHandler {
     public AccountDao getAccountDao() {
         return accountDao;
     }
-
-    @Inject
-    public void setAccountDao(AccountDao accountDao) {
-        this.accountDao = accountDao;
-    }
-
 }

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/agent/AgentRemove.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/agent/AgentRemove.java
@@ -1,6 +1,7 @@
 package io.cattle.platform.process.agent;
 
 import io.cattle.platform.agent.util.AgentUtils;
+import io.cattle.platform.core.constants.AgentConstants;
 import io.cattle.platform.core.constants.StoragePoolConstants;
 import io.cattle.platform.core.model.Account;
 import io.cattle.platform.core.model.Agent;
@@ -8,8 +9,11 @@ import io.cattle.platform.core.model.StoragePool;
 import io.cattle.platform.engine.handler.HandlerResult;
 import io.cattle.platform.engine.process.ProcessInstance;
 import io.cattle.platform.engine.process.ProcessState;
+import io.cattle.platform.object.util.DataAccessor;
 import io.cattle.platform.process.common.handler.AbstractObjectProcessHandler;
 import io.github.ibuildthecloud.gdapi.factory.SchemaFactory;
+
+import java.util.List;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -42,6 +46,7 @@ public class AgentRemove extends AbstractObjectProcessHandler {
                 continue;
             }
 
+            
             for (Object obj : objectManager.children(agent, clz)) {
                 if (obj instanceof StoragePool) {
                     StoragePool sp = (StoragePool)obj;
@@ -55,6 +60,11 @@ public class AgentRemove extends AbstractObjectProcessHandler {
         }
 
         deactivateThenScheduleRemove(objectManager.loadResource(Account.class, agent.getAccountId()), state.getData());
+
+        List<Long> authedRoleAccountIds = DataAccessor.fieldLongList(agent, AgentConstants.FIELD_AUTHORIZED_ROLE_ACCOUNTS);
+        for (Long accountId : authedRoleAccountIds) {
+            deactivateThenScheduleRemove(objectManager.loadResource(Account.class, accountId), state.getData());
+        }
 
         return null;
     }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/AccountConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/AccountConstants.java
@@ -43,6 +43,7 @@ public class AccountConstants {
     public static final String FIELD_ORCHESTRATION = "orchestration";
 
     public static final String DATA_ACT_AS_RESOURCE_ACCOUNT = "actAsResourceAccount";
+    public static final String DATA_AGENT_OWNER_ID = "agentOwnerId";
 
     public static final String DATA_ACT_AS_RESOURCE_ADMIN_ACCOUNT = "actAsResourceAdminAccount";
 

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/AgentConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/AgentConstants.java
@@ -11,8 +11,11 @@ public class AgentConstants {
     public static final String STATE_RECONNECTED = "reconnected";
     public static final String ID_REF = "agentId";
 
+    public static final String FIELD_ACCOUNT_ID = "accountId";
+    public static final String FIELD_AUTHORIZED_ROLE_ACCOUNTS = "authorizedRoleAccountIds";
+    
     public static final String DATA_AGENT_RESOURCES_ACCOUNT_ID = "agentResourcesAccountId";
-    public static final String DATA_ACCOUNT_DATA = "accountData";
+    public static final String DATA_REQUESTED_ROLES = "requestedRoles";
 
     public static final String PROCESS_ACTIVATE = "agent.activate";
     public static final String PROCESS_RECONNECT = "agent.reconnect";

--- a/resources/content/schema/base/agent.json
+++ b/resources/content/schema/base/agent.json
@@ -15,6 +15,10 @@
         "uri": {
             "type": "string",
             "unique": true
+        },
+        "authorizedRoleAccountIds": {
+            "type": "array[reference[account]]",
+            "nullable": true
         }
     },
     "resourceActions" : {

--- a/tests/integration/cattletest/core/test_agent.py
+++ b/tests/integration/cattletest/core/test_agent.py
@@ -72,6 +72,41 @@ def test_agent_create_for_env_role(context, super_client):
     assert 'POST' in agent_client.schema.types['container'].collectionMethods
 
 
+def test_agent_create_for_multi_roles(context, super_client):
+    c = context.create_container(labels={
+        'io.rancher.container.create_agent': 'true',
+        'io.rancher.container.agent.role': 'agent,environment'
+    })
+
+    c = super_client.reload(c)
+    agent = super_client.wait_success(c.agent())
+
+    # Assert that the primary account has "agent" privileges
+    assert agent.state == 'active'
+    primary_account = agent.account()
+    cred = agent.account().credentials()[0]
+    assert cred.publicValue is not None
+    assert cred.secretValue is not None
+    agent_client = api_client(cred.publicValue, cred.secretValue)
+    assert 'container' not in agent_client.schema.types
+
+    # Assert that the secondary account has "environment" privileges
+    assert len(agent.authorizedRoleAccountIds) == 1
+    account = super_client.by_id("account", agent.authorizedRoleAccountIds[0])
+    assert account.kind == 'agent'
+    cred = account.credentials()[0]
+    assert cred.publicValue is not None
+    assert cred.secretValue is not None
+    agent_client = api_client(cred.publicValue, cred.secretValue)
+    assert 'POST' in agent_client.schema.types['container'].collectionMethods
+
+    agent = super_client.wait_success(agent.deactivate())
+    agent = super_client.wait_success(agent.remove())
+    assert agent.removed is not None
+    wait_for(lambda: super_client.reload(account).state == 'removed')
+    wait_for(lambda: super_client.reload(primary_account).state == 'removed')
+
+
 def test_agent_create_for_not_env_role(context, super_client):
     c = context.create_container(labels={
         'io.rancher.container.create_agent': 'true',


### PR DESCRIPTION
Expands the functionality of the io.rancher.container.agent.role label
to allow a comma delimited list of roles.