### PR TITLE
SAML specific ExternalAuthProvider changes 

### DIFF
--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/external/ExternalServiceAuthProvider.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/external/ExternalServiceAuthProvider.java
@@ -209,12 +209,16 @@ public class ExternalServiceAuthProvider {
         //check if the setting 'support.identity.lookup = false', if yes then lookup the identity from token
 
         if(ServiceAuthConstants.NO_IDENTITY_LOOKUP_SUPPORTED.get()) {
+            // This means it is saml (among github and saml)
             log.debug("Identity lookup is not supported at the provider");
             if (tokenUtil.findAndSetJWT()) {
                 Set<Identity> identitiesInToken = tokenUtil.getIdentities();
                 log.debug("Found identitiesInToken {}" , identitiesInToken);
                 for (Identity identity : identitiesInToken) {
                     if(identity != null && id.equals(identity.getExternalId()) && scope.equals(identity.getExternalIdType())) {
+                        if (StringUtils.equals(identity.getExternalIdType(), ServiceAuthConstants.USER_TYPE.get())) {
+                            identity.setUser(true);
+                        }
                         return identity;
                     }
                 }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/8744
rancher-auth-service sets the setting `api.auth.external.provider.no.identity.lookup` to true, since unlike github/ldap, saml doesn't have identity lookup. Because of this setting being true, rancher-auth-service's `v1-auth/identities` is never called for saml while listing identities. It then reads allowed identities from db and gets only the `externalId` and `externalIdType`. This PR sets `user` flag on identities whose externalIdType matches the `USER_TYPE` setting.
`USER_TYPE` is obtained from the provider