### PR TITLE
Dont process stop events if container not started

### DIFF
--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/containerevent/ContainerEventCreate.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/containerevent/ContainerEventCreate.java
@@ -175,7 +175,11 @@ public class ContainerEventCreate extends AbstractDefaultProcessHandler {
                         if (STATE_STOPPED.equals(state) || STATE_STOPPING.equals(state))
                             return null;
 
-                        objectProcessManager.scheduleProcessInstance(PROCESS_STOP, instance, makeData());
+                        if (STATE_STARTING.equals(state)) {
+                            instance = resourceMonitor.waitForNotTransitioning(instance, 3000L);
+                        }
+
+                        objectProcessManager.scheduleProcessInstance(PROCESS_STOP, objectManager.reload(instance), makeData());
                     } else if (EVENT_DESTROY.equals(status)) {
                         if (REMOVED.equals(state) || REMOVING.equals(state) || PURGED.equals(state) || PURGING.equals(state))
                             return null;


### PR DESCRIPTION
If container is still in starting, then we need to let that finish.
This specifically addresses a bug wherein container create takes a very
long time due to copying data from the image into a volume, but it
makes sense more generally as well.