### PR TITLE
Container name unique per environment

### DIFF
--- a/resources/content/schema/base/container.json
+++ b/resources/content/schema/base/container.json
@@ -4,6 +4,7 @@
             "type": "map[string]",
             "create": true
         },
+        
         "command": {
             "type": "array[string]",
             "nullable": true,
@@ -388,6 +389,10 @@
          "userPorts" : {
             "type" : "array[string]",
             "nullable" : true
+        },
+        "name": {
+            "type": "string",
+            "unique": true
         }
     },
     "resourceActions": {

--- a/tests/integration-v1/cattletest/core/test_compose.py
+++ b/tests/integration-v1/cattletest/core/test_compose.py
@@ -36,12 +36,14 @@ def test_container_create_count(client, context):
     assert set(s.actions.keys()) == set(['remove'])
 
 
-def _create_service(client, context, project=None, service=None):
+def _create_service(client, context, project=None, service=None,
+                    service_index=1):
     if project is None:
         project = 'p-' + random_str()
     if service is None:
         service = 's-' + random_str()
-    c = context.create_container(name='{}_{}_1'.format(service, project),
+    c = context.create_container(name='{}_{}_{}'.format(service, project,
+                                                        service_index),
                                  labels={
                                      SERVICE: service,
                                      PROJECT: project,
@@ -77,7 +79,7 @@ def test_container_remove(client, context):
 
 def test_container_two_remove(client, context):
     project, service, c = _create_service(client, context)
-    project, service, c = _create_service(client, context, project, service)
+    project, service, c = _create_service(client, context, project, service, 2)
 
     s = find_one(c.services)
     maps = s.serviceExposeMaps()

--- a/tests/integration-v1/cattletest/core/test_container.py
+++ b/tests/integration-v1/cattletest/core/test_container.py
@@ -43,7 +43,7 @@ def test_container_create_only(super_client, client, context):
     uuid = "sim:{}".format(random_num())
     container = super_client.create_container(accountId=context.project.id,
                                               imageUuid=uuid,
-                                              name="test",
+                                              name="test" + random_str(),
                                               startOnCreate=False)
 
     assert_fields(container, {
@@ -162,7 +162,7 @@ def test_container_special_labels(client, context):
     container = client.create_container(accountId=context.project.id,
                                         networkMode='none',
                                         imageUuid=uuid,
-                                        name="test",
+                                        name="test" + random_str(),
                                         labels=labels,
                                         startOnCreate=False)
     container = client.wait_success(container)
@@ -219,7 +219,7 @@ def test_container_restart(client, super_client, context):
 
 
 def test_container_stop(client, super_client, context):
-    container = context.create_container(name="test")
+    container = context.create_container(name="test" + random_str())
     container = client.wait_success(container)
 
     assert_fields(container, {
@@ -302,7 +302,7 @@ def _assert_error(container):
 
 
 def test_container_remove(client, super_client, context):
-    container = context.create_container(name="test")
+    container = context.create_container(name="test" + random_str())
     container = client.wait_success(container)
     container = client.wait_success(container.stop())
 
@@ -319,7 +319,7 @@ def test_container_remove(client, super_client, context):
 
 
 def test_container_delete_while_running(client, super_client, context):
-    container = context.create_container(name="test")
+    container = context.create_container(name="test" + random_str())
     container = client.wait_success(container)
     assert container.state == 'running'
 
@@ -368,7 +368,7 @@ def test_container_purge(client, super_client, context):
 
 
 def test_start_stop(client, context):
-    container = context.create_container(name="test")
+    container = context.create_container(name="test" + random_str())
 
     container = client.wait_success(container)
 
@@ -518,7 +518,7 @@ def test_container_logs(context):
 
 def test_container_labels(client, context):
     labels = {'affinity': "container==B", '!affinity': "container==C"}
-    container = context.create_container(name="test",
+    container = context.create_container(name="test" + random_str(),
                                          labels=labels)
     container = client.wait_success(container)
     assert container.state == 'running'

--- a/tests/integration-v1/cattletest/core/test_private_repos.py
+++ b/tests/integration-v1/cattletest/core/test_private_repos.py
@@ -146,7 +146,7 @@ def test_container_image_and_registry_credential(client,
     name = server + '/rancher/authorized:latest'
     image_uuid = 'docker:' + name
     container = client.create_container(imageUuid=image_uuid,
-                                        name="test",
+                                        name="test" + random_str(),
                                         startOnCreate=False)
     container = super_client.wait_success(container)
     assert container.registryCredentialId == registry_credential.id

--- a/tests/integration/cattletest/core/test_api.py
+++ b/tests/integration/cattletest/core/test_api.py
@@ -23,14 +23,17 @@ def test_list_sort(super_client, context):
     name = random_str()
     containers = []
     for i in range(2):
-        c = context.create_container_no_success(name=name, startOnCreate=False)
+        c = context.create_container_no_success(name=name + random_str(),
+                                                startOnCreate=False,
+                                                description='test1')
         containers.append(c)
 
-    r = super_client.list_container(name=name)
+    r = super_client.list_container(description='test1')
     for i in range(len(r)):
         assert containers[i].id == r[i].id
 
-    r = super_client.list_container(name=name, sort='created', order='desc')
+    r = super_client.list_container(description='test1', sort='created',
+                                    order='desc')
     containers.reverse()
     for i in range(len(r)):
         assert containers[i].id == r[i].id
@@ -41,13 +44,15 @@ def test_pagination(context):
     name = random_str()
     containers = []
     for i in range(4):
-        c = client.create_container(imageUuid=context.image_uuid, name=name)
+        c = client.create_container(imageUuid=context.image_uuid,
+                                    name=name + random_str(),
+                                    description='test2')
         containers.append(c)
 
     for c in containers:
         client.wait_success(c)
 
-    r = client.list_container(name=name)
+    r = client.list_container(description='test2')
 
     assert len(r) == 4
     try:
@@ -56,7 +61,7 @@ def test_pagination(context):
         pass
 
     collected = {}
-    r = client.list_container(name=name, limit=2)
+    r = client.list_container(description='test2', limit=2)
     assert len(r) == 2
     assert r.pagination.next is not None
 
@@ -86,8 +91,9 @@ def test_pagination_include(super_client, new_context):
     containers = []
     for i in range(5):
         c = client.create_container(imageUuid=context.image_uuid,
-                                    name=name,
-                                    requestedHostId=host.id)
+                                    name=name + random_str(),
+                                    requestedHostId=host.id,
+                                    description='test3')
         c = super_client.reload(c)
         containers.append(c)
         container_ids.append(c.id)
@@ -97,7 +103,7 @@ def test_pagination_include(super_client, new_context):
 
     assert len(containers[0].instanceHostMaps()) == 1
     assert host.id == containers[0].instanceHostMaps()[0].host().id
-    r = super_client.list_container(name=name)
+    r = super_client.list_container(description='test3')
 
     assert len(r) == 5
     for c in r:
@@ -105,7 +111,8 @@ def test_pagination_include(super_client, new_context):
         assert c.instanceHostMaps()[0].hostId == host.id
 
     collected = {}
-    r = super_client.list_container(name=name, include='instanceHostMaps',
+    r = super_client.list_container(description='test3',
+                                    include='instanceHostMaps',
                                     limit=2)
     assert len(r) == 2
     for c in r:
@@ -192,21 +199,24 @@ def test_include_left_join(super_client, context):
 
 def test_include_left_join_sort(super_client, context):
     client = context.client
-    name = random_str()
     containers = []
     for i in range(2):
-        c = client.create_container(imageUuid=context.image_uuid, name=name)
+        c = client.create_container(imageUuid=context.image_uuid,
+                                    name="test" + random_str(),
+                                    description='test4')
         containers.append(c)
 
     for c in containers:
         client.wait_success(c)
 
-    r = super_client.list_container(name=name, include='instanceHostMaps',
-                                    sort='created', order='asc')
+    r = super_client.list_container(include='instanceHostMaps',
+                                    sort='created', order='asc',
+                                    description='test4')
     for i in range(len(r)):
         assert containers[i].id == r[i].id
 
-    r = super_client.list_container(name=name, include='instanceHostMaps',
+    r = super_client.list_container(description='test4',
+                                    include='instanceHostMaps',
                                     sort='created', order='desc')
     containers.reverse()
     for i in range(len(r)):

--- a/tests/integration/cattletest/core/test_compose.py
+++ b/tests/integration/cattletest/core/test_compose.py
@@ -36,12 +36,14 @@ def test_container_create_count(client, context):
     assert set(s.actions.keys()) == set(['remove'])
 
 
-def _create_service(client, context, project=None, service=None):
+def _create_service(client, context, project=None, service=None,
+                    service_index=1):
     if project is None:
         project = 'p-' + random_str()
     if service is None:
         service = 's-' + random_str()
-    c = context.create_container(name='{}_{}_1'.format(service, project),
+    c = context.create_container(name='{}_{}_{}'.format(service, project,
+                                                        service_index),
                                  labels={
                                      SERVICE: service,
                                      PROJECT: project,
@@ -77,7 +79,7 @@ def test_container_remove(client, context):
 
 def test_container_two_remove(client, context):
     project, service, c = _create_service(client, context)
-    project, service, c = _create_service(client, context, project, service)
+    project, service, c = _create_service(client, context, project, service, 2)
 
     s = find_one(c.services)
     maps = s.serviceExposeMaps()

--- a/tests/integration/cattletest/core/test_container.py
+++ b/tests/integration/cattletest/core/test_container.py
@@ -44,7 +44,7 @@ def test_container_create_only(super_client, client, context):
     uuid = "sim:{}".format(random_num())
     container = super_client.create_container(accountId=context.project.id,
                                               imageUuid=uuid,
-                                              name="test",
+                                              name="test" + random_str(),
                                               startOnCreate=False)
 
     assert_fields(container, {
@@ -163,7 +163,7 @@ def test_container_special_labels(client, context):
     container = client.create_container(accountId=context.project.id,
                                         networkMode='none',
                                         imageUuid=uuid,
-                                        name="test",
+                                        name="test" + random_str(),
                                         labels=labels,
                                         startOnCreate=False)
     container = client.wait_success(container)
@@ -231,7 +231,7 @@ def test_container_restart(client, super_client, context):
 
 
 def test_container_stop(client, super_client, context):
-    container = context.create_container(name="test")
+    container = context.create_container(name="test" + random_str())
     container = client.wait_success(container)
 
     assert_fields(container, {
@@ -314,7 +314,7 @@ def _assert_error(container):
 
 
 def test_container_remove(client, super_client, context):
-    container = context.create_container(name="test")
+    container = context.create_container(name="test" + random_str())
     container = client.wait_success(container)
     container = client.wait_success(container.stop())
 
@@ -331,7 +331,7 @@ def test_container_remove(client, super_client, context):
 
 
 def test_container_delete_while_running(client, super_client, context):
-    container = context.create_container(name="test")
+    container = context.create_container(name="test" + random_str())
     container = client.wait_success(container)
     assert container.state == 'running'
 
@@ -380,7 +380,7 @@ def test_container_purge(client, super_client, context):
 
 
 def test_start_stop(client, context):
-    container = context.create_container(name="test")
+    container = context.create_container(name="test" + random_str())
 
     container = client.wait_success(container)
 
@@ -522,7 +522,7 @@ def test_container_logs(context):
 
 def test_container_labels(client, context):
     labels = {'affinity': "container==B", '!affinity': "container==C"}
-    container = context.create_container(name="test",
+    container = context.create_container(name="test" + random_str(),
                                          labels=labels)
     container = client.wait_success(container)
     assert container.state == 'running'

--- a/tests/integration/cattletest/core/test_docker.py
+++ b/tests/integration/cattletest/core/test_docker.py
@@ -584,7 +584,7 @@ def test_container_fields(docker_client, super_client):
     image_uuid = 'docker:ibuildthecloud/helloworld'
     restart_policy = {"maximumRetryCount": 2, "name": "on-failure"}
 
-    c = docker_client.create_container(name=test_name,
+    c = docker_client.create_container(name=test_name + random_str(),
                                        networkMode='bridge',
                                        imageUuid=image_uuid,
                                        capAdd=caps,
@@ -1217,7 +1217,7 @@ def _check_path(volume, should_exist, client, super_client):
     path = _path_to_volume(volume)
     print 'Checking path [%s] for volume [%s].' % (path, volume)
     c = client. \
-        create_container(name="volume_check",
+        create_container(name="volume_check" + random_str(),
                          imageUuid="docker:ranchertest/volume-test:v0.1.0",
                          networkMode=None,
                          environment={'TEST_PATH': path},

--- a/tests/integration/cattletest/core/test_private_repos.py
+++ b/tests/integration/cattletest/core/test_private_repos.py
@@ -148,7 +148,7 @@ def test_container_image_and_registry_credential(client,
     name = server + '/rancher/authorized:latest'
     image_uuid = 'docker:' + name
     container = client.create_container(imageUuid=image_uuid,
-                                        name="test",
+                                        name="test" + random_str(),
                                         startOnCreate=False)
     container = super_client.wait_success(container)
     assert container.registryCredentialId == registry_credential.id


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/7384

@ibuildthecloud @vincent99 still uncertain whether putting this restriction on API side is correct, given that internally we do allow duplicated names (during in service upgrade use case, failed health check instance recreate, etc)