### PR TITLE
Dont find an agent if the resource is removed

### DIFF
--- a/code/iaas/logic-common/src/main/java/io/cattle/platform/process/common/handler/AgentBasedProcessLogic.java
+++ b/code/iaas/logic-common/src/main/java/io/cattle/platform/process/common/handler/AgentBasedProcessLogic.java
@@ -218,7 +218,11 @@ public class AgentBasedProcessLogic extends AbstractObjectProcessLogic implement
     }
 
     protected Object getAgentResource(ProcessState state, ProcessInstance process, Object dataResource) {
-        return getObjectByRelationship(agentResourceRelationship, state.getResource());
+        Object agentResource = getObjectByRelationship(agentResourceRelationship, state.getResource());
+        if (ObjectUtils.getRemoved(agentResource) != null) {
+            return null;
+        }
+        return agentResource;
     }
 
     protected Object getEventResource(ProcessState state, ProcessInstance process) {


### PR DESCRIPTION
When getting the "agentResource" that is later used to find an agent,
don't return the resource if it has been removed.

This will cause AgentBasedProcessHandler logic to short circuit and
complete successfully.

The concrete case for this if when a storage pool has been removed but
there are still volumeStoragePoolMaps associated with it that need
removed.