### PR TITLE
Don't call external sched during deploy planning

### DIFF
--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AllocationHelperImpl.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AllocationHelperImpl.java
@@ -81,12 +81,9 @@ public class AllocationHelperImpl implements AllocationHelper {
         List<Constraint> hostAffinityConstraints = getHostAffinityConstraintsFromLabels(labelConstraints);
 
         List<Long> acceptableHostIds = new ArrayList<Long>();
-        List<String> acceptableHostUUIDsFromExSche = allocatorService.callExternalSchedulerForHostsSatisfyingLabels(accountId, labelConstraints);
         for (Host host : hosts) {
             if (hostSatisfiesHostAffinity(host.getId(), hostAffinityConstraints)) {
-                if (acceptableHostUUIDsFromExSche == null || acceptableHostUUIDsFromExSche.contains(host.getUuid())) {
-                    acceptableHostIds.add(host.getId());
-                }
+                acceptableHostIds.add(host.getId());
             }
         }
         return acceptableHostIds;


### PR DESCRIPTION
The global service deployment planner was calling the external
scheduler to check if any hosts should be excluded from its list due to
scheduling rules there. This was specifically added to allow the
io.rancher.scheduler.require_any host label to work with global
services. But we cannot make this call here because the calling code
occupies a thread in the core executore service, which must be fast or
it will back up the system.