### PR TITLE
Propagate instances set for upgrade to metadata. 

### DIFF
--- a/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/MetaDataInfoDaoImpl.java
+++ b/code/iaas/config-item/server/src/main/java/io/cattle/platform/configitem/context/dao/impl/MetaDataInfoDaoImpl.java
@@ -131,7 +131,6 @@ public class MetaDataInfoDaoImpl extends AbstractJooqDao implements MetaDataInfo
                 .and(targetInstance.REMOVED.isNull())
                 .and(SERVICE_EXPOSE_MAP.STATE.isNull().or(
                         SERVICE_EXPOSE_MAP.STATE.notIn(CommonStatesConstants.REMOVING, CommonStatesConstants.REMOVED)))
-                .and(SERVICE_EXPOSE_MAP.UPGRADE.isNull().or(SERVICE_EXPOSE_MAP.UPGRADE.eq(false)))
                 .and(condition)
                 .fetchInto(
                         new RecordHandler<Record21<Long, Long, String, String, Long, String, Long, String, String, String, String, Long, Long, Boolean, String, String, String, String, Long, String, String>>() {


### PR DESCRIPTION
Revert the metadata fix https://github.com/rancher/cattle/pull/1791 to solve the 503 issue with start-before-stop service upgrade

https://github.com/rancher/rancher/issues/8684

The same PR has been tested with 1.6 setup as well, and can be cherry-picked to 1.6 as-is.

@cjellick @ibuildthecloud please review.