### PR TITLE
Fix volumeTemplate stackID problems

### DIFF
--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/VolumeTemplateCreateValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/VolumeTemplateCreateValidationFilter.java
@@ -2,9 +2,11 @@ package io.cattle.platform.servicediscovery.api.filter;
 
 import static io.cattle.platform.core.model.tables.VolumeTemplateTable.*;
 
+import io.cattle.platform.api.auth.Policy;
 import io.cattle.platform.core.model.VolumeTemplate;
 import io.cattle.platform.iaas.api.filter.common.AbstractDefaultResourceManagerFilter;
 import io.cattle.platform.object.ObjectManager;
+import io.github.ibuildthecloud.gdapi.context.ApiContext;
 import io.github.ibuildthecloud.gdapi.exception.ValidationErrorException;
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 import io.github.ibuildthecloud.gdapi.request.resource.ResourceManager;
@@ -40,8 +42,8 @@ public class VolumeTemplateCreateValidationFilter extends AbstractDefaultResourc
     }
 
     private void validateNameUniqueness(VolumeTemplate template) {
-        if (objectManager.find(VolumeTemplate.class, VOLUME_TEMPLATE.REMOVED, null, VOLUME_TEMPLATE.STACK_ID,
-                template.getStackId(), VOLUME_TEMPLATE.NAME, template.getName()).size() > 0) {
+        if (objectManager.find(VolumeTemplate.class, VOLUME_TEMPLATE.ACCOUNT_ID, ((Policy) ApiContext.getContext().getPolicy()).getAccountId(),
+                VOLUME_TEMPLATE.REMOVED, null, VOLUME_TEMPLATE.STACK_ID, template.getStackId(), VOLUME_TEMPLATE.NAME, template.getName()).size() > 0) {
             throw new ValidationErrorException(ValidationErrorCodes.NOT_UNIQUE, "name");
         }
     }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/DeploymentUnit.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/DeploymentUnit.java
@@ -2,6 +2,7 @@ package io.cattle.platform.servicediscovery.deployment.impl.unit;
 
 import static io.cattle.platform.core.model.tables.VolumeTable.*;
 import static io.cattle.platform.core.model.tables.VolumeTemplateTable.*;
+
 import io.cattle.platform.core.constants.AgentConstants;
 import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.constants.ExternalEventConstants;
@@ -377,12 +378,18 @@ public class DeploymentUnit {
         String volumeNamePostfix = splitted[0];
         String volumePath = volumeName.replaceFirst(splitted[0] + ":", "");
 
-        final VolumeTemplate template = context.objectManager.findOne(VolumeTemplate.class, VOLUME_TEMPLATE.ACCOUNT_ID,
+        VolumeTemplate tmplt = context.objectManager.findOne(VolumeTemplate.class, VOLUME_TEMPLATE.ACCOUNT_ID,
                 service.getAccountId(), VOLUME_TEMPLATE.REMOVED, null, VOLUME_TEMPLATE.NAME, splitted[0],
                 VOLUME_TEMPLATE.STACK_ID, stack.getId());
-        if (template == null) {
-            return;
+        if (tmplt == null) {
+            tmplt = context.objectManager.findOne(VolumeTemplate.class, VOLUME_TEMPLATE.ACCOUNT_ID,
+                    service.getAccountId(), VOLUME_TEMPLATE.REMOVED, null, VOLUME_TEMPLATE.NAME, splitted[0],
+                    VOLUME_TEMPLATE.STACK_ID, null, VOLUME_TEMPLATE.EXTERNAL, true);
+            if (tmplt == null) {
+                return;
+            }
         }
+        final VolumeTemplate template = tmplt;
         
         Volume volume = null;
         if (template.getExternal()) {


### PR DESCRIPTION
- When validating volumeTemplate name uniqueness, scope query to account
- When looking for volumeTemplates during DU creation, if we can't find
  by name and stackId, do a second query with stackId null and
  external=true