### PR TITLE
Ability to change Auth service logging level

### DIFF
--- a/code/implementation/docker/machine/src/main/java/io/cattle/platform/docker/machine/launch/AuthServiceLauncher.java
+++ b/code/implementation/docker/machine/src/main/java/io/cattle/platform/docker/machine/launch/AuthServiceLauncher.java
@@ -51,6 +51,7 @@ public class AuthServiceLauncher extends GenericServiceLauncher implements Initi
     public static final DynamicStringProperty SECURITY_SETTING = ArchaiusUtil.getString("api.security.enabled");
     public static final DynamicStringProperty EXTERNAL_AUTH_PROVIDER_SETTING = ArchaiusUtil.getString("api.auth.external.provider.configured");
     public static final DynamicStringProperty NO_IDENTITY_LOOKUP_SETTING = ArchaiusUtil.getString("api.auth.external.provider.no.identity.lookup");
+    private static final DynamicStringProperty AUTH_SERVICE_LOG_LEVEL = ArchaiusUtil.getString("auth.service.log.level");
 
     @Override
     protected boolean shouldRun() {
@@ -126,6 +127,7 @@ public class AuthServiceLauncher extends GenericServiceLauncher implements Initi
         list.add(NO_IDENTITY_LOOKUP_SETTING);
         list.add(ServiceAuthConstants.USER_TYPE);
         list.add(ServiceAuthConstants.IDENTITY_SEPARATOR);
+        list.add(AUTH_SERVICE_LOG_LEVEL);
 
         //read Db settings name starting with "api.auth" to add additional provider specific settings
         List<Setting> settings = objectManager.find(Setting.class,

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/process/defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/process/defaults.properties
@@ -116,6 +116,7 @@ registry.whitelist=
 
 auth.service.executable=rancher-auth-service
 auth.service.execute=false
+auth.service.log.level=INFO
 
 api.auth.local.validate.url=
 api.auth.local.validate.description=


### PR DESCRIPTION
This introduces a method to change the logging level of rancher-auth-service during run time.

The log level can be changed via setting 'auth.service.log.level' by accessing it on /v2-beta/settings/auth.service.log.level

This will reload the auth-service and set the new log level to be used.
This also needs the rancher-auth-service PR https://github.com/rancher/rancher-auth-service/pull/21


https://github.com/rancher/rancher/issues/9390