### PR TITLE
Use 'stable' release of UI

### DIFF
--- a/resources/content/cattle-global.properties
+++ b/resources/content/cattle-global.properties
@@ -2,7 +2,7 @@
 # Versions         #
 ####################
 
-api.ui.index=//releases.rancher.com/ui/latest
+api.ui.index=//releases.rancher.com/ui/stable
 api.ui.js.url=https://releases.rancher.com/api-ui/1.0.4/ui.min.js
 api.ui.css.url=https://releases.rancher.com/api-ui/1.0.4/ui.min.css
 lb.instance.image=rancher/lb-service-haproxy:v0.7.5


### PR DESCRIPTION
On master, we should be using 'latest', but on the v1.6 branch, we
should be using 'stable', which points at the latest available v1.6 UI
release.