### PR TITLE
compare labels values in case insensitive manner

### DIFF
--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/host/HostLabelReconcile.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/host/HostLabelReconcile.java
@@ -73,7 +73,7 @@ public class HostLabelReconcile extends AbstractObjectProcessHandler implements 
             Long labelId = mapping.getLabelId();
             Label existingLabel = existingLabelLookupById.get(labelId);
             String newLabelValue = labelsField.get(existingLabel.getKey());
-            if (newLabelValue == null || !newLabelValue.equals(existingLabel.getValue())) {
+            if (newLabelValue == null || !newLabelValue.equalsIgnoreCase(existingLabel.getValue())) {
                 objectProcessManager.scheduleProcessInstance("hostlabelmap.remove", mapping, null);
             }
         }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/7874

@cjellick could you merge only if allocator doesn't care about the case of the label value. Otherwise we'd have to fix it differently, by re-creating the label mapping when the case of the old/new value doesn't match