### PR TITLE
Fix host template + host validation

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/HostConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/HostConstants.java
@@ -21,6 +21,7 @@ public class HostConstants {
     public static final String FIELD_MEMORY = "memory";
     public static final String FIELD_MILLI_CPU = "milliCpu";
     public static final String FIELD_LOCAL_STORAGE_MB = "localStorageMb";
+    public static final String FIELD_HOST_TEMPLATE_ID = "hostTemplateId";
 
     public static final String PROCESS_REMOVE = "host.remove";
     public static final String PROCESS_CREATE = "host.create";

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/HostDao.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/HostDao.java
@@ -26,7 +26,7 @@ public interface HostDao {
 
     Map<Long, List<Object>> getInstancesPerHost(List<Long> hosts, IdFormatter idFormatter);
 
-    PhysicalHost createMachineForHost(Host host);
+    PhysicalHost createMachineForHost(Host host, String driver);
 
     Map<Long, PhysicalHost> getPhysicalHostsForHosts(List<Long> hosts);
 

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/HostDaoImpl.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/impl/HostDaoImpl.java
@@ -138,7 +138,7 @@ public class HostDaoImpl extends AbstractJooqDao implements HostDao {
     }
 
     @Override
-    public PhysicalHost createMachineForHost(final Host host) {
+    public PhysicalHost createMachineForHost(final Host host, String driver) {
         String uuid = UUID.randomUUID().toString();
         final Map<Object, Object> data = new HashMap<Object, Object>(DataUtils.getFields(host));
         data.put(PHYSICAL_HOST.KIND, MachineConstants.KIND_MACHINE);
@@ -146,6 +146,7 @@ public class HostDaoImpl extends AbstractJooqDao implements HostDao {
         data.put(PHYSICAL_HOST.DESCRIPTION, host.getDescription());
         data.put(PHYSICAL_HOST.ACCOUNT_ID, host.getAccountId());
         data.put(PHYSICAL_HOST.EXTERNAL_ID, uuid);
+        data.put(PHYSICAL_HOST.DRIVER, driver);
 
         PhysicalHost phyHost = DeferredUtils.nest(new Callable<PhysicalHost>() {
             @Override

--- a/code/implementation/docker/machine/src/main/java/io/cattle/platform/docker/machine/api/filter/MachineValidationFilter.java
+++ b/code/implementation/docker/machine/src/main/java/io/cattle/platform/docker/machine/api/filter/MachineValidationFilter.java
@@ -63,7 +63,7 @@ public class MachineValidationFilter extends AbstractDefaultResourceManagerFilte
             }
         }
 
-        if (!alreadyFound) {
+        if (!alreadyFound && data.get(HostConstants.FIELD_HOST_TEMPLATE_ID) == null) {
             throw new ClientVisibleException(ResponseCodes.UNPROCESSABLE_ENTITY, DRIVER_CONFIG_EXACTLY_ONE_REQUIRED);
         }
         return super.create(type, request, next);

--- a/tests/integration/cattletest/core/test_host_template.py
+++ b/tests/integration/cattletest/core/test_host_template.py
@@ -43,30 +43,3 @@ def test_host_template_create(client, service_client):
     client.delete(mds)
     mds = client.wait_success(mds)
     assert mds.removed is not None
-
-
-def _ignore_test_host_from_host_template(docker_client):  # NOQA
-    for i in docker_client.list_host_template():
-        docker_client.delete(i)
-
-    ht = docker_client.create_host_template(
-        publicValues={
-            'digitaloceanConfig': {
-                'region': 'sfo1',
-                'size': '1gb',
-            },
-        },
-        secretValues={
-            'digitaloceanConfig': {
-                'accessToken': 'XXXXX',
-            },
-        },
-    )
-    ht = docker_client.wait_success(ht)
-    assert ht.state == 'active'
-
-    host = docker_client.create_host(hostname='lala',
-                                     digitaloceanConfig={},
-                                     hostTemplateId=ht.id)
-    host = docker_client.wait_success(host)
-    assert host.state == 'active'


### PR DESCRIPTION
When creating a host, if only hostTemplateId is set and no *Config
field is set, don't fail validation. Also, since we set the driver
field based off of the selected config, update that logic to account
for hostTemplate logic.