### PR TITLE
Some LBs seeem to set the x-forwarded-for header to include the port

### DIFF
--- a/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/request/parser/DefaultApiRequestParser.java
+++ b/code/framework/java-server/src/main/java/io/github/ibuildthecloud/gdapi/request/parser/DefaultApiRequestParser.java
@@ -165,6 +165,13 @@ public class DefaultApiRequestParser implements ApiRequestParser {
         clientIp = getOverrideHeader(request, overrideClientIpHeader, clientIp);
         clientIp = getOverrideHeader(request, FORWARDED_FOR_HEADER, clientIp, false);
 
+        if (StringUtils.isNotBlank(clientIp)) {
+            // This is to deal with situations in which the x-forwarded-for is incorrect and has the remote port in it
+            String[] parts = clientIp.split("[:]");
+            if (parts.length == 2) {
+                return parts[0];
+            }
+        }
         return clientIp;
     }
 

--- a/tests/integration/cattletest/core/test_api.py
+++ b/tests/integration/cattletest/core/test_api.py
@@ -1,5 +1,6 @@
 from cattle import ApiError
 from common_fixtures import *  # NOQA
+import requests
 
 
 def test_agent_unique(super_client):
@@ -369,3 +370,13 @@ def test_query_length(admin_user_client):
 
     bigger = 'a' * (16384 - 512)
     admin_user_client.list_account(name=bigger)
+
+
+def test_x_bad_forwarded(cattle_url):
+    resp = requests.get(cattle_url, headers={'x-forwarded-for': '1.1.1.1'})
+    assert resp.headers['x-api-client-ip'] == '1.1.1.1'
+
+    resp = requests.get(cattle_url, headers={
+        'x-forwarded-for': '1.1.1.1:1234'
+    })
+    assert resp.headers['x-api-client-ip'] == '1.1.1.1'


### PR DESCRIPTION
If we see a port in the x-forwarded-for header we just remove it now.

https://github.com/rancher/rancher/issues/8315