### PR TITLE
Fix potential memory leak

### DIFF
--- a/code/framework/engine/src/main/java/io/cattle/platform/engine/manager/impl/DefaultProcessManager.java
+++ b/code/framework/engine/src/main/java/io/cattle/platform/engine/manager/impl/DefaultProcessManager.java
@@ -164,15 +164,12 @@ public class DefaultProcessManager implements ProcessManager, InitializationTask
         while (true) {
             ProcessInstance process = toPersist.take().getObject().get();
             if (process == null) {
-                return;
+                continue;
             }
 
             synchronized (process) {
                 if (process.isRunningLogic()) {
                     persistState(process, false);
-                }
-                if (process.getExitReason() == null) {
-                    queue(process);
                 }
             }
         }

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/defaults/defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/defaults/defaults.properties
@@ -1,4 +1,4 @@
-process.log.save.interval.ms=15000
+process.log.save.interval.ms=5000
 process.replay.batch.size=50000
 
 eventing.pool.process.count=100


### PR DESCRIPTION
During memory presure the queue to persist logs could slow down to
purging one entry per second. Under high load this means the queue
could take up 100s of megabytes.