### PR TITLE
service token to metadata

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/metadata/common/ServiceMetaData.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/data/metadata/common/ServiceMetaData.java
@@ -144,6 +144,7 @@ public class ServiceMetaData {
         this.environment_uuid = account.getUuid();
         this.state = service.getState();
         this.metadata_kind = "service";
+        this.token = DataAccessor.fieldString(service, ServiceConstants.FIELD_TOKEN);
     }
 
     public static String getVip(Service service) {


### PR DESCRIPTION
@janeczku  @ibuildthecloud added missing token propagation to metadata - needed by Public DNS component.

