### PR TITLE
export mode with number

### DIFF
--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/service/impl/ServiceDiscoveryApiServiceImpl.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/service/impl/ServiceDiscoveryApiServiceImpl.java
@@ -408,9 +408,9 @@ public class ServiceDiscoveryApiServiceImpl implements ServiceDiscoveryApiServic
                         } else {
                             String uid = secretOpts.get(UID).toString();
                             String gid = secretOpts.get(GID).toString();
-                            String mode = secretOpts.get(MODE).toString();
+                            Integer mode = Integer.parseInt(secretOpts.get(MODE).toString());
                             String filename = secretOpts.get(NAME).toString();
-                            Map<String, String> secretMap = new HashMap<>();
+                            Map<String, Object> secretMap = new HashMap<>();
                             secretMap.put(SOURCE, secretName);
                             secretMap.put(TARGET, filename);
                             secretMap.put(UID, uid);

--- a/tests/integration/cattletest/core/test_secrets.py
+++ b/tests/integration/cattletest/core/test_secrets.py
@@ -232,7 +232,7 @@ def test_service_secrets_fields(context, secret_context):
     assert svc['secrets'][0] == secret1.name
     assert svc['secrets'][1]['uid'] == '0'
     assert svc['secrets'][1]['gid'] == '0'
-    assert svc['secrets'][1]['mode'] == '444'
+    assert svc['secrets'][1]['mode'] == 444
     assert svc['secrets'][1]['source'] == secret2.name
     assert svc['secrets'][1]['target'] == 'my_secret2'
 


### PR DESCRIPTION
Converting mode as number. Rancher-compose executor can't parse mode as string. https://github.com/rancher/rancher/issues/9501