### PR TITLE
don't override userPort field

### DIFF
--- a/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/instancehostmap/DockerPostInstanceHostMapActivate.java
+++ b/code/implementation/docker/compute/src/main/java/io/cattle/platform/docker/process/instancehostmap/DockerPostInstanceHostMapActivate.java
@@ -329,7 +329,9 @@ public class DockerPostInstanceHostMapActivate extends AbstractObjectProcessLogi
             }
         }
         List<String> userPorts = DataAccessor.fieldStringList(instance, InstanceConstants.FIELD_PORTS);
-        DataAccessor.fields(instance).withKey(InstanceConstants.FIELD_USER_PORTS).set(userPorts);
+        if (DataAccessor.fieldStringList(instance, InstanceConstants.FIELD_USER_PORTS).isEmpty()) {
+            DataAccessor.fields(instance).withKey(InstanceConstants.FIELD_USER_PORTS).set(userPorts);
+        }
         DataAccessor.fields(instance).withKey(InstanceConstants.FIELD_PORTS).set(publishedPorts);
         objectManager.persist(instance);
     }


### PR DESCRIPTION
It will address the issue where we restart the container and then the userPort field is overridden. https://github.com/rancher/rancher/issues/7782