### PR TITLE
WIP Support calling more than one external scheduler

### DIFF
--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/dao/impl/AgentInstanceDaoImpl.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/dao/impl/AgentInstanceDaoImpl.java
@@ -18,13 +18,24 @@ import io.cattle.platform.core.model.tables.LabelTable;
 import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
 import io.cattle.platform.object.ObjectManager;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 
+import org.jooq.Record2;
+import org.jooq.RecordHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class AgentInstanceDaoImpl extends AbstractJooqDao implements AgentInstanceDao {
+
+    private static final Logger log = LoggerFactory.getLogger(AgentInstanceDaoImpl.class);
 
     GenericResourceDao resourceDao;
     ObjectManager objectManager;
@@ -65,8 +76,9 @@ public class AgentInstanceDaoImpl extends AbstractJooqDao implements AgentInstan
     @Override
     public List<Long> getAgentProvider(String providedServiceLabel, long accountId) {
         String priorityLabel = providedServiceLabel + ".priority";
-        LabelTable priority = LABEL.as("priority");
-        return Arrays.asList(create().select(INSTANCE.AGENT_ID)
+        final LabelTable priority = LABEL.as("priority");
+        final Map<Long, Integer> result = new HashMap<>();
+        create().select(INSTANCE.AGENT_ID, priority.VALUE)
                 .from(INSTANCE)
                 .join(INSTANCE_LABEL_MAP)
                     .on(INSTANCE_LABEL_MAP.INSTANCE_ID.eq(INSTANCE.ID))
@@ -80,7 +92,34 @@ public class AgentInstanceDaoImpl extends AbstractJooqDao implements AgentInstan
                         .and(INSTANCE.HEALTH_STATE.in(HealthcheckConstants.HEALTH_STATE_HEALTHY,
                                 HealthcheckConstants.HEALTH_STATE_UPDATING_HEALTHY)))
                 .orderBy(priority.VALUE.asc(), INSTANCE.AGENT_ID.asc())
-                .fetch().intoArray(INSTANCE.AGENT_ID));
+        .fetchInto(new RecordHandler<Record2<Long, String>>() {
+            @Override
+            public void next(Record2<Long, String> record) {
+                Long agentId = record.getValue(INSTANCE.AGENT_ID);
+                String p = record.getValue(priority.VALUE);
+                Integer pVal = 10000;
+                try {
+                    pVal = Integer.valueOf(p);
+                } catch (Exception e) {
+                    log.warn("Found bad priority label value {} for agent {}", p, agentId);
+                }
+                result.put(agentId, pVal);
+            }
+        });
+        
+        List<Long> returnAgentIds = new ArrayList<>(result.keySet());
+        
+        Collections.sort(returnAgentIds, new Comparator<Long>() {
+            @Override
+            public int compare(Long id1, Long id2) {
+                
+                return -1;
+                //return Long.compare(d1.getCreateIndex(), d2.getCreateIndex());
+            }
+        });
+        
+        return returnAgentIds;
+        
     }
 
     @Override


### PR DESCRIPTION
Chain the schedulers one after another based on a priority label and
add a context property to the even sent to them that contains all the
instances being scheduled so that the event can be generic.

We need to change the logic for prioritizing schedulers. Because the value is a string, the sorting wont behave as expected for numbers. Also, the value field is not indexed, so it is not an optimal query.

I have some work started on a jooq result handler and comparator.