### PR TITLE
Reconcile healthchecks on host.activate

### DIFF
--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/impl/AllocatorDaoImpl.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/impl/AllocatorDaoImpl.java
@@ -480,13 +480,11 @@ public class AllocatorDaoImpl extends AbstractJooqDao implements AllocatorDao {
                 .leftOuterJoin(AGENT)
                     .on(AGENT.ID.eq(HOST.AGENT_ID))
                 .where(
-                        AGENT.ID.isNull()
-                                .or(AGENT.STATE.in(CommonStatesConstants.ACTIVE,
-                                        AgentConstants.STATE_FINISHING_RECONNECT, AgentConstants.STATE_RECONNECTED))
+                AGENT.ID.isNull()
+                .or(AGENT.STATE.in(CommonStatesConstants.ACTIVE, AgentConstants.STATE_FINISHING_RECONNECT, AgentConstants.STATE_RECONNECTED))
                 .and(HOST.REMOVED.isNull())
                 .and(HOST.ACCOUNT_ID.eq(accountId))
-                                .and(HOST.STATE.in(CommonStatesConstants.ACTIVATING, CommonStatesConstants.ACTIVE,
-                                        CommonStatesConstants.UPDATING_ACTIVE)))
+                .and(HOST.STATE.in(CommonStatesConstants.ACTIVATING, CommonStatesConstants.ACTIVE, CommonStatesConstants.UPDATING_ACTIVE)))
                 .fetchInto(Host.class);
     }
 

--- a/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/HealthCheckReconcilePostTrigger.java
+++ b/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/HealthCheckReconcilePostTrigger.java
@@ -4,6 +4,7 @@ import io.cattle.iaas.healthcheck.service.HealthcheckInstancesLookup;
 import io.cattle.iaas.healthcheck.service.HealthcheckService;
 import io.cattle.iaas.healthcheck.service.HealthcheckService.HealthcheckInstanceType;
 import io.cattle.platform.core.constants.AgentConstants;
+import io.cattle.platform.core.constants.HostConstants;
 import io.cattle.platform.core.dao.HostDao;
 import io.cattle.platform.core.dao.NetworkDao;
 import io.cattle.platform.core.model.Instance;
@@ -41,7 +42,7 @@ public class HealthCheckReconcilePostTrigger extends AbstractObjectProcessLogic 
     @Override
     public String[] getProcessNames() {
         return new String[] { AgentConstants.PROCESS_RECONNECT, AgentConstants.PROCESS_FINISH_RECONNECT,
-                "networkserviceproviderinstancemap.create",
+                HostConstants.PROCESS_ACTIVATE,
                 "healthcheckinstancehostmap.remove" };
     }
 

--- a/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/service/impl/AgentHealthcheckInstancesLookup.java
+++ b/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/service/impl/AgentHealthcheckInstancesLookup.java
@@ -23,11 +23,15 @@ public class AgentHealthcheckInstancesLookup extends AbstractJooqDao implements 
 
     @Override
     public List<? extends Instance> getInstances(Object obj) {
-        if (!(obj instanceof Agent)) {
-            return null;
+        Host host = null;
+
+        if (obj instanceof Agent) {
+            Agent agent = (Agent) obj;
+            host = objectManager.findAny(Host.class, HOST.AGENT_ID, agent.getId(), HOST.REMOVED, null);
+        } else if (obj instanceof Host) {
+            host = (Host) obj;
         }
-        Agent agent = (Agent) obj;
-        Host host = objectManager.findAny(Host.class, HOST.AGENT_ID, agent.getId(), HOST.REMOVED, null);
+
         if (host == null) {
             return null;
         }

--- a/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/service/impl/HostMapHealthcheckInstancesLookup.java
+++ b/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/service/impl/HostMapHealthcheckInstancesLookup.java
@@ -25,9 +25,6 @@ public class HostMapHealthcheckInstancesLookup extends AbstractJooqDao implement
         HealthcheckInstanceHostMap hostMap = (HealthcheckInstanceHostMap) obj;
 
         List<Instance> instances = new ArrayList<>();
-        if (!(obj instanceof HealthcheckInstanceHostMap)) {
-            return instances;
-        }
         HealthcheckInstance hInstance = objectManager.loadResource(HealthcheckInstance.class,
                 hostMap.getHealthcheckInstanceId());
         if (hInstance == null || hInstance.getRemoved() != null) {

--- a/code/implementation/simulator/agent-connection/src/main/java/io/cattle/platform/agent/connection/simulator/AgentConnectionSimulator.java
+++ b/code/implementation/simulator/agent-connection/src/main/java/io/cattle/platform/agent/connection/simulator/AgentConnectionSimulator.java
@@ -32,6 +32,10 @@ public class AgentConnectionSimulator implements Simulator {
 
     @Override
     public Event execute(Event event) {
+        if (!open) {
+            return null;
+        }
+
         objectManager.reload(agent);
         for (AgentSimulatorEventProcessor processor : processors) {
             Event response = null;
@@ -59,6 +63,14 @@ public class AgentConnectionSimulator implements Simulator {
 
     public List<AgentSimulatorEventProcessor> getProcessors() {
         return processors;
+    }
+
+    public boolean isOpen() {
+        return open;
+    }
+
+    public void setOpen(boolean open) {
+        this.open = open;
     }
 
 }

--- a/code/implementation/simulator/agent-connection/src/main/java/io/cattle/platform/agent/connection/simulator/impl/SimulatorStartStopProcessor.java
+++ b/code/implementation/simulator/agent-connection/src/main/java/io/cattle/platform/agent/connection/simulator/impl/SimulatorStartStopProcessor.java
@@ -38,6 +38,7 @@ public class SimulatorStartStopProcessor implements AgentSimulatorEventProcessor
 
     private static final Pattern SHUTDOWN = Pattern.compile(".*simShutdownAfter\",\"([0-9]+)");
     private static final Pattern FORGET = Pattern.compile(".*simForgetImmediately.*");
+    private static final Pattern DISCONNECT = Pattern.compile(".*simDisconnectAgent.*");
     private static final String SIM_CREATE_ANOTHER = "simCreateAnother_";
     private static final Pattern CREATE_ANOTHER = Pattern.compile(".*simCreateAnother_.*");
 
@@ -103,6 +104,10 @@ public class SimulatorStartStopProcessor implements AgentSimulatorEventProcessor
                     simulator.getInstances().remove(uuid.toString());
                 }
             }, Long.parseLong(m.group(1)), TimeUnit.SECONDS);
+        }
+
+        if (DISCONNECT.matcher(eventString).matches()) {
+            simulator.setOpen(false);
         }
 
         if (CREATE_ANOTHER.matcher(eventString).matches()) {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/8416

This fixes a bug that occurs if you take you environment down to zero
hosts by removin the hosts from your cloud provider and they go into a
disconnected state in Rancher. In that scenario, healthchecked
instances on the disconnected host would never get healthchecks
scheduled on the newly added hosts and thus would never get moved off
the disconnected host.

The process that we were previously keying off of
(networkserviceproviderinstancemap.create) is no longer executed. It
was executed to lanuch the network-agent container on the host, but
we've completely gone away from that model. We were previously using
that process because we needed the network-agent to be running in order
for that host to process healthchecks, but that is no longer necessary
because healthcheks are deployed in their own containers. The logic
later in this process that schedules the new healthchecks ensures that
the host will have a healthcheck container deployed to it, if it
doesn't already.