### PR TITLE
Fix secrets test

### DIFF
--- a/tests/integration/cattletest/core/test_secrets.py
+++ b/tests/integration/cattletest/core/test_secrets.py
@@ -145,7 +145,7 @@ def test_secret_create_and_download(secret_context, super_client):
     assert resp[0]['uid'] == 'user'
     assert resp[0]['gid'] == 'group'
     assert resp[0]['mode'] == '0400'
-    assert len(resp[0]['rewrapText']) == 344
+    assert len(resp[0]['rewrapText']) == 908
 
 
 def test_secret_multi_host(secret_context, super_client):


### PR DESCRIPTION
The test is checking the length of the payload, but the expected length
was based off of a previous version of the secrets binary.