### PR TITLE
OpenLDAP: Support for accessMode and allowedIdentities added

### DIFF
--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/LDAPIdentityProvider.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/LDAPIdentityProvider.java
@@ -14,6 +14,7 @@ import io.github.ibuildthecloud.gdapi.util.ResponseCodes;
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Map;
 
 import javax.annotation.PostConstruct;
 import javax.naming.Context;
@@ -381,4 +382,21 @@ public abstract class LDAPIdentityProvider implements IdentityProvider{
                 "NotConfigured", "Ldap is not configured", null);
     }
 
+    public List<Identity> getIdentities(List<Map<String, String>> identitiesGiven) {
+        if (identitiesGiven == null || identitiesGiven.isEmpty()){
+            return new ArrayList<>();
+        }
+
+        List<Identity> identities = new ArrayList<>();
+        for (Map<String, String> identity: identitiesGiven){
+            String externalId = identity.get(IdentityConstants.EXTERNAL_ID);
+            String externalIdType = identity.get(IdentityConstants.EXTERNAL_ID_TYPE);
+            Identity gotIdentity = getIdentity(externalId, externalIdType);
+            if (gotIdentity == null) {
+                throw new ClientVisibleException(ResponseCodes.BAD_REQUEST, "InvalidIdentity", "Invalid Identity", null);
+            }
+            identities.add(gotIdentity);
+        }
+        return identities;
+    }
 }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPConfig.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPConfig.java
@@ -6,7 +6,6 @@ import io.cattle.platform.iaas.api.auth.integration.ldap.interfaces.LDAPConfig;
 import io.github.ibuildthecloud.gdapi.annotation.Field;
 import io.github.ibuildthecloud.gdapi.annotation.Type;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Type(name = OpenLDAPConstants.CONFIG)
