### PR TITLE
Support legacy port allocation

### DIFF
--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/dao/AgentInstanceDao.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/dao/AgentInstanceDao.java
@@ -9,7 +9,7 @@ public interface AgentInstanceDao {
 
     Agent getAgentByUri(String uri);
 
-    Instance getInstanceByAgent(Agent agent);
+    Instance getInstanceByAgent(Long agentId);
 
     boolean areAllCredentialsActive(Agent agent);
 

--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/dao/impl/AgentInstanceDaoImpl.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/dao/impl/AgentInstanceDaoImpl.java
@@ -44,10 +44,14 @@ public class AgentInstanceDaoImpl extends AbstractJooqDao implements AgentInstan
     }
 
     @Override
-    public Instance getInstanceByAgent(Agent agent) {
+    public Instance getInstanceByAgent(Long agentId) {
+        if (agentId == null) {
+            return null;
+        }
+
         return create()
                 .selectFrom(INSTANCE)
-                .where(INSTANCE.AGENT_ID.eq(agent.getId())
+                .where(INSTANCE.AGENT_ID.eq(agentId)
                         .and(INSTANCE.REMOVED.isNull())
                         .and(INSTANCE.STATE.notIn(InstanceConstants.STATE_ERROR, InstanceConstants.STATE_ERRORING,
                                 CommonStatesConstants.REMOVING)))

--- a/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/factory/impl/AgentInstanceFactoryImpl.java
+++ b/code/iaas/agent-instance/src/main/java/io/cattle/platform/agent/instance/factory/impl/AgentInstanceFactoryImpl.java
@@ -78,7 +78,7 @@ public class AgentInstanceFactoryImpl implements AgentInstanceFactory {
     }
 
     private Instance getInstance(Agent agent, AgentInstanceBuilderImpl builder) {
-        Instance instance = factoryDao.getInstanceByAgent(agent);
+        Instance instance = factoryDao.getInstanceByAgent(agent.getId());
 
         if (instance != null) {
             return instance;
@@ -233,7 +233,7 @@ public class AgentInstanceFactoryImpl implements AgentInstanceFactory {
         return lockManager.lock(new AgentInstanceAgentCreateLock(agent.getUri()), new LockCallback<Instance>() {
             @Override
             public Instance doWithLock() {
-                Instance instance = factoryDao.getInstanceByAgent(agent);
+                Instance instance = factoryDao.getInstanceByAgent(agent.getId());
 
                 if (instance == null) {
                     instance = DeferredUtils.nest(new Callable<Instance>() {

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/PortsConstraint.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/PortsConstraint.java
@@ -1,0 +1,67 @@
+package io.cattle.platform.allocator.constraint;
+
+import io.cattle.platform.allocator.service.AllocationCandidate;
+import io.cattle.platform.core.constants.PortConstants;
+import io.cattle.platform.core.model.Port;
+import io.cattle.platform.object.util.DataAccessor;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class PortsConstraint extends HardConstraint implements Constraint {
+
+    List<Port> ports;
+
+    long instanceId;
+
+    public PortsConstraint(long instanceId, List<Port> ports) {
+        this.ports = ports;
+        this.instanceId = instanceId;
+    }
+
+    @Override
+    public boolean matches(AllocationCandidate candidate) {
+        if (candidate.getHost() == null) {
+            return false;
+        }
+
+        // TODO: Performance improvement. Move more of the filtering into the DB query itself
+        List<Port> portsUsedByHost = candidate.getUsedPorts();
+        for (Port portUsed : portsUsedByHost) {
+            for (Port requestedPort : ports) {
+                if (requestedPort.getPublicPort() != null &&
+                        requestedPort.getPublicPort().equals(portUsed.getPublicPort()) &&
+                        publicIpTheSame(requestedPort, portUsed) &&
+                        requestedPort.getProtocol().equals(portUsed.getProtocol())) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private boolean publicIpTheSame(Port requestedPort, Port portUsed) {
+        if (requestedPort.getPublicIpAddressId() != null) {
+            return requestedPort.getPublicIpAddressId().equals(portUsed.getPublicIpAddressId());
+        } else {
+            String requestedIp = DataAccessor.fields(requestedPort).withKey(PortConstants.FIELD_BIND_ADDR).as(String.class);
+            String usedIp = DataAccessor.fields(portUsed).withKey(PortConstants.FIELD_BIND_ADDR).as(String.class);
+            return StringUtils.equals(requestedIp, usedIp);
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        for (Port port: ports) {
+            if (sb.length() > 0) {
+                sb.append(", ");
+            }
+            sb.append(port.getPublicPort());
+            sb.append("/");
+            sb.append(port.getProtocol());
+        }
+        return String.format("host needs ports %s available", sb.toString());
+    }
+}

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/PortsConstraintProvider.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/constraint/PortsConstraintProvider.java
@@ -1,0 +1,50 @@
+package io.cattle.platform.allocator.constraint;
+
+import static io.cattle.platform.core.model.tables.PortTable.*;
+import io.cattle.platform.allocator.dao.AllocatorDao;
+import io.cattle.platform.allocator.exception.FailedToAllocate;
+import io.cattle.platform.allocator.service.AllocationAttempt;
+import io.cattle.platform.allocator.service.AllocationLog;
+import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.Port;
+import io.cattle.platform.object.ObjectManager;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+public class PortsConstraintProvider implements AllocationConstraintsProvider {
+
+    @Inject
+    AllocatorDao allocatorDao;
+
+    @Inject
+    ObjectManager objectManager;
+
+    @Override
+    public void appendConstraints(AllocationAttempt attempt, AllocationLog log, List<Constraint> constraints) {
+        Set<String> duplicatePorts = new HashSet<String>();
+        boolean checkForDupes = attempt.getInstances().size() > 1;
+        for (Instance instance : attempt.getInstances()) {
+            List<Port> ports = objectManager.find(Port.class, PORT.INSTANCE_ID, instance.getId(), PORT.REMOVED, null);
+            if (checkForDupes) {
+                for (Port port : ports) {
+                    String p = String.format("%s/%s", port.getPublicPort(), port.getProtocol());
+                    if (!duplicatePorts.add(p)) {
+                        throw new FailedToAllocate(String.format("Port %s requested more than once.", p));
+                    }
+                }
+            }
+            if (ports.size() > 0) {
+                constraints.add(new PortsConstraint(instance.getId(), ports));
+            }
+        }
+    }
+
+    @Override
+    public boolean isCritical() {
+        return false;
+    }
+}

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/eventing/impl/AllocatorServiceImpl.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/eventing/impl/AllocatorServiceImpl.java
@@ -33,16 +33,12 @@ public class AllocatorServiceImpl implements AllocatorService {
 
     @Override
     public void ensureResourcesReservedForStart(Instance instance) {
-        log.info("Ensuring resources reserved for instance.start [{}]", instance.getId());
         allocator.ensureResourcesReserved(instance);
-        log.info("Ensured resources released for instance.start [{}]", instance.getId());
     }
 
     @Override
     public void ensureResourcesReleasedForStop(Instance instance) {
-        log.info("Ensuring resources released for stop for instance [{}]", instance.getId());
         allocator.ensureResourcesReleased(instance);
-        log.info("Ensured resources released for stop for instance [{}]", instance.getId());
     }
 
     @Override

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AllocationCandidate.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AllocationCandidate.java
@@ -3,6 +3,7 @@ package io.cattle.platform.allocator.service;
 import io.cattle.platform.core.model.Port;
 import io.cattle.platform.object.ObjectManager;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -19,6 +20,7 @@ public class AllocationCandidate {
     String hostUuid;
     Map<Long, Long> subnetIds = new HashMap<Long, Long>();
     Map<Long, Set<Long>> pools = new HashMap<Long, Set<Long>>();
+    List<Port> usedPorts;
     ObjectManager objectManager;
     Map<Pair<Class<?>, Long>, Object> resources;
     boolean valid = true;
@@ -31,6 +33,7 @@ public class AllocationCandidate {
         this.hostUuid = candidate.hostUuid;
         this.subnetIds = candidate.subnetIds == null ? null : new HashMap<Long, Long>(candidate.subnetIds);
         this.pools = candidate.pools == null ? null : new HashMap<Long, Set<Long>>(candidate.pools);
+        this.usedPorts = candidate.usedPorts == null ? new ArrayList<Port>() : new ArrayList<Port>(candidate.usedPorts);
         this.objectManager = candidate.objectManager;
         this.resources = candidate.resources == null ? null : new HashMap<Pair<Class<?>, Long>, Object>(candidate.resources);
         this.valid = candidate.valid;
@@ -44,6 +47,7 @@ public class AllocationCandidate {
         this.host = hostId;
         this.hostUuid = hostUuid;
         this.pools = new HashMap<Long, Set<Long>>();
+        this.usedPorts = usedPorts;
 
         for (Map.Entry<Long, Long> entry : pools.entrySet()) {
             Set<Long> set = new HashSet<Long>();
@@ -99,6 +103,14 @@ public class AllocationCandidate {
 
     public void setPools(Map<Long, Set<Long>> pools) {
         this.pools = pools;
+    }
+
+    public List<Port> getUsedPorts() {
+        return usedPorts;
+    }
+
+    public void setUsedPorts(List<Port> ports) {
+        this.usedPorts = ports;
     }
 
     public boolean isValid() {

--- a/code/iaas/simple-allocator/src/main/java/io/cattle/platform/simple/allocator/dao/QueryOptions.java
+++ b/code/iaas/simple-allocator/src/main/java/io/cattle/platform/simple/allocator/dao/QueryOptions.java
@@ -7,6 +7,7 @@ public class QueryOptions {
 
     Long accountId;
     String kind;
+    boolean includeUsedPorts;
     Set<Long> hosts = new HashSet<Long>();
     Long requestedHostId;
 
@@ -28,6 +29,14 @@ public class QueryOptions {
 
     public void setAccountId(Long accountId) {
         this.accountId = accountId;
+    }
+
+    public boolean isIncludeUsedPorts() {
+        return includeUsedPorts;
+    }
+
+    public void setIncludeUsedPorts(boolean getUsedPorts) {
+        this.includeUsedPorts = getUsedPorts;
     }
 
     public Long getRequestedHostId() {

--- a/code/iaas/simple-allocator/src/main/java/io/cattle/platform/simple/allocator/dao/impl/SimpleAllocatorDaoImpl.java
+++ b/code/iaas/simple-allocator/src/main/java/io/cattle/platform/simple/allocator/dao/impl/SimpleAllocatorDaoImpl.java
@@ -3,12 +3,17 @@ package io.cattle.platform.simple.allocator.dao.impl;
 import static io.cattle.platform.core.model.tables.AgentTable.*;
 import static io.cattle.platform.core.model.tables.HostTable.*;
 import static io.cattle.platform.core.model.tables.InstanceHostMapTable.*;
+import static io.cattle.platform.core.model.tables.InstanceTable.*;
 import static io.cattle.platform.core.model.tables.PortTable.*;
+import static io.cattle.platform.core.model.tables.ServiceExposeMapTable.*;
 import static io.cattle.platform.core.model.tables.StoragePoolHostMapTable.*;
 import static io.cattle.platform.core.model.tables.StoragePoolTable.*;
 
 import io.cattle.platform.allocator.service.AllocationCandidate;
 import io.cattle.platform.core.constants.CommonStatesConstants;
+import io.cattle.platform.core.constants.InstanceConstants;
+import io.cattle.platform.core.model.Port;
+import io.cattle.platform.core.model.tables.records.PortRecord;
 import io.cattle.platform.db.jooq.dao.impl.AbstractJooqDao;
 import io.cattle.platform.object.ObjectManager;
 import io.cattle.platform.simple.allocator.dao.QueryOptions;
@@ -28,6 +33,7 @@ import javax.inject.Inject;
 
 import org.jooq.Condition;
 import org.jooq.Field;
+import org.jooq.Record;
 import org.jooq.Record3;
 import org.jooq.Result;
 import org.jooq.SelectConditionStep;
@@ -86,7 +92,45 @@ public class SimpleAllocatorDaoImpl extends AbstractJooqDao implements SimpleAll
             }
         }
 
+        if (options.isIncludeUsedPorts()) {
+            updateHostsWithUsedPorts(hostIds, hostInfos);
+        }
+
         return new AllocationCandidateIterator(objectManager, hostInfos, volumes);
+    }
+
+    private void updateHostsWithUsedPorts(Set<Long> hostIds, List<CandidateHostInfo> hostInfos) {
+        Map<Long, Result<Record>> results = create()
+                .select(hostAndPortFields)
+                    .from(PORT)
+                    .join(INSTANCE_HOST_MAP)
+                        .on(PORT.INSTANCE_ID.eq(INSTANCE_HOST_MAP.INSTANCE_ID))
+                    .join(INSTANCE)
+                        .on(INSTANCE_HOST_MAP.INSTANCE_ID.eq(INSTANCE.ID))
+                .leftOuterJoin(SERVICE_EXPOSE_MAP)
+                .on(SERVICE_EXPOSE_MAP.INSTANCE_ID.eq(INSTANCE.ID))
+                    .where(INSTANCE_HOST_MAP.HOST_ID.in(hostIds)
+                        .and(INSTANCE.REMOVED.isNull())
+                        .and(INSTANCE.STATE.in(InstanceConstants.STATE_STARTING, InstanceConstants.STATE_RESTARTING, InstanceConstants.STATE_RUNNING))
+                        .and(INSTANCE_HOST_MAP.REMOVED.isNull())
+                        .and(PORT.REMOVED.isNull())
+                        .and(SERVICE_EXPOSE_MAP.UPGRADE.eq(false).or(SERVICE_EXPOSE_MAP.UPGRADE.isNull())))
+                .fetchGroups(INSTANCE_HOST_MAP.HOST_ID);
+
+        Map<Long, List<Port>> hostToPorts = new HashMap<>();
+        for (Map.Entry<Long, Result<Record>> entry : results.entrySet()) {
+            List<Port> ports = new ArrayList<>();
+            hostToPorts.put(entry.getKey(), ports);
+            for (Record rec : entry.getValue()) {
+                PortRecord port = rec.into(PortRecord.class);
+                ports.add(port);
+            }
+        }
+
+        for (CandidateHostInfo hostInfo : hostInfos) {
+            List<Port> ports = hostToPorts.get(hostInfo.getHostId()) != null ? hostToPorts.get(hostInfo.getHostId()) : new ArrayList<Port>();
+            hostInfo.setUsedPorts(ports);
+        }
     }
 
     protected SelectConditionStep<Record3<String, Long, Long>> getHostQuery(List<String> orderedHostUUIDs, QueryOptions options) {

--- a/code/packaging/app-config/src/main/java/io/cattle/platform/app/AllocatorServerConfig.java
+++ b/code/packaging/app-config/src/main/java/io/cattle/platform/app/AllocatorServerConfig.java
@@ -4,6 +4,7 @@ import io.cattle.platform.allocator.constraint.AccountConstraintsProvider;
 import io.cattle.platform.allocator.constraint.AffinityConstraintsProvider;
 import io.cattle.platform.allocator.constraint.BaseConstraintsProvider;
 import io.cattle.platform.allocator.constraint.NetworkContainerConstraintProvider;
+import io.cattle.platform.allocator.constraint.PortsConstraintProvider;
 import io.cattle.platform.allocator.constraint.VolumeAccessModeConstraintProvider;
 import io.cattle.platform.allocator.constraint.VolumesFromConstraintProvider;
 import io.cattle.platform.allocator.dao.impl.AllocatorDaoImpl;
@@ -19,8 +20,9 @@ import org.springframework.context.annotation.Configuration;
 public class AllocatorServerConfig {
 
     @Bean
-    AllocatorServiceImpl AllocatorEventListenerImpl() {
+    AllocatorServiceImpl AllocatorServiceImpl() {
         return new AllocatorServiceImpl();
+
     }
 
     @Bean
@@ -29,7 +31,7 @@ public class AllocatorServerConfig {
     }
 
     @Bean
-    AllocationHelperImpl AllocatorServiceImpl() {
+    AllocationHelperImpl AllocationHelperImpl() {
         return new AllocationHelperImpl();
     }
 
@@ -41,6 +43,11 @@ public class AllocatorServerConfig {
     @Bean
     AccountConstraintsProvider AccountConstraintsProvider() {
         return new AccountConstraintsProvider();
+    }
+
+    @Bean
+    PortsConstraintProvider PortsConstraintProvider() {
+        return new PortsConstraintProvider();
     }
 
     @Bean

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/allocator-server/defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/allocator-server/defaults.properties
@@ -1,1 +1,2 @@
 simple.allocator.lock.wait=2500
+port.scheduler.image.version=v0.6.0

--- a/tests/integration-v1/cattletest/core/test_allocation.py
+++ b/tests/integration-v1/cattletest/core/test_allocation.py
@@ -90,6 +90,78 @@ def test_allocation_stay_associated_to_host(super_client, context):
     assert len(c.hosts()) == 1
 
 
+def test_port_constraint(new_context):
+    host1 = new_context.host
+    client = new_context.client
+    image_uuid = new_context.image_uuid
+
+    containers = []
+
+    try:
+        c = client.wait_success(
+            client.create_container(imageUuid=image_uuid,
+                                    requestedHostId=host1.id,
+                                    ports=['8081:81/tcp']))
+        containers.append(c)
+
+        # try to deploy another container with same public port + protocol
+        c2 = client.wait_transitioning(
+            client.create_container(imageUuid=image_uuid,
+                                    ports=['8081:81/tcp']))
+        assert c2.transitioning == 'error'
+        assert c2.transitioningMessage == \
+            'Allocation failed: host needs ports 8081/tcp available'
+        assert c2.state == 'error'
+
+        # try different public port
+        c3 = new_context.super_create_container(imageUuid=image_uuid,
+                                                ports=['8082:81/tcp'])
+        containers.append(c3)
+
+        # try different protocol
+        c4 = client.wait_success(
+            client.create_container(imageUuid=image_uuid,
+                                    ports=['8081:81/udp']))
+        containers.append(c4)
+
+        # UDP is now taken
+        c5 = client.wait_transitioning(
+            client.create_container(imageUuid=image_uuid,
+                                    ports=['8081:81/udp']))
+        assert c5.transitioning == 'error'
+        assert c5.transitioningMessage == \
+            'Allocation failed: host needs ports 8081/udp available'
+        assert c5.state == 'error'
+
+        # try different bind IP
+        c6 = client.wait_success(
+            client.create_container(imageUuid=image_uuid,
+                                    requestedHostId=host1.id,
+                                    ports=['127.2.2.2:8081:81/tcp']))
+        containers.append(c6)
+
+        # Bind IP is now taken
+        c7 = client.wait_transitioning(
+            client.create_container(imageUuid=image_uuid,
+                                    ports=['127.2.2.2:8081:81/tcp']))
+        assert c7.transitioning == 'error'
+        assert c7.transitioningMessage == \
+            'Allocation failed: host needs ports 8081/tcp available'
+        assert c7.state == 'error'
+
+        # increase host pool and check whether allocator picks other host
+        host2 = register_simulated_host(new_context.client)
+        c8 = client.wait_success(
+            client.create_container(imageUuid=image_uuid,
+                                    ports=['8081:81/tcp']))
+        assert c8.hosts()[0].id == host2.id
+        containers.append(c8)
+    finally:
+        for c in containers:
+            if c is not None:
+                new_context.delete(c)
+
+
 def test_request_host_override(new_context):
     host = new_context.host
     c = None

--- a/tests/integration-v1/cattletest/core/test_docker.py
+++ b/tests/integration-v1/cattletest/core/test_docker.py
@@ -420,6 +420,40 @@ def test_docker_ports_from_container(docker_client, super_client):
 
 
 @if_docker
+def test_docker_bind_address(docker_client, super_client):
+    c = docker_client.create_container(name='bindAddrTest',
+                                       networkMode='bridge',
+                                       imageUuid=TEST_IMAGE_UUID,
+                                       ports=['127.0.0.1:89:8999'])
+    c = docker_client.wait_success(c)
+    assert c.state == 'running'
+
+    c = super_client.reload(c)
+    bindings = c.data['dockerInspect']['HostConfig']['PortBindings']
+    assert bindings['8999/tcp'] == [{'HostIp': '127.0.0.1', 'HostPort': '89'}]
+
+    c = docker_client.create_container(name='bindAddrTest2',
+                                       networkMode='bridge',
+                                       imageUuid=TEST_IMAGE_UUID,
+                                       ports=['127.2.2.2:89:8999'])
+    c = docker_client.wait_success(c)
+    assert c.state == 'running'
+    c = super_client.reload(c)
+    bindings = c.data['dockerInspect']['HostConfig']['PortBindings']
+    assert bindings['8999/tcp'] == [{'HostIp': '127.2.2.2', 'HostPort': '89'}]
+
+    c = docker_client.create_container(name='bindAddrTest3',
+                                       networkMode='bridge',
+                                       imageUuid=TEST_IMAGE_UUID,
+                                       ports=['127.2.2.2:89:8999'])
+    c = docker_client.wait_transitioning(c)
+    assert c.transitioning == 'error'
+    assert c.transitioningMessage == \
+        'Allocation failed: host needs ports 89/tcp available'
+    assert c.state == 'error'
+
+
+@if_docker
 def test_no_port_override(docker_client, super_client):
     c = docker_client.create_container(imageUuid=TEST_IMAGE_UUID,
                                        networkMode='bridge',

--- a/tests/integration/cattletest/core/test_allocation.py
+++ b/tests/integration/cattletest/core/test_allocation.py
@@ -90,6 +90,140 @@ def test_allocation_stay_associated_to_host(super_client, context):
     assert len(c.hosts()) == 1
 
 
+def test_port_constraint(new_context):
+    host1 = new_context.host
+    client = new_context.client
+    image_uuid = new_context.image_uuid
+
+    containers = []
+
+    try:
+        c = client.wait_success(
+            client.create_container(imageUuid=image_uuid,
+                                    requestedHostId=host1.id,
+                                    ports=['8081:81/tcp']))
+        containers.append(c)
+
+        # try to deploy another container with same public port + protocol
+        c2 = client.wait_transitioning(
+            client.create_container(imageUuid=image_uuid,
+                                    ports=['8081:81/tcp']))
+        assert c2.transitioning == 'error'
+        assert c2.transitioningMessage == \
+            'Allocation failed: host needs ports 8081/tcp available'
+        assert c2.state == 'error'
+
+        # try different public port
+        c3 = new_context.super_create_container(imageUuid=image_uuid,
+                                                ports=['8082:81/tcp'])
+        containers.append(c3)
+
+        # try different protocol
+        c4 = client.wait_success(
+            client.create_container(imageUuid=image_uuid,
+                                    ports=['8081:81/udp']))
+        containers.append(c4)
+
+        # UDP is now taken
+        c5 = client.wait_transitioning(
+            client.create_container(imageUuid=image_uuid,
+                                    ports=['8081:81/udp']))
+        assert c5.transitioning == 'error'
+        assert c5.transitioningMessage == \
+            'Allocation failed: host needs ports 8081/udp available'
+        assert c5.state == 'error'
+
+        # try different bind IP
+        c6 = client.wait_success(
+            client.create_container(imageUuid=image_uuid,
+                                    requestedHostId=host1.id,
+                                    ports=['127.2.2.2:8081:81/tcp']))
+        containers.append(c6)
+
+        # Bind IP is now taken
+        c7 = client.wait_transitioning(
+            client.create_container(imageUuid=image_uuid,
+                                    ports=['127.2.2.2:8081:81/tcp']))
+        assert c7.transitioning == 'error'
+        assert c7.transitioningMessage == \
+            'Allocation failed: host needs ports 8081/tcp available'
+        assert c7.state == 'error'
+
+        # increase host pool and check whether allocator picks other host
+        host2 = register_simulated_host(new_context.client)
+        c8 = client.wait_success(
+            client.create_container(imageUuid=image_uuid,
+                                    ports=['8081:81/tcp']))
+        assert c8.hosts()[0].id == host2.id
+        containers.append(c8)
+    finally:
+        for c in containers:
+            if c is not None:
+                new_context.delete(c)
+
+
+def test_conflicting_ports_in_deployment_unit(new_context):
+    client = new_context.client
+    image_uuid = new_context.image_uuid
+    client.wait_success(client.create_container(name='reset',
+                                                imageUuid=image_uuid))
+
+    env = client.create_stack(name=random_str())
+    env = client.wait_success(env)
+    assert env.state == "active"
+
+    launch_config = {"imageUuid": image_uuid, "ports": ['5555:6666']}
+    secondary_lc = {"imageUuid": image_uuid,
+                    "name": "secondary", "ports": ['5555:6666']}
+
+    svc = client.create_service(name=random_str(),
+                                stackId=env.id,
+                                launchConfig=launch_config,
+                                secondaryLaunchConfigs=[secondary_lc])
+    svc = client.wait_success(svc)
+    assert svc.state == "inactive"
+
+    svc = svc.activate()
+    c = _wait_for_compose_instance_error(client, svc, env)
+    assert 'Port 5555/tcp requested more than once.' in c.transitioningMessage
+    env.remove()
+
+
+def test_simultaneous_port_allocation(new_context):
+    # This test ensures if two containers are allocated simultaneously, only
+    # one will get the port and the other will fail to allocate.
+    # By nature, this test is exercise a race condition, so it isn't perfect.
+    client = new_context.client
+    image_uuid = new_context.image_uuid
+
+    env = client.create_stack(name=random_str())
+    env = client.wait_success(env)
+    assert env.state == "active"
+
+    launch_config = {"imageUuid": image_uuid, "ports": ['5555:6666']}
+    svc = client.create_service(name=random_str(),
+                                stackId=env.id,
+                                launchConfig=launch_config,
+                                scale=2)
+    svc = client.wait_success(svc)
+    assert svc.state == "inactive"
+
+    svc = svc.activate()
+    c = _wait_for_compose_instance_error(client, svc, env)
+    assert 'host needs ports 5555/tcp available' in c.transitioningMessage
+
+
+def _wait_for_compose_instance_error(client, service, env):
+    name = env.name + "-" + service.name + "%"
+
+    def check():
+        containers = client.list_container(name_like=name, state='error')
+        if len(containers) > 0:
+            return containers[0]
+    container = wait_for(check)
+    return container
+
+
 def test_request_host_override(new_context):
     host = new_context.host
     c = None


### PR DESCRIPTION
Support the scenario where the user has upgraded rancher but not
upgraded the scheduler service. To do this, I've reintroduced the
previous port constraint logic and added a check to see if the
scheduler is of a version that is less than the version in which we
added port allocation logic.