### PR TITLE
Fix where transitioning: error is not removed on next transition

### DIFF
--- a/code/iaas/logic-common/src/main/java/io/cattle/platform/process/common/generic/GenericResourceProcessState.java
+++ b/code/iaas/logic-common/src/main/java/io/cattle/platform/process/common/generic/GenericResourceProcessState.java
@@ -80,6 +80,8 @@ public class GenericResourceProcessState extends AbstractStatesBasedProcessState
 
     @Override
     protected boolean setState(boolean transitioning, String oldState, String newState) {
+        reload();
+
         if (resource != null && transitioning && ObjectMetaDataManager.STATE_FIELD.equals(getStatesDefinition().getStateField())) {
             DataAccessor field = DataAccessor.fields(resource).withKey(ObjectMetaDataManager.TRANSITIONING_FIELD);
             DataAccessor message = DataAccessor.fields(resource).withKey(ObjectMetaDataManager.TRANSITIONING_MESSAGE_FIELD);
@@ -91,7 +93,6 @@ public class GenericResourceProcessState extends AbstractStatesBasedProcessState
             }
         }
 
-        reload();
         String resourceState = lookupState();
         if (oldState == null || (!oldState.equals(resourceState) && !newState.equals(resourceState))) {
             return false;


### PR DESCRIPTION
We reloaded the instance before saving the modified transitioning
fields.