### PR TITLE
Use event for instance data cache invalidation

### DIFF
--- a/code/iaas/events/src/main/java/io/cattle/platform/iaas/event/IaasEvents.java
+++ b/code/iaas/events/src/main/java/io/cattle/platform/iaas/event/IaasEvents.java
@@ -14,6 +14,7 @@ public class IaasEvents {
     public static final String RESOURCE_CHANGE = "resource.change";
     public static final String STACK_UPDATE = "stack.update";
     public static final String CLEAR_CACHE = "clear.cache";
+    public static final String INVALIDATE_INSTANCE_DATA_CACHE = "invalidate.instance.data.cache";
     public static final String HOST_ENDPOINTS_UPDATE = "host.endpoints.update";
 
     public static final String ACCOUNT_QUALIFIER = "account";

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/dao/InstanceDao.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/dao/InstanceDao.java
@@ -9,6 +9,7 @@ import io.cattle.platform.core.model.InstanceHostMap;
 import io.cattle.platform.core.model.InstanceLink;
 import io.cattle.platform.core.model.Nic;
 import io.cattle.platform.core.model.Service;
+import io.cattle.platform.eventing.model.Event;
 
 import java.util.List;
 import java.util.Map;
@@ -47,7 +48,7 @@ public interface InstanceDao {
 
     Map<String, Object> getCacheInstanceData(long instanceId);
 
-    void clearCacheInstanceData(long instanceId);
+    void clearCacheInstanceData(Event event);
 
     List<IpAddressToServiceIndex> getIpToIndex(Service service);
 


### PR DESCRIPTION
This change adresses a bug where in an HA setup, when a load balancer
was updated to have a new port rule, the newly published port may not
show up in metadata and thus not get programmed properly by networking.
The bug was caused by not invalidating the instance data cache on all
nodes and thus potentially serving up stale data to the metadata
service.

Addresses https://github.com/rancher/rancher/issues/9172