@@ -35,6 +34,7 @@ public class OpenLDAPConfig implements Configurable, LDAPConfig {
     private final String groupMemberMappingAttribute;
     private final long connectionTimeout;
     private final String groupMemberUserAttribute;
+    private List<Identity> allowedIdentities;
 
     public OpenLDAPConfig(String server, Integer port, Integer userDisabledBitMask, String loginDomain, String domain,
                           Boolean enabled, String accessMode, String serviceAccountUsername,
@@ -42,7 +42,7 @@ public class OpenLDAPConfig implements Configurable, LDAPConfig {
                           String userObjectClass, String userNameField, String userEnabledAttribute, 
                           String groupSearchField, String groupObjectClass, String groupNameField, 
                           String userMemberAttribute, String groupMemberMappingAttribute, 
-                          long connectionTimeout, String groupDNField, String groupMemberUserAttribute) {
+                          long connectionTimeout, String groupDNField, String groupMemberUserAttribute, List<Identity> allowedIdentities) {
         this.server = server;
         this.port = port;
         this.userDisabledBitMask = userDisabledBitMask;
@@ -66,6 +66,7 @@ public class OpenLDAPConfig implements Configurable, LDAPConfig {
         this.connectionTimeout = connectionTimeout;
         this.groupDNField = groupDNField;
         this.groupMemberUserAttribute = groupMemberUserAttribute;
+        this.allowedIdentities = allowedIdentities;
     }
 
     @Field(required = true, nullable = false, minLength = 1)
@@ -185,7 +186,7 @@ public class OpenLDAPConfig implements Configurable, LDAPConfig {
 
     @Override
     public List<Identity> getAllowedIdentities() {
-        return new ArrayList<>();
+        return allowedIdentities;
     }
     
     @Override

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPConfigManager.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPConfigManager.java
@@ -1,16 +1,21 @@
 package io.cattle.platform.iaas.api.auth.integration.ldap.OpenLDAP;
 
+import io.cattle.platform.api.auth.Identity;
 import io.cattle.platform.core.util.SettingsUtils;
+import io.cattle.platform.iaas.api.auth.AbstractTokenUtil;
 import io.cattle.platform.iaas.api.auth.SecurityConstants;
 import io.cattle.platform.iaas.api.auth.integration.ldap.LDAPUtils;
 import io.cattle.platform.iaas.api.auth.integration.ldap.interfaces.LDAPConstants;
 import io.cattle.platform.json.JsonMapper;
+import io.cattle.platform.util.type.CollectionUtils;
 import io.github.ibuildthecloud.gdapi.factory.SchemaFactory;
 import io.github.ibuildthecloud.gdapi.model.ListOptions;
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 import io.github.ibuildthecloud.gdapi.request.resource.impl.AbstractNoOpResourceManager;
 
+import java.util.List;
 import java.util.Map;
+
 import javax.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
@@ -20,6 +25,9 @@ public class OpenLDAPConfigManager extends AbstractNoOpResourceManager {
 
     @Inject
     SettingsUtils settingsUtils;
+
+    @Inject
+    OpenLDAPIdentityProvider openLDAPIdentityProvider;
 
     @Inject
     JsonMapper jsonMapper;
@@ -36,105 +44,114 @@ public class OpenLDAPConfigManager extends AbstractNoOpResourceManager {
         }
         LDAPConstants config = request.proxyRequestObject(LDAPConstants.class);
         LDAPUtils.validateConfig(config);
-        return updateCurrentConfig(config);
+        Map<String, Object> configMap = CollectionUtils.toMap(request.getRequestObject());
+        return updateCurrentConfig(configMap);
     }
 
-    private OpenLDAPConfig currentLdapConfig(LDAPConstants config) {
+    @SuppressWarnings("unchecked")
+    private OpenLDAPConfig currentLdapConfig(Map<String, Object> config) {
         OpenLDAPConfig currentConfig = (OpenLDAPConfig) listInternal(null, null, null, null);
         String domain = currentConfig.getDomain();
-        if (config.getDomain() != null) {
-            domain = config.getDomain();
+        if (config.get(OpenLDAPConstants.CONFIG_DOMAIN) != null) {
+            domain = (String)config.get(OpenLDAPConstants.CONFIG_DOMAIN);
         }
         String server = currentConfig.getServer();
-        if (config.getServer() != null) {
-            server = config.getServer();
+        if (config.get(OpenLDAPConstants.CONFIG_SERVER) != null) {
+            server = (String)config.get(OpenLDAPConstants.CONFIG_SERVER);
         }
         String loginDomain = currentConfig.getLoginDomain();
-        if (config.getLoginDomain() != null) {
-            loginDomain = config.getLoginDomain();
+        if (config.get(OpenLDAPConstants.CONFIG_LOGIN_DOMAIN) != null) {
+            loginDomain = (String)config.get(OpenLDAPConstants.CONFIG_LOGIN_DOMAIN);
         }
         String accessMode = currentConfig.getAccessMode();
-        if (config.getAccessMode() != null) {
-            accessMode = config.getAccessMode();
+        if (config.get(AbstractTokenUtil.ACCESSMODE) != null) {
+            accessMode = (String)config.get(AbstractTokenUtil.ACCESSMODE);
         }
         String serviceAccountUsername = currentConfig.getServiceAccountUsername();
-        if (config.getServiceAccountUsername() != null) {
-            serviceAccountUsername = config.getServiceAccountUsername();
+        if (config.get(OpenLDAPConstants.CONFIG_SERVICE_ACCOUNT_USERNAME) != null) {
+            serviceAccountUsername = (String)config.get(OpenLDAPConstants.CONFIG_SERVICE_ACCOUNT_USERNAME);
         }
         String serviceAccountPassword = currentConfig.getServiceAccountPassword();
-        if (config.getServiceAccountPassword() != null) {
-            serviceAccountPassword = config.getServiceAccountPassword();
+        if (config.get(OpenLDAPConstants.CONFIG_SERVICE_ACCOUNT_PASSWORD) != null) {
+            serviceAccountPassword = (String)config.get(OpenLDAPConstants.CONFIG_SERVICE_ACCOUNT_PASSWORD);
         }
         boolean tls = currentConfig.getTls();
-        if (config.getTls() != null) {
-            tls = config.getTls();
+        if (config.get(OpenLDAPConstants.CONFIG_TLS) != null) {
+            tls = (Boolean)config.get(OpenLDAPConstants.CONFIG_TLS);
         }
         int port = currentConfig.getPort();
-        if (config.getPort() != null) {
-            port = config.getPort();
+        if (config.get(OpenLDAPConstants.CONFIG_PORT) != null) {
+            port = ((Long)config.get(OpenLDAPConstants.CONFIG_PORT)).intValue();
         }
         boolean enabled = currentConfig.getEnabled();
-        if (config.getEnabled() != null) {
-            enabled = config.getEnabled();
+        if (config.get(OpenLDAPConstants.CONFIG_SECURITY) != null) {
+            enabled = (Boolean)config.get(OpenLDAPConstants.CONFIG_SECURITY);
         }
         String userSearchField = currentConfig.getUserSearchField();
-        if (config.getUserSearchField() != null){
-            userSearchField = config.getUserSearchField();
+        if (config.get(OpenLDAPConstants.CONFIG_USER_SEARCH_FIELD) != null){
+            userSearchField = (String)config.get(OpenLDAPConstants.CONFIG_USER_SEARCH_FIELD);
         }
         String groupSearchField = currentConfig.getGroupSearchField();
-        if (config.getGroupSearchField() != null){
-            groupSearchField = config.getGroupSearchField();
+        if (config.get(OpenLDAPConstants.CONFIG_GROUP_SEARCH_FIELD) != null){
+            groupSearchField = (String)config.get(OpenLDAPConstants.CONFIG_GROUP_SEARCH_FIELD);
         }
         String userLoginField = currentConfig.getUserLoginField();
-        if (config.getUserLoginField() != null){
-            userLoginField = config.getUserLoginField();
+        if (config.get(OpenLDAPConstants.CONFIG_USER_LOGIN_FIELD) != null){
+            userLoginField = (String)config.get(OpenLDAPConstants.CONFIG_USER_LOGIN_FIELD);
         }
         int userEnabledMaskBit = currentConfig.getUserDisabledBitMask();
-        if (config.getUserDisabledBitMask() !=null){
-            userEnabledMaskBit = config.getUserDisabledBitMask();
+        if (config.get(OpenLDAPConstants.CONFIG_USER_DISABLED_BIT_MASK) !=null){
+            userEnabledMaskBit = ((Long)config.get(OpenLDAPConstants.CONFIG_USER_DISABLED_BIT_MASK)).intValue();
         }
 
         String userObjectClass = currentConfig.getUserObjectClass();
-        if (config.getUserObjectClass() != null) {
-            userObjectClass = config.getUserObjectClass();
+        if (config.get(OpenLDAPConstants.CONFIG_USER_OBJECT_CLASS) != null) {
+            userObjectClass = (String)config.get(OpenLDAPConstants.CONFIG_USER_OBJECT_CLASS);
         }
         String userNameField = currentConfig.getUserNameField();
-        if (config.getUserNameField() != null){
-            userNameField = config.getUserNameField();
+        if (config.get(OpenLDAPConstants.CONFIG_USER_NAME_FIELD) != null){
+            userNameField = (String)config.get(OpenLDAPConstants.CONFIG_USER_NAME_FIELD);
         }
         String userEnabledAttribute = currentConfig.getUserEnabledAttribute();
-        if (config.getUserEnabledAttribute() != null){
-            userEnabledAttribute = config.getUserEnabledAttribute();
+        if (config.get(OpenLDAPConstants.CONFIG_USER_ENABLED_ATTRIBUTE) != null){
+            userEnabledAttribute = (String)config.get(OpenLDAPConstants.CONFIG_USER_ENABLED_ATTRIBUTE);
         }
         String groupObjectClass  = currentConfig.getGroupObjectClass();
-        if (config.getGroupObjectClass()!= null){
-            groupObjectClass = config.getGroupObjectClass();
+        if (config.get(OpenLDAPConstants.CONFIG_GROUP_OBJECT_CLASS)!= null){
+            groupObjectClass = (String)config.get(OpenLDAPConstants.CONFIG_GROUP_OBJECT_CLASS);
         }
         String groupNameField = currentConfig.getGroupNameField();
-        if (config.getGroupNameField() != null){
-            groupNameField = config.getGroupNameField();
+        if (config.get(OpenLDAPConstants.CONFIG_GROUP_NAME_FIELD) != null){
+            groupNameField = (String)config.get(OpenLDAPConstants.CONFIG_GROUP_NAME_FIELD);
         }
         String userMemberAttribute = currentConfig.getUserMemberAttribute();
-        if (config.getUserMemberAttribute() != null){
-            userMemberAttribute = config.getUserMemberAttribute();
+        if (config.get(OpenLDAPConstants.CONFIG_USER_MEMBER_ATTRIBUTE) != null){
+            userMemberAttribute = (String)config.get(OpenLDAPConstants.CONFIG_USER_MEMBER_ATTRIBUTE);
         }
         String groupMemberMappingAttribute = currentConfig.getGroupMemberMappingAttribute();
-        if (config.getGroupMemberMappingAttribute() != null){
-            groupMemberMappingAttribute = config.getGroupMemberMappingAttribute();
+        if (config.get(OpenLDAPConstants.CONFIG_GROUP_USER_MAPPING_ATTRIBUTE) != null){
+            groupMemberMappingAttribute = (String)config.get(OpenLDAPConstants.CONFIG_GROUP_USER_MAPPING_ATTRIBUTE);
         }
         String groupDNField = currentConfig.getGroupDNField();
-        if (config.getGroupDNField() != null){
-            groupDNField = config.getGroupDNField();
+        if (config.get(OpenLDAPConstants.CONFIG_GROUP_DN_FIELD) != null){
+            groupDNField = (String)config.get(OpenLDAPConstants.CONFIG_GROUP_DN_FIELD);
         }
         String groupMemberUserAttribute = currentConfig.getGroupMemberUserAttribute();
-        if (config.getGroupMemberUserAttribute() != null){
-            groupMemberUserAttribute = config.getGroupMemberUserAttribute();
+        if(config.get(OpenLDAPConstants.CONFIG_GROUP_MEMBER_USER_ATTRIBUTE) != null){
+            groupMemberUserAttribute = (String)config.get(OpenLDAPConstants.CONFIG_GROUP_MEMBER_USER_ATTRIBUTE);
+        }
+
+        List<Identity> identities = currentConfig.getAllowedIdentities();
+        String accessModeInConfig = (String)config.get(AbstractTokenUtil.ACCESSMODE);
+        if (config.get(OpenLDAPConstants.CONFIG_ALLOWED_IDENTITIES) != null && accessModeInConfig != null
+                && (AbstractTokenUtil.isRestrictedAccess(accessModeInConfig) || AbstractTokenUtil.isRequiredAccess(accessModeInConfig))) {
+            identities = openLDAPIdentityProvider.getIdentities((List<Map<String, String>>) config.get(OpenLDAPConstants.CONFIG_ALLOWED_IDENTITIES));
         }
 
         return new OpenLDAPConfig(server, port, userEnabledMaskBit, loginDomain, domain, enabled, accessMode,
                 serviceAccountUsername, serviceAccountPassword, tls, userSearchField, userLoginField, userObjectClass,
                 userNameField, userEnabledAttribute, groupSearchField, groupObjectClass, groupNameField, userMemberAttribute,
-                groupMemberMappingAttribute, config.getConnectionTimeout(), groupDNField, groupMemberUserAttribute);
+                groupMemberMappingAttribute, (Long)config.get(OpenLDAPConstants.CONFIG_TIMEOUT), groupDNField, groupMemberUserAttribute, identities);
     }
 
     @Override
@@ -162,41 +179,54 @@ public class OpenLDAPConfigManager extends AbstractNoOpResourceManager {
         long connectionTimeout = OpenLDAPConstants.CONNECTION_TIMEOUT.get();
         String groupDNField = OpenLDAPConstants.GROUP_DN_FIELD.get();
         String groupMemberUserAttribute = OpenLDAPConstants.GROUP_MEMBER_USER_ATTRIBUTE.get();
+        List<Identity> identities = openLDAPIdentityProvider.savedIdentities();
 
         return new OpenLDAPConfig(server, port, userEnabledMaskBit, loginDomain, domain, enabled, accessMode,
                 serviceAccountUsername, serviceAccountPassword, tls, userSearchField, userLoginField, userObjectClass,
                 userNameField, userEnabledAttribute, groupSearchField, groupObjectClass, groupNameField, userMemberAttribute,
-                groupMemberMappingAttribute, connectionTimeout, groupDNField, groupMemberUserAttribute);
+                groupMemberMappingAttribute, connectionTimeout, groupDNField, groupMemberUserAttribute, identities);
     }
 
-    public OpenLDAPConfig updateCurrentConfig(LDAPConstants config) {
-        settingsUtils.changeSetting(OpenLDAPConstants.ACCESS_MODE_SETTING, config.getAccessMode());
-        settingsUtils.changeSetting(OpenLDAPConstants.DOMAIN_SETTING, config.getDomain());
-        settingsUtils.changeSetting(OpenLDAPConstants.GROUP_NAME_FIELD_SETTING, config.getGroupNameField());
-        settingsUtils.changeSetting(OpenLDAPConstants.GROUP_OBJECT_CLASS_SETTING, config.getGroupObjectClass());
-        settingsUtils.changeSetting(OpenLDAPConstants.GROUP_SEARCH_FIELD_SETTING, config.getGroupSearchField());
-        settingsUtils.changeSetting(OpenLDAPConstants.GROUP_USER_MAPPING_ATTRIBUTE_SETTING, config.getGroupMemberMappingAttribute());
-        settingsUtils.changeSetting(OpenLDAPConstants.LOGIN_DOMAIN_SETTING, config.getLoginDomain());
-        settingsUtils.changeSetting(OpenLDAPConstants.PORT_SETTING, config.getPort());
-        settingsUtils.changeSetting(OpenLDAPConstants.SERVER_SETTING, config.getServer());
-        settingsUtils.changeSetting(OpenLDAPConstants.SERVICE_ACCOUNT_PASSWORD_SETTING, config.getServiceAccountPassword());
-        settingsUtils.changeSetting(OpenLDAPConstants.SERVICE_ACCOUNT_USERNAME_SETTING, config.getServiceAccountUsername());
-        settingsUtils.changeSetting(OpenLDAPConstants.TLS_SETTING, config.getTls());
-        settingsUtils.changeSetting(OpenLDAPConstants.USER_DISABLED_BIT_MASK_SETTING, config.getUserDisabledBitMask());
-        settingsUtils.changeSetting(OpenLDAPConstants.USER_ENABLED_ATTRIBUTE_SETTING, config.getUserEnabledAttribute());
-        settingsUtils.changeSetting(OpenLDAPConstants.USER_LOGIN_FIELD_SETTING, config.getUserLoginField());
-        settingsUtils.changeSetting(OpenLDAPConstants.USER_MEMBER_ATTRIBUTE_SETTING, config.getUserMemberAttribute());
-        settingsUtils.changeSetting(OpenLDAPConstants.USER_NAME_FIELD_SETTING, config.getUserNameField());
-        settingsUtils.changeSetting(OpenLDAPConstants.USER_OBJECT_CLASS_SETTING, config.getUserObjectClass());
-        settingsUtils.changeSetting(OpenLDAPConstants.USER_SEARCH_FIELD_SETTING, config.getUserSearchField());
-        settingsUtils.changeSetting(OpenLDAPConstants.TIMEOUT_SETTING, config.getConnectionTimeout());
-        settingsUtils.changeSetting(OpenLDAPConstants.GROUP_DN_FIELD_SETTING, config.getGroupDNField());
-        settingsUtils.changeSetting(OpenLDAPConstants.GROUP_MEMBER_USER_ATTRIBUTE_SETTING, config.getGroupMemberUserAttribute());
-        settingsUtils.changeSetting(SecurityConstants.SECURITY_SETTING, config.getEnabled());
-        if (config.getEnabled() != null){
+    public OpenLDAPConfig updateCurrentConfig(Map<String, Object> config) {
+        settingsUtils.changeSetting(OpenLDAPConstants.ACCESS_MODE_SETTING, config.get(AbstractTokenUtil.ACCESSMODE));
+        settingsUtils.changeSetting(OpenLDAPConstants.DOMAIN_SETTING, config.get(OpenLDAPConstants.CONFIG_DOMAIN));
+        settingsUtils.changeSetting(OpenLDAPConstants.GROUP_NAME_FIELD_SETTING, config.get(OpenLDAPConstants.CONFIG_GROUP_NAME_FIELD));
+        settingsUtils.changeSetting(OpenLDAPConstants.GROUP_OBJECT_CLASS_SETTING, config.get(OpenLDAPConstants.CONFIG_GROUP_OBJECT_CLASS));
+        settingsUtils.changeSetting(OpenLDAPConstants.GROUP_SEARCH_FIELD_SETTING, config.get(OpenLDAPConstants.CONFIG_GROUP_SEARCH_FIELD));
+        settingsUtils.changeSetting(OpenLDAPConstants.GROUP_USER_MAPPING_ATTRIBUTE_SETTING, config.get(OpenLDAPConstants.CONFIG_GROUP_USER_MAPPING_ATTRIBUTE));
+        settingsUtils.changeSetting(OpenLDAPConstants.LOGIN_DOMAIN_SETTING, config.get(OpenLDAPConstants.CONFIG_LOGIN_DOMAIN));
+        settingsUtils.changeSetting(OpenLDAPConstants.PORT_SETTING, config.get(OpenLDAPConstants.CONFIG_PORT));
+        settingsUtils.changeSetting(OpenLDAPConstants.SERVER_SETTING, config.get(OpenLDAPConstants.CONFIG_SERVER));
+        if(config.get(OpenLDAPConstants.CONFIG_SERVICE_ACCOUNT_PASSWORD) != null){
+            settingsUtils.changeSetting(OpenLDAPConstants.SERVICE_ACCOUNT_PASSWORD_SETTING, config.get(OpenLDAPConstants.CONFIG_SERVICE_ACCOUNT_PASSWORD));
+        }
+        settingsUtils.changeSetting(OpenLDAPConstants.SERVICE_ACCOUNT_USERNAME_SETTING, config.get(OpenLDAPConstants.CONFIG_SERVICE_ACCOUNT_USERNAME));
+        settingsUtils.changeSetting(OpenLDAPConstants.TLS_SETTING, config.get(OpenLDAPConstants.CONFIG_TLS));
+        settingsUtils.changeSetting(OpenLDAPConstants.USER_DISABLED_BIT_MASK_SETTING, config.get(OpenLDAPConstants.CONFIG_USER_DISABLED_BIT_MASK));
+        settingsUtils.changeSetting(OpenLDAPConstants.USER_ENABLED_ATTRIBUTE_SETTING, config.get(OpenLDAPConstants.CONFIG_USER_ENABLED_ATTRIBUTE));
+        settingsUtils.changeSetting(OpenLDAPConstants.USER_LOGIN_FIELD_SETTING, config.get(OpenLDAPConstants.CONFIG_USER_LOGIN_FIELD));
+        settingsUtils.changeSetting(OpenLDAPConstants.USER_MEMBER_ATTRIBUTE_SETTING, config.get(OpenLDAPConstants.CONFIG_USER_MEMBER_ATTRIBUTE));
+        settingsUtils.changeSetting(OpenLDAPConstants.USER_NAME_FIELD_SETTING, config.get(OpenLDAPConstants.CONFIG_USER_NAME_FIELD));
+        settingsUtils.changeSetting(OpenLDAPConstants.USER_OBJECT_CLASS_SETTING, config.get(OpenLDAPConstants.CONFIG_USER_OBJECT_CLASS));
+        settingsUtils.changeSetting(OpenLDAPConstants.USER_SEARCH_FIELD_SETTING, config.get(OpenLDAPConstants.CONFIG_USER_SEARCH_FIELD));
+        settingsUtils.changeSetting(OpenLDAPConstants.TIMEOUT_SETTING, config.get(OpenLDAPConstants.CONFIG_TIMEOUT));
+        settingsUtils.changeSetting(OpenLDAPConstants.GROUP_DN_FIELD_SETTING, config.get(OpenLDAPConstants.CONFIG_GROUP_DN_FIELD));
+        settingsUtils.changeSetting(OpenLDAPConstants.GROUP_MEMBER_USER_ATTRIBUTE_SETTING, config.get(OpenLDAPConstants.CONFIG_GROUP_MEMBER_USER_ATTRIBUTE));
+        settingsUtils.changeSetting(SecurityConstants.SECURITY_SETTING, config.get(OpenLDAPConstants.CONFIG_SECURITY));
+        if (config.get(OpenLDAPConstants.CONFIG_SECURITY) != null){
             settingsUtils.changeSetting(SecurityConstants.AUTH_PROVIDER_SETTING, OpenLDAPConstants.CONFIG);
         } else {
             settingsUtils.changeSetting(SecurityConstants.AUTH_PROVIDER_SETTING, SecurityConstants.NO_PROVIDER);
+        }
+        String accessModeInConfig = (String)config.get(AbstractTokenUtil.ACCESSMODE);
+        if (AbstractTokenUtil.isRestrictedAccess(accessModeInConfig) || AbstractTokenUtil.isRequiredAccess(accessModeInConfig)) {
+            //validate the allowedIdentities
+            @SuppressWarnings("unchecked")
+            String ids = openLDAPIdentityProvider.validateIdentities((List<Map<String, String>>) config.get(OpenLDAPConstants.CONFIG_ALLOWED_IDENTITIES));
+            settingsUtils.changeSetting(OpenLDAPConstants.ALLOWED_IDENTITIES_SETTING, ids);
+        } else if (AbstractTokenUtil.isUnrestrictedAccess(accessModeInConfig)) {
+            //clear out the allowedIdentities Set
+            settingsUtils.changeSetting(OpenLDAPConstants.ALLOWED_IDENTITIES_SETTING, null);
         }
         return currentLdapConfig(config);
     }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPConstants.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPConstants.java
@@ -47,6 +47,7 @@ public class OpenLDAPConstants {
     public static final String TIMEOUT_SETTING = SETTING_BASE + "connection.timeout";
     public static final String GROUP_DN_FIELD_SETTING = SETTING_BASE + "group.dn.field";
     public static final String GROUP_MEMBER_USER_ATTRIBUTE_SETTING = SETTING_BASE + "group.member.user.attribute";
+    public static final String ALLOWED_IDENTITIES_SETTING = SETTING_BASE + "allowed.identities";
 
 
     public static final Set<String> SCOPES = Collections.unmodifiableSet(
@@ -89,4 +90,31 @@ public class OpenLDAPConstants {
     public static final DynamicLongProperty CONNECTION_TIMEOUT = ArchaiusUtil.getLong(TIMEOUT_SETTING);
     public static final DynamicStringProperty GROUP_DN_FIELD = ArchaiusUtil.getString(GROUP_DN_FIELD_SETTING);
     public static final DynamicStringProperty GROUP_MEMBER_USER_ATTRIBUTE = ArchaiusUtil.getString(GROUP_MEMBER_USER_ATTRIBUTE_SETTING);
+    public static final DynamicStringProperty LDAP_ALLOWED_IDENTITIES = ArchaiusUtil.getString(ALLOWED_IDENTITIES_SETTING);
+
+
+    public static final String CONFIG_DOMAIN = "domain";
+    public static final String CONFIG_ALLOWED_IDENTITIES = "allowedIdentities";
+    public static final String CONFIG_GROUP_NAME_FIELD = "groupNameField";
+    public static final String CONFIG_GROUP_OBJECT_CLASS = "groupObjectClass";
+    public static final String CONFIG_GROUP_SEARCH_FIELD = "groupSearchField";
+    public static final String CONFIG_LOGIN_DOMAIN = "loginDomain";
+    public static final String CONFIG_PORT = "port";
+    public static final String CONFIG_SERVER = "server";
+    public static final String CONFIG_SERVICE_ACCOUNT_PASSWORD = "serviceAccountPassword";
+    public static final String CONFIG_SERVICE_ACCOUNT_USERNAME = "serviceAccountUsername";
+    public static final String CONFIG_TLS = "tls";
+    public static final String CONFIG_USER_DISABLED_BIT_MASK = "userDisabledBitMask";
+    public static final String CONFIG_USER_ENABLED_ATTRIBUTE = "userEnabledAttribute";
+    public static final String CONFIG_USER_LOGIN_FIELD = "userLoginField";
+    public static final String CONFIG_USER_NAME_FIELD = "userNameField";
+    public static final String CONFIG_USER_OBJECT_CLASS = "userObjectClass";
+    public static final String CONFIG_USER_SEARCH_FIELD = "userSearchField";
+    public static final String CONFIG_TIMEOUT = "connectionTimeout";
+    public static final String CONFIG_SECURITY = "enabled";
+    public static final String CONFIG_GROUP_DN_FIELD = "groupDNField";
+    public static final String CONFIG_GROUP_MEMBER_USER_ATTRIBUTE = "groupMemberUserAttribute";
+    public static final String CONFIG_GROUP_USER_MAPPING_ATTRIBUTE = "groupMemberMappingAttribute";
+    public static final String CONFIG_USER_MEMBER_ATTRIBUTE = "userMemberAttribute";
+
 }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPIdentityProvider.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPIdentityProvider.java
@@ -16,8 +16,10 @@ import io.github.ibuildthecloud.gdapi.exception.ClientVisibleException;
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 import io.github.ibuildthecloud.gdapi.util.ResponseCodes;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
@@ -47,6 +49,7 @@ public class OpenLDAPIdentityProvider extends LDAPIdentityProvider implements Id
     ExecutorService executorService;
     @Inject
     OpenLDAPConstantsConfig openLDAPConfig;
+
 
     @Override
     public Set<Identity> getIdentities(Account account) {
@@ -236,5 +239,23 @@ public class OpenLDAPIdentityProvider extends LDAPIdentityProvider implements Id
     @Override
     public String getName() {
         return getConstantsConfig().getProviderName();
+    }
+
+    public String validateIdentities(List<Map<String, String>> identitiesGiven) {
+        List<Identity> identities = getIdentities(identitiesGiven);
+        return openLDAPUtils.toHashSeparatedString(identities);
+    }
+
+    public List<Identity> savedIdentities() {
+        List<String> ids = openLDAPUtils.fromHashSeparatedString(OpenLDAPConstants.LDAP_ALLOWED_IDENTITIES.get());
+        List<Identity> identities = new ArrayList<>();
+        if (ids.isEmpty() || !isConfigured()) {
+            return identities;
+        }
+        for(String id: ids){
+            String[] split = id.split(":", 2);
+            identities.add(getIdentity(split[1], split[0]));
+        }
+        return identities;
     }
 }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPUtils.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/OpenLDAP/OpenLDAPUtils.java
@@ -1,9 +1,14 @@
 package io.cattle.platform.iaas.api.auth.integration.ldap.OpenLDAP;
 
+import io.cattle.platform.api.auth.Identity;
 import io.cattle.platform.core.model.Account;
 import io.cattle.platform.iaas.api.auth.AbstractTokenUtil;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class OpenLDAPUtils extends AbstractTokenUtil {
 
@@ -14,8 +19,42 @@ public class OpenLDAPUtils extends AbstractTokenUtil {
 
     @Override
     protected boolean isWhitelisted(List<String> idList) {
-        //TODO Real white listing needed.
-        return true;
+        if (idList == null || idList.isEmpty()) {
+            return false;
+        }
+        List<String> whitelistedValues = fromHashSeparatedString(OpenLDAPConstants.LDAP_ALLOWED_IDENTITIES.get());
+
+        for (String id : idList) {
+            for (String whiteId: whitelistedValues){
+                if (StringUtils.equals(id, whiteId)){
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public String toHashSeparatedString(List<Identity> identities) {
+        StringBuilder sb = new StringBuilder();
+        Iterator<Identity> identityIterator = identities.iterator();
+        while (identityIterator.hasNext()){
+            sb.append(identityIterator.next().getId().trim());
+            if (identityIterator.hasNext()) sb.append('#');
+        }
+        return sb.toString();
+    }
+
+    public List<String> fromHashSeparatedString(String string) {
+        if (StringUtils.isEmpty(string)) {
+            return new ArrayList<>();
+        }
+        List<String> strings = new ArrayList<>();
+        String[] splitted = string.split("#");
+        for (String aSplitted : splitted) {
+            String element = aSplitted.trim();
+            strings.add(element);
+        }
+        return strings;
     }
 
     @Override

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADIdentityProvider.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/ad/ADIdentityProvider.java
@@ -3,7 +3,6 @@ package io.cattle.platform.iaas.api.auth.integration.ldap.ad;
 import static javax.naming.directory.SearchControls.*;
 
 import io.cattle.platform.api.auth.Identity;
-import io.cattle.platform.core.constants.IdentityConstants;
 import io.cattle.platform.core.model.Account;
 import io.cattle.platform.core.model.AuthToken;
 import io.cattle.platform.iaas.api.auth.AbstractTokenUtil;
@@ -349,21 +348,4 @@ public class ADIdentityProvider extends LDAPIdentityProvider implements Identity
         return adTokenUtils.toHashSeparatedString(identities);
     }
 
-    public List<Identity> getIdentities(List<Map<String, String>> identitiesGiven) {
-        if (identitiesGiven == null || identitiesGiven.isEmpty()){
-            return new ArrayList<>();
-        }
-
-        List<Identity> identities = new ArrayList<>();
-        for (Map<String, String> identity: identitiesGiven){
-            String externalId = identity.get(IdentityConstants.EXTERNAL_ID);
-            String externalIdType = identity.get(IdentityConstants.EXTERNAL_ID_TYPE);
-            Identity gotIdentity = getIdentity(externalId, externalIdType);
-            if (gotIdentity == null) {
-                throw new ClientVisibleException(ResponseCodes.BAD_REQUEST, "InvalidIdentity", "Invalid Identity", null);
-            }
-            identities.add(gotIdentity);
-        }
-        return identities;
-    }
 }

--- a/resources/content/schema/admin/admin-auth.json
+++ b/resources/content/schema/admin/admin-auth.json
@@ -192,6 +192,8 @@
         "openldapconfig.connectionTimeout" : "cr",
         "openldapconfig.groupDNField" : "cr",
         "openldapconfig.groupMemberUserAttribute" : "cr",
+        "openldapconfig.allowedIdentities": "cr",
+
 
         "password.accountId" : "cr",
 

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -587,7 +587,8 @@ def test_openldap_auth(admin_user_client, user_client, project_client):
         'userMemberAttribute': 'cr',
         'connectionTimeout': 'cr',
         'groupDNField': 'cr',
-        'groupMemberUserAttribute': 'cr'
+        'groupMemberUserAttribute': 'cr',
+        'allowedIdentities': 'cr'
     })
 
 


### PR DESCRIPTION
Added changes to support the Site Access functionality for OpenLDAP.

For OpenLDAP, Admin can now set the accessMode ["unrestricted"/"restricted"/"required"] and the list of users/groups allowed to login.

https://github.com/rancher/rancher/issues/5141