### PR TITLE
no force upgrade on service.update when nothing changed

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/ServiceExposeMapDao.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/ServiceExposeMapDao.java
@@ -39,7 +39,7 @@ public interface ServiceExposeMapDao {
 
     Host getHostForInstance(long instanceId);
 
-    List<? extends Instance> getInstancesSetForUpgrade(long serviceId);
+    List<? extends Instance> getServiceInstancesSetForUpgrade(long serviceId);
 
     List<? extends Instance> getInstancesToUpgrade(Service service, String launchConfigName, String toVersion);
 
@@ -55,4 +55,6 @@ public interface ServiceExposeMapDao {
 
     ServiceExposeMap createServiceInstanceMap(Service service, Instance instance, boolean managed, String dnsPrefix);
     
+    List<? extends Instance> getDeploymentUnitInstancesSetForUpgrade(DeploymentUnit unit);
+
 }

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/ServiceExposeMapDaoImpl.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/ServiceExposeMapDaoImpl.java
@@ -364,7 +364,7 @@ public class ServiceExposeMapDaoImpl extends AbstractJooqDao implements ServiceE
     }
 
     @Override
-    public List<? extends Instance> getInstancesSetForUpgrade(long serviceId) {
+    public List<? extends Instance> getServiceInstancesSetForUpgrade(long serviceId) {
         return create()
                 .select(INSTANCE.fields())
                 .from(INSTANCE)
@@ -375,6 +375,23 @@ public class ServiceExposeMapDaoImpl extends AbstractJooqDao implements ServiceE
                 .and(SERVICE_EXPOSE_MAP.UPGRADE.eq(true))
                 .and(SERVICE_EXPOSE_MAP.STATE.in(CommonStatesConstants.ACTIVATING,
                         CommonStatesConstants.ACTIVE, CommonStatesConstants.REQUESTED))
+                .and(INSTANCE.REMOVED.isNull())
+                .and(INSTANCE.STATE.ne(CommonStatesConstants.REMOVING))
+                .fetchInto(InstanceRecord.class);
+    }
+
+    @Override
+    public List<? extends Instance> getDeploymentUnitInstancesSetForUpgrade(DeploymentUnit unit) {
+        return create()
+                .select(INSTANCE.fields())
+                .from(INSTANCE)
+                .join(DEPLOYMENT_UNIT)
+                .on(DEPLOYMENT_UNIT.ID.eq(INSTANCE.DEPLOYMENT_UNIT_ID))
+                .join(SERVICE_EXPOSE_MAP)
+                .on(SERVICE_EXPOSE_MAP.INSTANCE_ID.eq(INSTANCE.ID))
+                .where(DEPLOYMENT_UNIT.ID.eq(unit.getId()))
+                .and(SERVICE_EXPOSE_MAP.MANAGED.eq(false))
+                .and(SERVICE_EXPOSE_MAP.UPGRADE.eq(true))
                 .and(INSTANCE.REMOVED.isNull())
                 .and(INSTANCE.STATE.ne(CommonStatesConstants.REMOVING))
                 .fetchInto(InstanceRecord.class);

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/util/ServiceUtil.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/util/ServiceUtil.java
@@ -428,22 +428,9 @@ public class ServiceUtil {
                             resetVersion = true;
                         }
                         currentConfig.remove(key);
-                    } else if (upgradeTriggerFields.contains(key)) {
+                    } else if (upgradeTriggerFields.contains(key) && mergedConfig.get(key) != null) {
                         resetVersion = true;
                     }
-                }
-
-                // if there are no updatable keys left,
-                // consider force upgrade
-                boolean upgradableFieldsLeft = false;
-                for (String key : currentConfig.keySet()) {
-                    if (upgradeTriggerFields.contains(key)) {
-                        upgradableFieldsLeft = true;
-                        break;
-                    }
-                }
-                if (!upgradableFieldsLeft) {
-                    resetVersion = true;
                 }
                 mergedConfig.putAll(currentConfig);
                 currentConfigsMap.remove(name);

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/planner/AbstractServiceDeploymentPlanner.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/planner/AbstractServiceDeploymentPlanner.java
@@ -164,9 +164,13 @@ public abstract class AbstractServiceDeploymentPlanner implements ServiceDeploym
         sortByCreated(units);
 
         for (DeploymentUnit unit : units) {
+            // to handle the case when deactivate/activate is called in a row
+            if (unit.getState().equalsIgnoreCase(CommonStatesConstants.DEACTIVATING)) {
+                unit = context.resourceMonitor.waitForNotTransitioning(unit);
+            }
             if (unit.getState().equalsIgnoreCase(CommonStatesConstants.INACTIVE)) {
                 context.objectProcessManager.scheduleStandardProcessAsync(StandardProcess.ACTIVATE, unit, null);
-            } else if (unit.getState().equalsIgnoreCase(CommonStatesConstants.REQUESTED)) {
+            }else if (unit.getState().equalsIgnoreCase(CommonStatesConstants.REQUESTED)) {
                 context.objectProcessManager.scheduleStandardChainedProcessAsync(StandardProcess.CREATE,
                         StandardProcess.ACTIVATE,
                         unit, null);

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/upgrade/impl/UpgradeManagerImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/upgrade/impl/UpgradeManagerImpl.java
@@ -485,7 +485,7 @@ public class UpgradeManagerImpl implements UpgradeManager {
     }
 
     public void cleanupUpgradedInstances(Service service) {
-        List<? extends Instance> instances = exposeMapDao.getInstancesSetForUpgrade(service.getId());
+        List<? extends Instance> instances = exposeMapDao.getServiceInstancesSetForUpgrade(service.getId());
         for (Instance instance : instances) {
             try {
                 objectProcessMgr.scheduleProcessInstanceAsync(InstanceConstants.PROCESS_REMOVE,


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/8190

Also added a fix to cleanup instances set for upgrade (the ones you can rollback to) to be removed as a part of deployment unit removal.