### PR TITLE
Setting for roles allowed to add users

### DIFF
--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/dao/AuthDao.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/dao/AuthDao.java
@@ -63,4 +63,6 @@ public interface AuthDao {
     String getRole(Account account, Policy policy, Policy authenticatedAsPolicy);
 
     Account getAccountByAccessKey(String accessKey);
+
+    boolean canSetProjectMembers(long projectId, Long usingAccount, boolean isAdmin, Set<Identity> identities);
 }

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/projects/ProjectResourceManager.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/projects/ProjectResourceManager.java
@@ -118,11 +118,18 @@ public class ProjectResourceManager extends AbstractObjectResourceManager {
         }
         boolean isOwner = authDao.isProjectOwner(project.getId(), policy.getAccountId(), policy.isOption(Policy.AUTHORIZED_FOR_ALL_ACCOUNTS), policy
                 .getIdentities());
+        boolean setMem = authDao.canSetProjectMembers(project.getId(), policy.getAccountId(), policy.isOption(Policy.AUTHORIZED_FOR_ALL_ACCOUNTS), policy
+                .getIdentities());
+
         if (!accountDao.isActiveAccount(project) && !isOwner) {
             return null;
         }
+
         if (isOwner) {
             ApiContext.getContext().addCapability(project, ProjectConstants.OWNER);
+            ApiContext.getContext().addCapability(project, ProjectConstants.SET_MEMBERS);
+        } else if (setMem) {
+            ApiContext.getContext().addCapability(project, ProjectConstants.SET_MEMBERS);
         } else {
             ApiContext.getContext().setCapabilities(project, new ArrayList<String>());
         }
@@ -151,7 +158,7 @@ public class ProjectResourceManager extends AbstractObjectResourceManager {
             newProject.setKind(AccountConstants.PROJECT_KIND);
             objectManager.persist(newProject);
             List<Map<String, String>> members = (ArrayList<Map<String, String>>) project.get("members");
-            projectMemberResourceManager.setMembers(newProject, members);
+            projectMemberResourceManager.setMembers(newProject, members, true);
             policy.grantObjectAccess(newProject);
             return objectManager.reload(newProject);
         } else {

--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/projects/SetProjectMembersActionHandler.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/projects/SetProjectMembersActionHandler.java
@@ -30,7 +30,7 @@ public class SetProjectMembersActionHandler implements ActionHandler {
         }
         LinkedHashMap<String, Object> reqObj = (LinkedHashMap<String, Object>) request.getRequestObject();
         List<Map<String, String>> members = (List<Map<String, String>>) reqObj.get("members");
-        return projectMemberResourceManager.setMembers(project, members);
+        return projectMemberResourceManager.setMembers(project, members, false);
     }
 
     @Override

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/ProjectConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/ProjectConstants.java
@@ -14,6 +14,7 @@ public class ProjectConstants {
     public static final String NAME = "rancher";
 
     public static final String OWNER = "owner";
+    public static final String SET_MEMBERS = "setMembers";
 
 
     public static final String AUTH_HEADER = "Authorization";

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/iaas-api/defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/iaas-api/defaults.properties
@@ -79,5 +79,6 @@ api.github.scheme=https://
 bootstrap.source=config-content/bootstrap/bootstrap.sh
 
 project.create.default=true
+project.set.member.roles=owner
 
 modify.infrastructure.roles=superadmin,admin,service,owner,member,project,environment,projectadmin,agent

--- a/resources/content/schema/base/project.json
+++ b/resources/content/schema/base/project.json
@@ -4,7 +4,7 @@
       "input": "setProjectMembersInput",
       "output": "setProjectMembersInput",
       "attributes" : {
-        "capability" : "owner"
+        "capability" : "setMembers"
       }
     },
     "deactivate" : {


### PR DESCRIPTION
Add a setting to control which roles are allowed to add members to a
project (as opposed to the current hard-coded "owner").