### PR TITLE
put wait for dependant services to activate logic back

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceUpdateActivate.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/ServiceUpdateActivate.java
@@ -70,6 +70,7 @@ public class ServiceUpdateActivate extends AbstractObjectProcessHandler {
         activity.run(service, process.getName(), getMessage(process.getName()), new Runnable() {
             @Override
             public void run() {
+                waitForConsumedServicesActivate(state);
                 deploymentMgr.activate(service);
             }
         });


### PR DESCRIPTION
@ibuildthecloud not sure if this logic was removed intentionally as a part of "add service log" commit 7 months back (6178227acdcbd2d1d2cb881b42e7b438ee9ae794). But it breaks dependencies-start-basedOnLinks when called from stack.activateServices.