### PR TITLE
For HZ don't create qualified topics, just use one generic one

### DIFF
--- a/scripts/run
+++ b/scripts/run
@@ -23,6 +23,8 @@ mkdir -p $RUNTIME_DIR
 CMD="java
     -Xmx1024m
     -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled
+    -Dmodule.profile.hazelcast.eventing=true
+    -Dspring.profiles.active=hazelcast.eventing,hazelcast.lock,hazelcast.config.basic
     -Dconfig.item.dynamic=false
     -Dsecrets.api.execute=true
     -Dagent.ping.reconnect.after.failed.count=60


### PR DESCRIPTION
In hazelcast we end up leaking topics as more topics of the form
name;key=value are created where key=value are unique.  To work around
this we only create one topic called name; and then put key=value in the
message to be filtered by the listener.