### PR TITLE
Reworked db upgrade for volume.uri field

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/Volume.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/Volume.java
@@ -242,7 +242,7 @@ public interface Volume extends java.io.Serializable {
 	/**
 	 * Getter for <code>cattle.volume.uri</code>.
 	 */
-	@javax.persistence.Column(name = "uri", length = 512)
+	@javax.persistence.Column(name = "uri", length = 255)
 	public java.lang.String getUri();
 
 	/**

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/VolumeTable.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/VolumeTable.java
@@ -11,7 +11,7 @@ package io.cattle.platform.core.model.tables;
 @java.lang.SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class VolumeTable extends org.jooq.impl.TableImpl<io.cattle.platform.core.model.tables.records.VolumeRecord> {
 
-	private static final long serialVersionUID = 1693280794;
+	private static final long serialVersionUID = 2135625558;
 
 	/**
 	 * The singleton instance of <code>cattle.volume</code>
@@ -129,7 +129,7 @@ public class VolumeTable extends org.jooq.impl.TableImpl<io.cattle.platform.core
 	/**
 	 * The column <code>cattle.volume.uri</code>.
 	 */
-	public final org.jooq.TableField<io.cattle.platform.core.model.tables.records.VolumeRecord, java.lang.String> URI = createField("uri", org.jooq.impl.SQLDataType.VARCHAR.length(512), this, "");
+	public final org.jooq.TableField<io.cattle.platform.core.model.tables.records.VolumeRecord, java.lang.String> URI = createField("uri", org.jooq.impl.SQLDataType.VARCHAR.length(255), this, "");
 
 	/**
 	 * The column <code>cattle.volume.external_id</code>.

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/records/VolumeRecord.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/model/tables/records/VolumeRecord.java
@@ -13,7 +13,7 @@ package io.cattle.platform.core.model.tables.records;
 @javax.persistence.Table(name = "volume", schema = "cattle")
 public class VolumeRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.platform.core.model.tables.records.VolumeRecord> implements io.cattle.platform.db.jooq.utils.TableRecordJaxb, io.cattle.platform.core.model.Volume {
 
-	private static final long serialVersionUID = 983309391;
+	private static final long serialVersionUID = -705639029;
 
 	/**
 	 * Setter for <code>cattle.volume.id</code>.
@@ -367,7 +367,7 @@ public class VolumeRecord extends org.jooq.impl.UpdatableRecordImpl<io.cattle.pl
 	/**
 	 * Getter for <code>cattle.volume.uri</code>.
 	 */
-	@javax.persistence.Column(name = "uri", length = 512)
+	@javax.persistence.Column(name = "uri", length = 255)
 	@Override
 	public java.lang.String getUri() {
 		return (java.lang.String) getValue(20);

--- a/resources/content/db/mysql/mysql-dump.sql
+++ b/resources/content/db/mysql/mysql-dump.sql
@@ -3717,7 +3717,7 @@ CREATE TABLE `volume` (
   `image_id` bigint(20) DEFAULT NULL,
   `offering_id` bigint(20) DEFAULT NULL,
   `zone_id` bigint(20) DEFAULT NULL,
-  `uri` varchar(512) DEFAULT NULL,
+  `uri` varchar(255) DEFAULT NULL,
   `external_id` varchar(128) DEFAULT NULL,
   `access_mode` varchar(255) DEFAULT NULL,
   `host_id` bigint(20) DEFAULT NULL,


### PR DESCRIPTION
@ibuildthecloud long story.. so volume.uri field was shortened from 512 to 255 as a part of this [pr](https://github.com/rancher/cattle/pull/2209), but instead of creating new core file, the old one core-019 was modified. Then looks like on your branch you already had an old version of this file in DATABASE_CHANGE_LOG, so running codegen reset the field back to 512 in VolumeTable.

The fix is: proper upgrade + regenerated jooq