### PR TITLE
WIP Attempt to find projectId in URL path

### DIFF
--- a/code/framework/api/src/main/java/io/cattle/platform/api/parser/ApiRequestParser.java
+++ b/code/framework/api/src/main/java/io/cattle/platform/api/parser/ApiRequestParser.java
@@ -7,6 +7,7 @@ import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 import io.github.ibuildthecloud.gdapi.request.parser.DefaultApiRequestParser;
 
 import java.io.IOException;
+
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -60,13 +61,27 @@ public class ApiRequestParser extends DefaultApiRequestParser {
 
             apiRequest.setSubContext(String.format("/%s/%s", parts[2], projectId));
 
-            String[] newPath = ArrayUtils.addAll(new String[]{"", parts[1]}, ArrayUtils.subarray(parts, 4, Integer.MAX_VALUE));
+            String[] newPath = ArrayUtils.addAll(new String[] { "", parts[1] }, ArrayUtils.subarray(parts, 4, Integer.MAX_VALUE));
             String servletPath = StringUtils.join(newPath, "/");
             request = new ProjectHttpServletRequest(request, projectId, servletPath);
             apiRequest.getServletContext().setRequest(request);
         }
 
         return super.parse(apiRequest);
+    }
+
+    public static String parseProjectIdFromPath(ApiRequest apiRequest) {
+        // Note: this just matches the above logic in pars(ApiRequest). It's
+        // cleaner to duplicate than refactor into reusable method.
+        HttpServletRequest request = apiRequest.getServletContext().getRequest();
+        String path = request.getServletPath();
+
+        String[] parts = path.split("/");
+        if (parts.length > 4 && "projects".equalsIgnoreCase(parts[2]) && !"projectMembers".equalsIgnoreCase(parts[4])) {
+            return parts[3];
+        }
+
+        return null;
     }
 
 }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/impl/ApiAuthenticator.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/impl/ApiAuthenticator.java
@@ -2,6 +2,7 @@ package io.cattle.platform.iaas.api.auth.impl;
 
 import io.cattle.platform.api.auth.Identity;
 import io.cattle.platform.api.auth.Policy;
+import io.cattle.platform.api.parser.ApiRequestParser;
 import io.cattle.platform.core.constants.AccountConstants;
 import io.cattle.platform.core.constants.ProjectConstants;
 import io.cattle.platform.core.dao.AccountDao;
@@ -184,14 +185,17 @@ public class ApiAuthenticator extends AbstractApiRequestHandler {
         String parsedProjectId = null;
 
         String projectId = request.getServletContext().getRequest().getHeader(ProjectConstants.PROJECT_HEADER);
-        if (projectId == null || projectId.isEmpty()) {
+        if (StringUtils.isEmpty(projectId)) {
             projectId = request.getServletContext().getRequest().getParameter("projectId");
         }
-        if (projectId == null || projectId.isEmpty()) {
+        if (StringUtils.isEmpty(projectId)) {
             projectId = (String) request.getAttribute(ProjectConstants.PROJECT_HEADER);
         }
+        if (StringUtils.isEmpty(projectId)) {
+            projectId = ApiRequestParser.parseProjectIdFromPath(request);
+        }
 
-        if (projectId == null || projectId.isEmpty()) {
+        if (StringUtils.isEmpty(projectId)) {
             String accessKey = request.getServletContext().getRequest().getHeader(ProjectConstants.CLIENT_ACCESS_KEY);
             if (StringUtils.isNotBlank(accessKey)) {
                 Account account = authDao.getAccountByAccessKey(accessKey);


### PR DESCRIPTION
This will allow us to put the project ID in proxied microservices (like
auth and catalog service). For example, the URLs will be able to look
like: http://localhost:8080/v1-catalog/projects/1a5/something

@ibuildthecloud @vincent99 curious what you think about this.