### PR TITLE
Prevent access to infra stacks

### DIFF
--- a/code/iaas/api-logic/pom.xml
+++ b/code/iaas/api-logic/pom.xml
@@ -72,5 +72,10 @@
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.cattle</groupId>
+            <artifactId>cattle-docker-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/instance/InstanceOutputFilter.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/instance/InstanceOutputFilter.java
@@ -1,5 +1,6 @@
 package io.cattle.platform.iaas.api.filter.instance;
 
+import io.cattle.platform.api.utils.ApiUtils;
 import io.cattle.platform.core.addon.HealthcheckState;
 import io.cattle.platform.core.addon.MountEntry;
 import io.cattle.platform.core.constants.InstanceConstants;
@@ -7,10 +8,15 @@ import io.cattle.platform.core.constants.NetworkConstants;
 import io.cattle.platform.core.dao.ServiceDao;
 import io.cattle.platform.core.dao.VolumeDao;
 import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.util.SystemLabels;
+import io.cattle.platform.docker.constants.DockerInstanceConstants;
 import io.cattle.platform.iaas.api.filter.common.CachedOutputFilter;
+import io.cattle.platform.iaas.api.infrastructure.InfrastructureAccessManager;
+import io.cattle.platform.json.JsonMapper;
 import io.cattle.platform.object.ObjectManager;
 import io.cattle.platform.object.meta.ObjectMetaDataManager;
 import io.cattle.platform.object.util.DataAccessor;
+import io.cattle.platform.object.util.ObjectUtils;
 import io.cattle.platform.util.type.CollectionUtils;
 import io.github.ibuildthecloud.gdapi.context.ApiContext;
 import io.github.ibuildthecloud.gdapi.id.IdFormatter;
@@ -19,6 +25,7 @@ import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 
 import java.net.URL;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -31,6 +38,10 @@ public class InstanceOutputFilter extends CachedOutputFilter<Map<Long, Map<Strin
     ObjectManager objectManager;
     @Inject
     VolumeDao volumeDao;
+    @Inject
+    JsonMapper jsonMapper;
+    @Inject
+    InfrastructureAccessManager infraAccess;
 
     @Override
     public Class<?>[] getTypeClasses() {
@@ -62,16 +73,38 @@ public class InstanceOutputFilter extends CachedOutputFilter<Map<Long, Map<Strin
             converted.getFields().put(InstanceConstants.FIELD_PRIMARY_NETWORK_ID, idF.formatId(NetworkConstants.KIND_NETWORK, networkIds.get(0)));
         }
 
+        Map<String, URL> actions = converted.getActions();
+
+        if (actions == null || actions.isEmpty()) {
+            return converted;
+        }
+
+        boolean infraRestricted = !infraAccess.canModifyInfrastructure(ApiUtils.getPolicy());
+
         Map<String, Object> labels = CollectionUtils.toMap(converted.getFields().get(InstanceConstants.FIELD_LABELS));
         if ("rancher-agent".equals(labels.get("io.rancher.container.system")) &&
                 "rancher-agent".equals(converted.getFields().get(ObjectMetaDataManager.NAME_FIELD))) {
-            Map<String, URL> actions = converted.getActions();
-            if (actions != null) {
-                actions.remove("remove");
-                actions.remove("stop");
-                actions.remove("start");
-                actions.remove("restart");
-            }
+            actions.remove(InstanceConstants.ACTION_REMOVE);
+            actions.remove(InstanceConstants.ACTION_STOP);
+            actions.remove(InstanceConstants.ACTION_START);
+            actions.remove(InstanceConstants.ACTION_RESTART);
+        }
+
+        List<?> capAdd = DataAccessor.fromMap(converted.getFields()).withKey(DockerInstanceConstants.FIELD_CAP_ADD).asList(jsonMapper, String.class);
+        if (infraRestricted && (labels.containsKey(SystemLabels.LABEL_AGENT_CREATE)
+                || DataAccessor.fromMap(converted.getFields()).withKey(InstanceConstants.FIELD_PRIVILEGED).as(Boolean.class)
+                || (capAdd != null && !capAdd.isEmpty()))) {
+            actions.remove(InstanceConstants.ACTION_EXEC);
+            actions.remove(InstanceConstants.ACTION_PROXY);
+        }
+
+        if (infraRestricted && ObjectUtils.isSystem(converted.getFields())) {
+            for(Iterator<Map.Entry<String, URL>> it = actions.entrySet().iterator(); it.hasNext(); ) {
+                Map.Entry<String, URL> entry = it.next();
+                if(!entry.getKey().equals(InstanceConstants.ACTION_LOGS)) {
+                  it.remove();
+                }
+              }
         }
 
         return converted;

