### PR TITLE
Insert an install.uuid in setting table during Cattle startup.

### DIFF
--- a/code/implementation/sample-setup/src/main/java/io/cattle/platform/sample/data/SampleDataStartupV16.java
+++ b/code/implementation/sample-setup/src/main/java/io/cattle/platform/sample/data/SampleDataStartupV16.java
@@ -1,0 +1,42 @@
+package io.cattle.platform.sample.data;
+
+import static io.cattle.platform.core.model.tables.SettingTable.*;
+import io.cattle.platform.archaius.util.ArchaiusUtil;
+import io.cattle.platform.core.model.Account;
+import io.cattle.platform.core.model.Setting;
+import io.cattle.platform.object.ObjectManager;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+
+public class SampleDataStartupV16 extends AbstractSampleData {
+
+    private static final String INSTALL_UUID = "install.uuid";
+
+    @Inject
+    ObjectManager objectManager;
+
+    @Override
+    protected String getName() {
+        return "sampleDataVersion16";
+    }
+
+    @Override
+    protected void populatedData(Account system, List<Object> toCreate) {
+          updateSetting();
+    }
+
+    protected void updateSetting() {
+        Setting setting = objectManager.findAny(Setting.class,
+                SETTING.NAME, INSTALL_UUID);
+        if (setting == null) {
+            Setting installUUIDSetting = objectManager.newRecord(Setting.class);
+            installUUIDSetting.setName(INSTALL_UUID);
+            installUUIDSetting.setValue(java.util.UUID.randomUUID().toString());
+            installUUIDSetting = objectManager.create(installUUIDSetting);
+            ArchaiusUtil.refresh();
+        }
+    }
+}

--- a/code/packaging/app-config/src/main/java/io/cattle/platform/app/SystemServicesConfig.java
+++ b/code/packaging/app-config/src/main/java/io/cattle/platform/app/SystemServicesConfig.java
@@ -103,6 +103,7 @@ import io.cattle.platform.sample.data.SampleDataStartupV12;
 import io.cattle.platform.sample.data.SampleDataStartupV13;
 import io.cattle.platform.sample.data.SampleDataStartupV14;
 import io.cattle.platform.sample.data.SampleDataStartupV15;
+import io.cattle.platform.sample.data.SampleDataStartupV16;
 import io.cattle.platform.sample.data.SampleDataStartupV3;
 import io.cattle.platform.sample.data.SampleDataStartupV5;
 import io.cattle.platform.sample.data.SampleDataStartupV6;
@@ -655,6 +656,11 @@ public class SystemServicesConfig {
     @Bean
     SampleDataStartupV15 SampleDataStartupV15() {
         return new SampleDataStartupV15();
+    }
+
+    @Bean
+    SampleDataStartupV16 SampleDataStartupV16() {
+        return new SampleDataStartupV16();
     }
 
     @Bean

--- a/tests/integration/cattletest/core/test_settings.py
+++ b/tests/integration/cattletest/core/test_settings.py
@@ -126,3 +126,10 @@ def test_settings_admin_user_list(admin_user_client):
     assert len(settings) != 0
     assert len(settings) < 16
     assert 'rancher.compose.linux.url' in names
+
+
+def test_settings_list_install_uuid(admin_user_client):
+    id = 'install.uuid'
+    s = admin_user_client.by_id_setting(id)
+    assert s is not None
+    assert s.value is not None


### PR DESCRIPTION
Code to insert an install.uuid in setting table during Cattle startup.
Also added a test to verify that the setting exists.

The uuid can be read via API /v2-beta/settings/install.uuid

@cjellick please review/merge.