### PR TITLE
increased label.value field size

### DIFF
--- a/resources/content/db/changelog.xml
+++ b/resources/content/db/changelog.xml
@@ -124,4 +124,5 @@
     <include file="db/core-117.xml"/>
     <include file="db/core-118.xml"/>
     <include file="db/core-119.xml"/>
+    <include file="db/core-120.xml"/>
 </databaseChangeLog>

--- a/resources/content/db/core-120.xml
+++ b/resources/content/db/core-120.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <property name="mediumtext" value="TEXT" dbms="postgresql" />
+    <property name="mediumtext" value="MEDIUMTEXT(16777215)" />
+    <property name="mediumtext" value="varchar" dbms="H2" />
+    <changeSet author="alena (generated)" id="dump1">
+        <modifyDataType columnName="value" newDataType="varchar(8192)" tableName="label"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/8168

@ibuildthecloud @LLParse apparently k8s puts a lot of data in stateful set pod container's label. Increased the label.value size in cattle db to mediumtext to fix it.