### PR TITLE
fix NPE in getIdentity

### DIFF
--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/external/ExternalServiceAuthProvider.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/external/ExternalServiceAuthProvider.java
@@ -295,6 +295,9 @@ public class ExternalServiceAuthProvider {
                 }
             });
 
+            if (jsonData == null) {
+                return null;
+            }
             return tokenUtil.jsonToIdentity(jsonData);
 
         } catch(HttpHostConnectException ex) {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/9456

Caused by regression added with pr for handleResponse https://github.com/rancher/cattle/pull/2854
The original code was retuning null if jsonData was null. The new changes also returned null but only from handleResponse and not from the getIdentity function