### PR TITLE
merge container affinity labels for primary and sickkicks

### DIFF
--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AllocationHelper.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AllocationHelper.java
@@ -31,5 +31,5 @@ public interface AllocationHelper {
 
     List<Long> getAllHostsSatisfyingHostAffinity(Long accountId, Map<String, String> labelConstraints);
 
-    List<LockDefinition> extractAllocationLockDefinitions(Instance instance);
+    List<LockDefinition> extractAllocationLockDefinitions(Instance instance, List<Instance> instances);
 }

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/impl/AllocatorServiceImpl.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/impl/AllocatorServiceImpl.java
@@ -321,7 +321,7 @@ public class AllocatorServiceImpl implements AllocatorService, Named {
     }
 
     protected LockDefinition getInstanceLockDef(Instance origInstance, List<Instance> instances, Set<Long> volumeIds) {
-        List<LockDefinition> locks = allocationHelper.extractAllocationLockDefinitions(origInstance);
+        List<LockDefinition> locks = allocationHelper.extractAllocationLockDefinitions(origInstance, instances);
 
         if (origInstance.getDeploymentUnitUuid() != null) {
             locks.add(new AllocateConstraintLock(AllocateConstraintLock.Type.DEPLOYMENT_UNIT, origInstance.getDeploymentUnitUuid()));


### PR DESCRIPTION
When adding locks for container affinity rules, we need to merge the labels for both primary containers and sidekicks. What happens now is that the sidekicks are often scheduled first and they don't have a container-affinity label and ending up landing on the same hosts. The primary container do have the labels but they are scheduled with the sidekicks then will violate the affinity_rules.