### PR TITLE
lb with default image can act as environment admin account

### DIFF
--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/factory/impl/AgentInstanceFactoryImpl.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/factory/impl/AgentInstanceFactoryImpl.java
@@ -154,7 +154,7 @@ public class AgentInstanceFactoryImpl implements AgentInstanceFactory {
         List<? extends Service> services = instanceDao.findServicesNonRemovedLinksOnly(instance);
         for (Service service : services) {
             Stack stack = objectManager.loadResource(Stack.class, service.getStackId());
-            if (ServiceConstants.isSystem(stack)) {
+            if (ServiceConstants.isSystem(stack) || isLBSystemService(service)) {
                 return true;
             }
         }


### PR DESCRIPTION
@cjellick could you review? looks like isLbSystemService check gone missing with multi role agent. We have this special handling just for lb service as it is not being deployed as a part of "system" catalog services, yet it requires a system role - it needs to fetch the certs.

https://github.com/rancher/rancher/issues/7555