### PR TITLE
update service instance ports before trigger orchestration on port obj

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceUpdatePostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceUpdatePostListener.java
@@ -100,6 +100,10 @@ public class LoadBalancerServiceUpdatePostListener extends AbstractObjectProcess
                 port = objectManager.create(port);
             }
 
+            // trigger instance/metadata update
+            instance = objectManager.setFields(instance, InstanceConstants.FIELD_PORTS, newPortDefs);
+            instanceDao.clearCacheInstanceData(instance.getId());
+
             for (Port port : toRetain.values()) {
                 createThenActivate(port, new HashMap<String, Object>());
             }
@@ -107,10 +111,6 @@ public class LoadBalancerServiceUpdatePostListener extends AbstractObjectProcess
             for (Port port : toRemove) {
                 deactivateThenRemove(port, new HashMap<String, Object>());
             }
-
-            // trigger instance/metadata update
-            instance = objectManager.setFields(instance, InstanceConstants.FIELD_PORTS, newPortDefs);
-            instanceDao.clearCacheInstanceData(instance.getId());
         }
     }
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/8257

On service ports update, we update all underlying instances with the new ports. The bug is that we used to call orchestration on the port  before setting port field in the instance. As a result, metadata upgrade was triggered while instances still had old ports.

@ibuildthecloud I'll put a separate fix for that in wagyu branch as the corresponding class name got changed there.