### PR TITLE
Add host event create for scheduler update

### DIFF
--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/externalevent/ExternalHostEventCreate.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/externalevent/ExternalHostEventCreate.java
@@ -136,7 +136,7 @@ public class ExternalHostEventCreate extends AbstractObjectProcessHandler {
 
     @Override
     public String[] getProcessNames() {
-        return new String[] {ExternalEventConstants.KIND_EXTERNAL_EVENT + ".create"};
+        return new String[] {ExternalEventConstants.PROCESS_EXTERNAL_EVENT_CREATE};
     }
 
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/ExternalEventConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/ExternalEventConstants.java
@@ -2,6 +2,7 @@ package io.cattle.platform.core.constants;
 
 public class ExternalEventConstants {
 
+    public static final String PROCESS_EXTERNAL_EVENT_CREATE = "externalEvent.create";
     public static final String KIND_VOLUME_EVENT = "externalVolumeEvent";
     public static final String KIND_STORAGE_POOL_EVENT = "externalStoragePoolEvent";
     public static final String KIND_EXTERNAL_DNS_EVENT = "externalDnsEvent";
@@ -17,6 +18,7 @@ public class ExternalEventConstants {
     public static final String TYPE_SERVICE_DELETE = "service.remove";
     public static final String TYPE_STACK_DELETE=  "stack.remove";
     public static final String TYPE_HOST_EVACUATE = "host.evacuate";
+    public static final String TYPE_SCHEDULER_UPDATE = "scheduler.update";
     public static final String VOLUME_POOL_LOCK_NAME = "VOLUME";
     public static final String STORAGE_POOL_LOCK_NAME = "STORAGEPOOL";
     public static final String EXERNAL_DNS_LOCK_NAME = "EXTERNALDNS";

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServicesReconcilePostTrigger.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServicesReconcilePostTrigger.java
@@ -1,6 +1,7 @@
 package io.cattle.platform.servicediscovery.process;
 
 import io.cattle.platform.core.constants.AgentConstants;
+import io.cattle.platform.core.constants.ExternalEventConstants;
 import io.cattle.platform.core.constants.HostConstants;
 import io.cattle.platform.core.constants.LabelConstants;
 import io.cattle.platform.core.model.Service;
@@ -35,7 +36,8 @@ public class ServicesReconcilePostTrigger extends AbstractObjectProcessLogic imp
                 LabelConstants.PROCESS_HOSTLABELMAP_CREATE,
                 LabelConstants.PROCESS_HOSTLABELMAP_REMOVE,
                 AgentConstants.PROCESS_RECONNECT,
-                AgentConstants.PROCESS_FINISH_RECONNECT
+                AgentConstants.PROCESS_FINISH_RECONNECT,
+                ExternalEventConstants.PROCESS_EXTERNAL_EVENT_CREATE
         };
     }
 

--- a/resources/content/schema/agent/externalHostEvent.json
+++ b/resources/content/schema/agent/externalHostEvent.json
@@ -1,0 +1,14 @@
+{
+    "collectionMethods": ["GET", "POST"],
+    "resourceMethods" : ["GET"],
+    "resourceFields": {
+        "id": {
+        },
+        "externalId": {
+            "create": true
+        },
+        "eventType": {
+            "create": true
+        }
+    }
+}

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -275,6 +275,7 @@ def test_agent_types(agent_client):
         'containerEvent',
         'error',
         'externalEvent',
+        'externalHostEvent',
         'externalVolumeEvent',
         'externalServiceEvent',
         'externalStoragePoolEvent',


### PR DESCRIPTION
We need to be able to ensure that when a host is added, removed, or
updated, global service reconciliation is kicked off AFTER the external
scheduler has had a chance to update its internal state.

This event handler allows for that. The flow for CRUDing the host will
be thus:
1. Host is CRUDed in cattle
2. Existing service reconcile trigger logic runs, but the host change
has not yet propogated to metadata and thus it is not in the scheduler,
so the scheduler behaves as though it doesnt know about the change and
global services are not changed.
3. Metadata updates and scheduler updates its internal state
4. Scheduler sends a external host event informing cattle that it
updated its state and global service reconciliation needs to be
triggered.
5. ExternalHostSchedulerUpdateEventCreate handles the event and kicks
off reconcile for global services.