### PR TITLE
fix native container for docker compose

### DIFF
--- a/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/instance/DockerInstancePreCreate.java
+++ b/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/instance/DockerInstancePreCreate.java
@@ -59,7 +59,7 @@ public class DockerInstancePreCreate extends AbstractObjectProcessLogic implemen
         data.put(DockerInstanceConstants.FIELD_NETWORK_MODE, mode);
 
         Network network = networkService.resolveNetwork(instance.getAccountId(), mode);
-        if (network == null && StringUtils.isNotBlank(mode)) {
+        if (network == null && StringUtils.isNotBlank(mode) && !instance.getNativeContainer()) {
             objectProcessManager.scheduleProcessInstance(InstanceConstants.PROCESS_REMOVE, instance, null);
             throw new ExecutionException(String.format("Failed to find network for networkMode %s", mode),
                     null, state.getResource());


### PR DESCRIPTION
@cjellick It appears that containers created by docker-compose always have a weird network name called `projectDir-default`, which cattle can't find it in database and will schedule instance.remove for them https://github.com/rancher/cattle/blob/master/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/instance/DockerInstancePreCreate.java#L61-L66 if network is null. ~~My change is just to go through all the logic in `resolveNetwork` and then if still can't find network, return the default `dockerBridge` because network `projectDir-default`is still valid and is treated as docker bridge indeed. But this can't cover all the cases as we can't tell the network type just from the name. However, it will be sufficient to let those containers go through the rancher container lifecycle~~ Tested end to end, it works.