### PR TITLE
Issue tokens yearly

### DIFF
--- a/code/implementation/register/src/main/java/io/cattle/platform/register/util/RegistrationToken.java
+++ b/code/implementation/register/src/main/java/io/cattle/platform/register/util/RegistrationToken.java
@@ -27,9 +27,11 @@ public class RegistrationToken {
 
     public static final String createToken(String accessKey, String secretKey) {
         Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        cal.set(Calendar.HOUR_OF_DAY, 0);
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);
         cal.set(Calendar.MILLISECOND, 0);
+        cal.set(Calendar.DAY_OF_YEAR, 0);
 
         return createToken(accessKey, secretKey, cal.getTime());
     }


### PR DESCRIPTION
Each registration token we issue is good for 10 years.  The problem is
that we issue a new one each minute and people assume that means the
last one isn't valid.  So now we will just issue a new one each year,
which is still valid for 10 years.  You can always invalidate the tokens
by deleting the registationToken in the API.