### PR TITLE
Removing the check to see if token_type saved in a auth_token matches current auth provider's token_type

### DIFF
--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/AbstractTokenUtil.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/AbstractTokenUtil.java
@@ -128,10 +128,6 @@ public abstract class AbstractTokenUtil implements TokenUtil {
             throw new ClientVisibleException(ResponseCodes.BAD_REQUEST, ACCESS_TOKEN_INVALID,
                     "Json Web Token invalid.", null);
         }
-        String tokenTypeActual = (String) jsonData.get(TOKEN);
-        if (!StringUtils.equals(tokenType, tokenTypeActual)) {
-            return null;
-        }
         if (!isAllowed(jsonData)) {
             throw new ClientVisibleException(ResponseCodes.UNAUTHORIZED);
         }


### PR DESCRIPTION
 With porting of auth_providers to external auth service this check breaks the auth_token check for upgraded setups, also it is not really necessary to do this check.

https://github.com/rancher/rancher/issues/9472