### PR TITLE
Make genericObject.resourceData updatable

### DIFF
--- a/resources/content/schema/admin/admin-auth.json
+++ b/resources/content/schema/admin/admin-auth.json
@@ -269,7 +269,7 @@
 
         "projectTemplate.isPublic" : "cru",
         
-        "genericObject" : "crd",
+        "genericObject" : "crud",
 		
         "end" : ""
     }

--- a/resources/content/schema/project/project-auth.json
+++ b/resources/content/schema/project/project-auth.json
@@ -83,7 +83,7 @@
         "balancerServiceTargetConfig" : "cr",
         "networkDriverService" : "crud",
         "storageDriverService" : "crud",
-        "genericObject" : "crd",
+        "genericObject" : "crud",
         "serviceRollback" : "cr",
         "convertToServiceInput": "cr",
         "instanceRevision": "r",

--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -838,7 +838,7 @@
         "genericObject.name" : "cr",
         "genericObject.key" : "cr",
         "genericObject.kind" : "cr",
-        "genericObject.resourceData" : "cr",
+        "genericObject.resourceData" : "cru",
 
         "serviceEvent" : "r",
         "serviceEvent.instanceId" : "r",

--- a/tests/integration/cattletest/core/test_authorization.py
+++ b/tests/integration/cattletest/core/test_authorization.py
@@ -2910,13 +2910,13 @@ def test_pull_task(admin_user_client, user_client, project_client):
 
 
 def test_generic_object(admin_user_client, user_client, project_client):
-    auth_check(admin_user_client.schema, 'genericObject', 'crd', {
+    auth_check(admin_user_client.schema, 'genericObject', 'crud', {
         'name': 'cr',
         'kind': 'cr',
         'key': 'cr',
         'accountId': 'r',
         'data': 'r',
-        'resourceData': 'cr'
+        'resourceData': 'cru'
     })
 
     auth_check(user_client.schema, 'genericObject', 'r', {
@@ -2927,12 +2927,12 @@ def test_generic_object(admin_user_client, user_client, project_client):
         'resourceData': 'r'
     })
 
-    auth_check(project_client.schema, 'genericObject', 'crd', {
+    auth_check(project_client.schema, 'genericObject', 'crud', {
         'name': 'cr',
         'kind': 'cr',
         'key': 'cr',
         'accountId': 'r',
-        'resourceData': 'cr'
+        'resourceData': 'cru'
     })
 
 

--- a/tests/integration/cattletest/core/test_generic_object.py
+++ b/tests/integration/cattletest/core/test_generic_object.py
@@ -22,6 +22,10 @@ def test_generic_object(client):
     assert len(
         client.list_generic_object(kind="webhookReceiver", key=uuid)) == 1
 
+    url += "updated"
+    resource_data["url"] = url
+    updated = client.update(generic_obj, resourceData=resource_data)
+    assert updated.resourceData["url"].endswith("updated")
     client.wait_success(client.delete(generic_obj))
     generic_objs = client.list_generic_object(key=uuid)
     assert len(generic_objs.data) == 0


### PR DESCRIPTION
This will provide greater flexibility for microservices that use
genericObject to store data.

See any obvious downsides to this @ibuildthecloud? Seems limited since the only udpatable field is the relatively newly introduced resourceData