### PR TITLE
Volume fixes

### DIFF
--- a/code/framework/resource-monitor/src/main/java/io/cattle/platform/object/monitor/impl/ResourceMonitorImpl.java
+++ b/code/framework/resource-monitor/src/main/java/io/cattle/platform/object/monitor/impl/ResourceMonitorImpl.java
@@ -133,7 +133,12 @@ public class ResourceMonitorImpl implements ResourceMonitor, AnnotatedEventListe
 
     @Override
     public <T> T waitForState(T obj, final String desiredState) {
-        return waitFor(obj, new ResourcePredicate<T>() {
+        return waitForState(obj, desiredState, DEFAULT_WAIT.get());
+    }
+
+    @Override
+    public <T> T waitForState(T obj, final String desiredState, long wait) {
+        return waitFor(obj, wait, new ResourcePredicate<T>() {
             @Override
             public boolean evaluate(T obj) {
                 return desiredState.equals(ObjectUtils.getState(obj));

--- a/code/framework/resource-monitor/src/main/java/io/cattle/platform/object/resource/ResourceMonitor.java
+++ b/code/framework/resource-monitor/src/main/java/io/cattle/platform/object/resource/ResourceMonitor.java
@@ -17,4 +17,6 @@ public interface ResourceMonitor {
     <T> T waitForNotTransitioning(T obj);
 
     <T> T waitForNotTransitioning(T obj, long timeout);
+
+    <T> T waitForState(T obj, String desiredState, long wait);
 }

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/inator/unit/VolumeUnit.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/inator/unit/VolumeUnit.java
@@ -32,6 +32,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
+
 public class VolumeUnit implements Unit, BasicStateUnit, InstanceBindable {
 
     VolumeTemplate volumeTemplate;
@@ -96,14 +98,16 @@ public class VolumeUnit implements Unit, BasicStateUnit, InstanceBindable {
 
         name += UUID.randomUUID().toString().substring(0, 5);
 
+        String driver = StringUtils.isBlank(volumeTemplate.getDriver()) ? VolumeConstants.LOCAL_DRIVER : volumeTemplate.getDriver();
         Volume volume = svc.objectManager.create(Volume.class,
                 VOLUME.DEPLOYMENT_UNIT_ID, deploymentUnitId,
                 ObjectMetaDataManager.NAME_FIELD, name,
                 ObjectMetaDataManager.ACCOUNT_FIELD, volumeTemplate.getAccountId(),
                 VOLUME.STACK_ID, stack.getId(),
                 VOLUME.VOLUME_TEMPLATE_ID, volumeTemplate.getId(),
+                VolumeConstants.FIELD_DEVICE_NUM, -1,
                 VolumeConstants.FIELD_VOLUME_DRIVER_OPTS, DataAccessor.fieldMap(volumeTemplate, VolumeConstants.FIELD_VOLUME_DRIVER_OPTS),
-                VolumeConstants.FIELD_VOLUME_DRIVER, volumeTemplate.getDriver());
+                VolumeConstants.FIELD_VOLUME_DRIVER, driver);
         return new VolumeWrapper(volumeTemplate, volume, svc);
     }
 

--- a/tests/integration/cattletest/core/test_docker.py
+++ b/tests/integration/cattletest/core/test_docker.py
@@ -456,6 +456,45 @@ def test_docker_volumes(docker_client, super_client):
 
 
 @if_docker
+def test_stack_volume_delete(docker_client, super_client):
+    stack = docker_client.create_stack(name=random_str())
+    stack = docker_client.wait_success(stack)
+    docker_client.create_volumeTemplate(name="foo", stackId=stack.id)
+
+    # create service
+    launch_config = {"imageUuid": "docker:debian", "dataVolumes": "foo:/bar",
+                     "networkMode": "none",
+                     "labels": {"io.rancher.container.start_once": "true"},
+                     "command": ["mkdir", "/bar/touched"]}
+    svc1 = docker_client.create_service(name=random_str(), stackId=stack.id,
+                                        launchConfig=launch_config, scale=1)
+    svc1 = docker_client.wait_success(svc1)
+    docker_client.wait_success(svc1.activate())
+    c = _validate_compose_instance_stopped(docker_client, svc1, stack, "1")
+    mounts = check_mounts(docker_client, c, 1)
+    vol = mounts[0].volume()
+
+    # remove stack, validate its volume is removed on the host
+    docker_client.wait_success(stack.remove())
+    _check_path(vol, False, docker_client, super_client,
+                ["%s:/test" % vol.name], "/test/touched")
+
+
+def _validate_compose_instance_stopped(client, service, env,
+                                       number, launch_config_name=None):
+    cn = launch_config_name + "-" if launch_config_name is not None else ""
+    name = env.name + "-" + service.name + "-" + cn + number
+
+    def wait_for_map_count(service):
+        instances = client.list_container(name=name, state="stopped")
+        return len(instances) == 1
+
+    wait_for(lambda: wait_for_condition(client, service, wait_for_map_count))
+    instances = client.list_container(name=name, state="stopped")
+    return instances[0]
+
+
+@if_docker
 def test_container_fields(docker_client, super_client):
     caps = ["SYS_MODULE", "SYS_RAWIO", "SYS_PACCT", "SYS_ADMIN",
             "SYS_NICE", "SYS_RESOURCE", "SYS_TIME", "SYS_TTY_CONFIG",
@@ -1118,18 +1157,24 @@ def _wait_for_compose_instance_error(client, service, env):
     return container
 
 
-def _check_path(volume, should_exist, client, super_client):
-    path = _path_to_volume(volume)
+def _check_path(volume, should_exist, client, super_client, extra_vols=None,
+                path_to_check=None):
+    if path_to_check:
+        path = path_to_check
+    else:
+        path = _path_to_volume(volume)
     print 'Checking path [%s] for volume [%s].' % (path, volume)
+    data_vols = ['/var/lib/docker:/host/var/lib/docker', '/tmp:/host/tmp']
+    if extra_vols:
+        data_vols.extend(extra_vols)
+
     c = client. \
         create_container(name="volume_check" + random_str(),
                          imageUuid="docker:ranchertest/volume-test:v0.1.0",
                          networkMode=None,
                          environment={'TEST_PATH': path},
                          command='/opt/tools/check_path_exists.sh',
-                         dataVolumes=[
-                             '/var/lib/docker:/host/var/lib/docker',
-                             '/tmp:/host/tmp'])
+                         dataVolumes=data_vols)
 
     c = super_client.wait_success(c)
     assert c.state == 'running'
@@ -1139,6 +1184,9 @@ def _check_path(volume, should_exist, client, super_client):
 
     code = c.data.dockerInspect.State.ExitCode
 
+    # Note that the test in the container is testing to see if the path is a
+    # directory. Code for the test is here:
+    # https://github.com/rancher/test-images/tree/master/images/volume-test
     if should_exist:
         # The exit code of the container should be a 10 if the path existed
         assert code == 10


### PR DESCRIPTION
Fixes multiple causes of stack volumes not getting delete properly on the hosts

Necessary changes:
- Set driver and device number on stack vols (needed for proper volume deletion in agent)
- Dont fallback to deactivate+remove for stack vols (needed so that volumes are not prematurely deleted)

Downside:
- If a stack is deleted and a volume it owned was mounted to a non-stack container, stack deletion will spin forever. But, our old behavior of just deleting the volume anyway (and then not actually deleting it on the host because it was in use and thus ultimately orphaning it on the host wasn't any better)