### PR TITLE
also look up for public port

### DIFF
--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/impl/AllocatorDaoImpl.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/impl/AllocatorDaoImpl.java
@@ -577,7 +577,9 @@ public class AllocatorDaoImpl extends AbstractJooqDao implements AllocatorDao {
                 Integer publicPort = (Integer) allocatedIp.get(PUBLIC_PORT);
                 Integer privatePort = (Integer) allocatedIp.get(PRIVATE_PORT);
                 for (Port port: objectManager.children(instance, Port.class)) {
-                    if (port.getPrivatePort().equals(privatePort) && StringUtils.equals(port.getProtocol(), protocol)) {
+                    if (port.getPrivatePort().equals(privatePort) 
+                            && StringUtils.equals(port.getProtocol(), protocol) 
+                            && (port.getPublicPort() == null || port.getPublicPort().equals(publicPort))) { 
                         DataAccessor.setField(port, BIND_ADDRESS, ipAddress);
                         port.setPublicPort(publicPort);
                         objectManager.persist(port);


### PR DESCRIPTION
Previously we look for ports based on private port and protocol, but this could be wrong if user specifies two different public ports pointing to the same private port.
So we need to add a check based on public port if it exists. In this way, we won't override the record if there are several same privatePort-protocol pairs.
For example, if user specifies:
3306 -> 80 tcp
80 -> 80 tcp
external scheduler returns the following to cattle:
0.0.0.0:3306:80 tcp
0.0.0.0:80:80 tcp
Cattle persists the records:
0.0.0.0:3306:80/tcp  looks for ports that matches 3306:80/tcp, instead of 80/tcp(which doesn't identify a row in port table in this case)
0.0.0.0:80:80/tcp  looks for ports that matches 80:80/tcp, instead of 80/tcp
This won't solve this case if user puts:
3306 -> 80
blank -> 80
Then we will override the record, to solve this we may need pass port ID which is complicated. I don't know even if that is valid use case.