### PR TITLE
Don't add rancher internal search domains when rancher container dns priority is None

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/util/SystemLabels.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/util/SystemLabels.java
@@ -5,6 +5,7 @@ public class SystemLabels {
     public static final String LABEL_AGENT_ROLE = "io.rancher.container.agent.role";
     public static final String LABEL_CATTLE_URL = "io.rancher.container.cattle_url";
     public static final String LABEL_USE_RANCHER_DNS = "io.rancher.container.dns";
+    public static final String LABEL_RANCHER_CONTAINER_DNS_PRIORITY = "io.rancher.container.dns.priority";
     public static final String LABEL_REQUESTED_IP = "io.rancher.container.requested_ip";
     public static final String LABEL_AGENT_URI_PREFIX = "io.rancher.container.agent.uri.prefix";
     public static final String LABEL_VOLUME_CLEANUP_STRATEGY = "io.rancher.container.volume_cleanup_strategy";

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/DefaultDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/DefaultDeploymentUnitInstance.java
@@ -353,6 +353,16 @@ public class DefaultDeploymentUnitInstance extends DeploymentUnitInstance implem
 
     @Override
     public List<String> getSearchDomains() {
+        Object serviceLabels = ServiceDiscoveryUtil.getLaunchConfigObject(service, launchConfigName,
+                InstanceConstants.FIELD_LABELS);
+        if (serviceLabels != null) {
+            String setSearchDomain = ((Map<String, String>) serviceLabels)
+                    .get(SystemLabels.LABEL_RANCHER_CONTAINER_DNS_PRIORITY);
+            if (setSearchDomain != null && !setSearchDomain.isEmpty() && StringUtils.equalsIgnoreCase(setSearchDomain.trim(), "None")) {
+                return Arrays.asList();
+            }
+        }
+
         String stackNamespace = ServiceDiscoveryDnsUtil.getStackNamespace(this.stack, this.service);
         String serviceNamespace = ServiceDiscoveryDnsUtil
                 .getServiceNamespace(this.stack, this.service);


### PR DESCRIPTION
Adding a new system label, "io.rancher.container.dns.priority" and skip adding the internal search domains when its value is None. This along with [plugin-manager fix](https://github.com/rancher/plugin-manager/pull/86) solves [rancher/rancher#9303](https://github.com/rancher/rancher/issues/9303). 

To test, 
1) start any regular user service by creating the service with label "io.rancher.container.dns.priority" : "None". Check its /etc/resolv.conf to confirm it doesn't have any rancher specific domains. 

2) In kubernetes, 
a) use the [k8s catalog template](https://github.com/rancher/rancher-catalog/pull/858) which starts kubelet with this label set. 
b) login to kubelet and see no rancher specific domains are set. 
c) create a simple replication controller, and see that the POD's /etc/resolv.conf doesn't have any rancher specific search domains set. 
d) verify that the skydns resolution still works fine. 