--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/instance/InstanceValidationFilter.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/instance/InstanceValidationFilter.java
@@ -1,9 +1,12 @@
 package io.cattle.platform.iaas.api.filter.instance;
 
+import io.cattle.platform.api.utils.ApiUtils;
 import io.cattle.platform.core.constants.InstanceConstants;
 import io.cattle.platform.core.model.Instance;
 import io.cattle.platform.iaas.api.filter.common.AbstractDefaultResourceManagerFilter;
+import io.cattle.platform.iaas.api.infrastructure.InfrastructureAccessManager;
 import io.cattle.platform.object.ObjectManager;
+import io.cattle.platform.object.util.ObjectUtils;
 import io.github.ibuildthecloud.gdapi.exception.ClientVisibleException;
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 import io.github.ibuildthecloud.gdapi.request.resource.ResourceManager;
@@ -12,10 +15,12 @@ import io.github.ibuildthecloud.gdapi.validation.ValidationErrorCodes;
 
 import javax.inject.Inject;
 
-public class InstanceAgentValidationFilter extends AbstractDefaultResourceManagerFilter {
+public class InstanceValidationFilter extends AbstractDefaultResourceManagerFilter {
 
     @Inject
     ObjectManager objectManager;
+    @Inject
+    InfrastructureAccessManager infraAccess;
 
     @Override
     public String[] getTypes() {
@@ -28,6 +33,18 @@ public class InstanceAgentValidationFilter extends AbstractDefaultResourceManage
     }
 
     @Override
+    public Object update(String type, String id, ApiRequest request, ResourceManager next) {
+        Object instance = objectManager.loadResource(type, id);
+        if (instance == null || !(instance instanceof Instance)) {
+            return super.update(type, id, request, next);
+        }
+
+        validateInfraAccess(instance, "update");
+
+        return super.update(type, id, request, next);
+    }
+
+    @Override
     public Object delete(String type, String id, ApiRequest request, ResourceManager next) {
         Object instance = objectManager.loadResource(type, id);
         if (instance == null || !(instance instanceof Instance)) {
@@ -36,10 +53,19 @@ public class InstanceAgentValidationFilter extends AbstractDefaultResourceManage
 
         if (InstanceConstants.isRancherAgent((Instance)instance)) {
             throw new ClientVisibleException(ResponseCodes.UNPROCESSABLE_ENTITY, ValidationErrorCodes.ACTION_NOT_AVAILABLE,
-                    "Can not delete rancher-agent", null);
+                    "Cannot delete rancher-agent", null);
         }
 
+        validateInfraAccess(instance, "delete");
+
         return super.delete(type, id, request, next);
+    }
+
+    private void validateInfraAccess(Object instance, String action) {
+        if (ObjectUtils.isSystem(instance) && !infraAccess.canModifyInfrastructure(ApiUtils.getPolicy())) {
+            String message = String.format("Cannot %s system container", action);
+            throw new ClientVisibleException(ResponseCodes.FORBIDDEN, "Forbidden", message, null);
+        }
     }
 
 }

--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/infrastructure/InfrastructureAccessManager.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/infrastructure/InfrastructureAccessManager.java
@@ -1,0 +1,7 @@
+package io.cattle.platform.iaas.api.infrastructure;
+
+import io.cattle.platform.api.auth.Policy;
+
+public interface InfrastructureAccessManager {
+    public boolean canModifyInfrastructure(Policy policy);
+}

--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/infrastructure/InfrastructureAccessManagerImpl.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/infrastructure/InfrastructureAccessManagerImpl.java
@@ -1,0 +1,41 @@
+package io.cattle.platform.iaas.api.infrastructure;
+
+import io.cattle.platform.api.auth.Policy;
+import io.cattle.platform.archaius.util.ArchaiusUtil;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.netflix.config.DynamicStringProperty;
+
+public class InfrastructureAccessManagerImpl implements InfrastructureAccessManager {
+
+    private static final DynamicStringProperty MODIFY_INFRA_ROLES = ArchaiusUtil.getString("modify.infrastructure.roles");
+
+    private Set<String> modifyInfraRoles = new HashSet<>();
+
+    public InfrastructureAccessManagerImpl() {
+        super();
+
+        String prop = MODIFY_INFRA_ROLES.get();
+        Set<String> roles = new HashSet<>(Arrays.asList(prop.split(",")));
+        modifyInfraRoles = roles;
+
+        MODIFY_INFRA_ROLES.addCallback(new Runnable() {
+            @Override
+            public void run() {
+                String prop = MODIFY_INFRA_ROLES.get();
+                Set<String> roles = new HashSet<>(Arrays.asList(prop.split(",")));
+                modifyInfraRoles = roles;
+            }
+        });
+    }
+
+    @Override
+    public boolean canModifyInfrastructure(Policy policy) {
+        // Return true if modifyInfraRoles contains any of the roles in
+        // policy.getRoles
+        return modifyInfraRoles.stream().anyMatch(policy.getRoles()::contains);
+    }
+}

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/InstanceConstants.java
@@ -19,6 +19,14 @@ public class InstanceConstants {
     public static final String TYPE = "instance";
     public static final String TYPE_CONTAINER = "container";
 
+    public static final String ACTION_START = "start";
+    public static final String ACTION_STOP = "stop";
+    public static final String ACTION_RESTART = "restart";
+    public static final String ACTION_REMOVE = "remove";
+    public static final String ACTION_EXEC = "execute";
+    public static final String ACTION_LOGS = "logs";
+    public static final String ACTION_PROXY = "proxy";
+
     public static final String FIELD_AGENT_INSTANCE = "agentInstance";
     public static final String FIELD_COUNT = "count";
     public static final String FIELD_CREDENTIAL_IDS = "credentialIds";

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/StackValidationFilter.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/filter/StackValidationFilter.java
@@ -1,13 +1,18 @@
 package io.cattle.platform.servicediscovery.api.filter;
 
+import io.cattle.platform.api.utils.ApiUtils;
 import io.cattle.platform.core.model.Stack;
 import io.cattle.platform.iaas.api.filter.common.AbstractDefaultResourceManagerFilter;
+import io.cattle.platform.iaas.api.infrastructure.InfrastructureAccessManager;
+import io.cattle.platform.object.ObjectManager;
 import io.cattle.platform.object.meta.ObjectMetaDataManager;
 import io.github.ibuildthecloud.gdapi.condition.Condition;
 import io.github.ibuildthecloud.gdapi.condition.ConditionType;
+import io.github.ibuildthecloud.gdapi.exception.ClientVisibleException;
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 import io.github.ibuildthecloud.gdapi.request.resource.ResourceManager;
 import io.github.ibuildthecloud.gdapi.request.resource.ResourceManagerLocator;
+import io.github.ibuildthecloud.gdapi.util.ResponseCodes;
 import io.github.ibuildthecloud.gdapi.validation.ValidationErrorCodes;
 
 import java.util.HashMap;
@@ -18,10 +23,14 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 @Named
-public class StackCreateValidationFilter extends AbstractDefaultResourceManagerFilter {
+public class StackValidationFilter extends AbstractDefaultResourceManagerFilter {
 
     @Inject
     ResourceManagerLocator locator;
+    @Inject
+    ObjectManager objMgr;
+    @Inject
+    InfrastructureAccessManager infraAccess;
 
     @Override
     public Class<?>[] getTypeClasses() {
@@ -44,9 +53,32 @@ public class StackCreateValidationFilter extends AbstractDefaultResourceManagerF
         criteria.put(ObjectMetaDataManager.REMOVED_FIELD, new Condition(ConditionType.NULL));
         List<?> existingEnv = rm.list(type, criteria, null);
         if (!existingEnv.isEmpty()) {
-            ValidationErrorCodes.throwValidationError(ValidationErrorCodes.NOT_UNIQUE,
-                    "name");
+            ValidationErrorCodes.throwValidationError(ValidationErrorCodes.NOT_UNIQUE, "name");
         }
         return super.create(type, request, next);
+    }
+
+    @Override
+    public Object update(String type, String id, ApiRequest request, ResourceManager next) {
+        Stack stack = objMgr.loadResource(Stack.class, id);
+        validateInfraAccess(request, stack, "update");
+
+        return super.update(type, id, request, next);
+    }
+
+    @Override
+    public Object delete(String type, String id, ApiRequest request, ResourceManager next) {
+        Stack stack = objMgr.loadResource(Stack.class, id);
+
+        validateInfraAccess(request, stack, "delete");
+
+        return super.delete(type, id, request, next);
+    }
+
+    private void validateInfraAccess(ApiRequest request, Stack stack, String action) {
+        if (stack.getSystem() && !infraAccess.canModifyInfrastructure(ApiUtils.getPolicy())) {
+            String message = String.format("Cannot %s system stack", action);
+            throw new ClientVisibleException(ResponseCodes.FORBIDDEN, "Forbidden", message, null);
+        }
     }
 }

--- a/code/packaging/app-config/src/main/java/io/cattle/platform/app/IaasApiConfig.java
+++ b/code/packaging/app-config/src/main/java/io/cattle/platform/app/IaasApiConfig.java
@@ -8,8 +8,8 @@ import io.cattle.platform.core.util.SettingsUtils;
 import io.cattle.platform.docker.api.transform.TransformInspect;
 import io.cattle.platform.docker.machine.api.MachineLinkFilter;
 import io.cattle.platform.docker.machine.api.addon.BaseMachineConfig;
-import io.cattle.platform.docker.machine.api.filter.MachineValidationFilter;
 import io.cattle.platform.docker.machine.api.filter.MachineOutputFilter;
+import io.cattle.platform.docker.machine.api.filter.MachineValidationFilter;
 import io.cattle.platform.docker.machine.launch.SecretsApiLauncher;
 import io.cattle.platform.docker.machine.launch.WebsocketProxyLauncher;
 import io.cattle.platform.extension.impl.EMUtils;
@@ -74,25 +74,27 @@ import io.cattle.platform.iaas.api.filter.containerevent.ContainerEventFilter;
 import io.cattle.platform.iaas.api.filter.dynamic.schema.DynamicSchemaFilter;
 import io.cattle.platform.iaas.api.filter.externalevent.ExternalEventFilter;
 import io.cattle.platform.iaas.api.filter.hosts.HostsFilter;
-import io.cattle.platform.iaas.api.filter.instance.InstanceAgentValidationFilter;
 import io.cattle.platform.iaas.api.filter.instance.InstanceImageValidationFilter;
 import io.cattle.platform.iaas.api.filter.instance.InstanceOutputFilter;
 import io.cattle.platform.iaas.api.filter.instance.InstancePortsValidationFilter;
+import io.cattle.platform.iaas.api.filter.instance.InstanceValidationFilter;
 import io.cattle.platform.iaas.api.filter.instance.InstanceVolumeCleanupStrategyValidationFilter;
 import io.cattle.platform.iaas.api.filter.machinedriver.MachineDriverFilter;
 import io.cattle.platform.iaas.api.filter.registry.RegistryServerAddressFilter;
 import io.cattle.platform.iaas.api.filter.secret.SecretValidationFilter;
-import io.cattle.platform.iaas.api.filter.service.ServiceMappingsOutputFilter;
+import io.cattle.platform.iaas.api.filter.service.ServiceOutputFilter;
 import io.cattle.platform.iaas.api.filter.serviceevent.ServiceEventFilter;
 import io.cattle.platform.iaas.api.filter.snapshot.SnapshotValidationFilter;
 import io.cattle.platform.iaas.api.filter.ssl.CertificateCreateValidationFilter;
 import io.cattle.platform.iaas.api.filter.stack.StackOutputFilter;
 import io.cattle.platform.iaas.api.filter.storagepool.StoragePoolOutputFilter;
 import io.cattle.platform.iaas.api.filter.volume.VolumeOutputFilter;
+import io.cattle.platform.iaas.api.infrastructure.InfrastructureAccessManager;
+import io.cattle.platform.iaas.api.infrastructure.InfrastructureAccessManagerImpl;
 import io.cattle.platform.iaas.api.manager.DataManager;
 import io.cattle.platform.iaas.api.manager.HaConfigManager;
-import io.cattle.platform.iaas.api.manager.InstanceManager;
 import io.cattle.platform.iaas.api.manager.HostTemplateManager;
+import io.cattle.platform.iaas.api.manager.InstanceManager;
 import io.cattle.platform.iaas.api.manager.ProcessPoolManager;
 import io.cattle.platform.iaas.api.manager.ProcessSummaryManager;
 import io.cattle.platform.iaas.api.manager.SecretManager;
@@ -325,8 +327,8 @@ public class IaasApiConfig {
     }
 
     @Bean
-    InstanceAgentValidationFilter InstanceAgentValidationFilter() {
-        return new InstanceAgentValidationFilter();
+    InstanceValidationFilter InstanceAgentValidationFilter() {
+        return new InstanceValidationFilter();
     }
 
     @Bean
@@ -455,8 +457,8 @@ public class IaasApiConfig {
     }
 
     @Bean
-    ServiceMappingsOutputFilter ServiceMappingsOutputFilter() {
-        return new ServiceMappingsOutputFilter();
+    ServiceOutputFilter ServiceMappingsOutputFilter() {
+        return new ServiceOutputFilter();
     }
 
     @Bean
@@ -942,6 +944,11 @@ public class IaasApiConfig {
     @Bean
     VolumeCreateValidationFilter VolumeCreateValidationFilter() {
         return new VolumeCreateValidationFilter();
+    }
+
+    @Bean
+    InfrastructureAccessManager InfrastructureAccessManager() {
+        return new InfrastructureAccessManagerImpl();
     }
 
 }

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/iaas-api/defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/iaas-api/defaults.properties
@@ -81,3 +81,5 @@ api.github.scheme=https://
 bootstrap.source=config-content/bootstrap/bootstrap.sh
 
 project.create.default=true
+
+modify.infrastructure.roles=superadmin,admin,service,owner,member,project,environment,projectadmin,agent

--- a/tests/integration/cattletest/core/test_restricted_auth.py
+++ b/tests/integration/cattletest/core/test_restricted_auth.py
@@ -1,0 +1,177 @@
+from common_fixtures import *  # NOQA
+import copy
+
+from cattle import ApiError
+from test_svc_discovery import _validate_compose_instance_start
+
+
+def test_restricted_from_system(new_context, admin_user_client):
+    restricted = create_restricted_user(new_context, admin_user_client)
+
+    # Restricted can't create system stack. system property not settable
+    rstack = restricted.create_stack(name=random_str(), system=True)
+    rstack = restricted.wait_success(rstack)
+    assert rstack.system is False
+
+    # Owner can create system stack
+    owner = new_context.owner_client
+    stack = owner.wait_success(owner.create_stack(name="test", system=True))
+    assert stack.state == "active"
+    assert stack.system is True
+
+    # Restricted cant update system stack
+    rstack = restricted.by_id_stack(stack.id)
+    assert rstack.name == "test"
+    with pytest.raises(ApiError) as e:
+        restricted.update(rstack, name="updated")
+    assert e.value.error.status == 403
+
+    # Restricted user should see no actions on system stack
+    assert len(rstack.actions) == 0
+    assert len(stack.actions) > 0
+
+    # Owner can update stack
+    stack = owner.update(stack, name="updated")
+
+    # Restricted can't create service in system stack
+    lc = {"imageUuid": new_context.image_uuid}
+    with pytest.raises(ApiError) as e:
+        restricted.create_service(name=random_str(), stackId=stack.id,
+                                  launchConfig=lc)
+    assert e.value.error.status == 403
+
+    # Owner can create service in system stack
+    svc = owner.create_service(name=random_str(), stackId=stack.id,
+                               launchConfig=lc, scale=1)
+    svc = owner.wait_success(svc)
+
+    # Owner can activate
+    svc = owner.wait_success(svc.activate())
+
+    c = _validate_compose_instance_start(owner, svc, stack, "1")
+
+    # Owner can update system service
+    svc = owner.update(svc, name="update")
+    svc = owner.wait_success(svc)
+
+    # Restricted can't update system service
+    rsvc = restricted.by_id_service(svc.id)
+    with pytest.raises(ApiError) as e:
+        restricted.update(rsvc, name="update")
+    assert e.value.error.status == 403
+
+    # Restricted user should see no actions on system service
+    assert len(rsvc.actions) == 0
+    assert len(svc.actions) > 0
+
+    # Restricted can't delete system service
+    with pytest.raises(ApiError) as e:
+        restricted.delete(rsvc)
+    assert e.value.error.status == 403
+
+    # Restricted can't update system container
+    rc = restricted.by_id_container(c.id)
+    with pytest.raises(ApiError) as e:
+        restricted.update(rc, name="update")
+    assert e.value.error.status == 403
+
+    # Owner can update system container
+    c = owner.update(c, name="update")
+
+    # Restricted can only see the logs actions of system containers
+    assert len(rc.actions) == 1 and rc.actions["logs"]
+    assert len(c.actions) > 1
+
+    # Restricted can't delete system container
+    rc = restricted.by_id_container(c.id)
+    with pytest.raises(ApiError) as e:
+        restricted.delete(rc)
+    assert e.value.error.status == 403
+
+    # Owner can delete system container
+    owner.delete(c)
+
+    # Owner can delete system service
+    owner.delete(svc)
+
+    # Restricted can't delete system stack
+    with pytest.raises(ApiError) as e:
+        restricted.delete(rstack)
+    assert e.value.error.status == 403
+
+    # Owner can delete system stack
+    owner.delete(stack)
+
+    # Restricted user can do all the above things for non-system resources
+    stack = restricted.wait_success(restricted.create_stack(name="restricted"))
+    assert stack.state == "active"
+    assert stack.system is False
+    stack = restricted.update(stack, name="r-updated")
+    assert len(stack.actions) > 0
+    svc = restricted.create_service(name=random_str(), stackId=stack.id,
+                                    launchConfig=lc)
+    svc = restricted.wait_success(svc)
+    svc = restricted.wait_success(svc.activate())
+    assert len(svc.actions) > 0
+    c = _validate_compose_instance_start(restricted, svc, stack, "1")
+    c = restricted.update(c, name="r-updated")
+    assert len(c.actions) > 1
+    svc = restricted.update(svc, name="r-updated")
+    restricted.delete(c)
+    restricted.delete(svc)
+    restricted.delete(stack)
+
+
+def test_restricted_agent_containers(new_context, admin_user_client):
+    restricted = create_restricted_user(new_context, admin_user_client)
+    client = new_context.client
+    c = new_context.create_container(labels={
+        'io.rancher.container.create_agent': 'true'
+    })
+    c = client.wait_success(c)
+    assert c.actions["execute"]
+    assert c.actions["proxy"]
+
+    rc = restricted.by_id_container(c.id)
+    assert "execute" not in rc.actions
+    assert "proxy" not in rc.actions
+
+
+def test_restricted_privileged_cap_add(new_context, admin_user_client):
+    restricted = create_restricted_user(new_context, admin_user_client)
+    client = new_context.client
+    c = new_context.create_container(privileged=True)
+    c = client.wait_success(c)
+    assert c.actions["execute"]
+    assert c.actions["proxy"]
+    rc = restricted.by_id_container(c.id)
+    assert "execute" not in rc.actions
+    assert "proxy" not in rc.actions
+
+    c = new_context.create_container(capAdd=["ALL"])
+    c = client.wait_success(c)
+    assert c.actions["execute"]
+    assert c.actions["proxy"]
+    rc = restricted.by_id_container(c.id)
+    assert "execute" not in rc.actions
+    assert "proxy" not in rc.actions
+
+
+def create_restricted_user(context, admin_user_client):
+    context2 = create_context(admin_user_client)
+    restricted = context2.user_client
+    members = get_plain_members(context.project.projectMembers())
+    members.append({
+        'role': 'restricted',
+        'externalId': acc_id(restricted),
+        'externalIdType': 'rancher_id'
+    })
+    project = context.user_client.reload(context.project)
+    project.setmembers(members=members)
+
+    restricted = context2.user_client
+    new_headers = copy.deepcopy(restricted._headers)
+    new_headers['X-API-Project-Id'] = project.id
+    restricted._headers = new_headers
+    restricted.reload_schema()
+    return restricted


### PR DESCRIPTION
Add a setting that controls roles taht can access infrastructure
stacks, services, or containers. This means they cannot create,
update, upgrade, exec into, or delete them.

This includes containers with the
io.rancher.container.create_agent containers (such as LB containers).