### PR TITLE
Add file_hash column to catalog_file table

### DIFF
--- a/resources/content/db/changelog.xml
+++ b/resources/content/db/changelog.xml
@@ -129,4 +129,5 @@
     <include file="db/core-122-1.xml"/>
     <include file="db/core-200.xml"/>
     <include file="db/core-201.xml"/>
+    <include file="db/core-202.xml"/>
 </databaseChangeLog>

--- a/resources/content/db/core-202.xml
+++ b/resources/content/db/core-202.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet author="rancher (generated)" id="dump2">
+	    <addColumn tableName="catalog_file">
+            <column name="file_hash" type="VARCHAR(128)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
This addresses part of https://github.com/rancher/rancher/issues/8716

This PR will create a column in which to store md5 hashes of each file. 