### PR TITLE
Enabled metadata cache locking

### DIFF
--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/defaults/defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/defaults/defaults.properties
@@ -95,6 +95,7 @@ host.remove.delay.seconds=-1
 host.remove.delay.startup.seconds=900
 
 cache.metadata=true
+cache.metadata.lock=true
 
 # 1 hour
 task.upgrade.schedule.schedule=3600


### PR DESCRIPTION
The setting make is such that one version of metadata is only generated
once per management server.