### PR TITLE
Fix missing ipAddress for ports when LB update & release port resource when remove

### DIFF
--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/AllocatorDao.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/AllocatorDao.java
@@ -62,4 +62,6 @@ public interface AllocatorDao {
     String getAllocatedHostUuid(Volume volume);
 
     Iterator<AllocationCandidate> iteratorHosts(List<String> orderedHostUuids, List<Long> volumes, QueryOptions options);
+
+    void updateInstancePorts(List<Map<String, Object>> dataList);
  }

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AllocatorService.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/AllocatorService.java
@@ -1,6 +1,7 @@
 package io.cattle.platform.allocator.service;
 
 import io.cattle.platform.core.model.Instance;
+import io.cattle.platform.core.model.Port;
 import io.cattle.platform.core.model.Volume;
 
 import java.util.List;
@@ -18,6 +19,10 @@ public interface AllocatorService {
     void ensureResourcesReleasedForStop(Instance instance);
 
     void ensureResourcesReservedForStart(Instance instance);
+
+    void allocatePortsForInstanceUpdate(Instance instance, List<Port> newPorts);
+
+    void releasePortsForInstanceUpdate(Instance instance, List<Port> removedPorts);
 
     List<String> callExternalSchedulerForHostsSatisfyingLabels(Long accountId, Map<String, String> labels);
 }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/9752
There are three issues being fixed in this PR:
When we first create LB service, scheduler will allocate an ip address for the ports. 
(1).However, when we update LB, the original ip address assigned for the old ports is missing (2).also, there is no ip allocated for new ports.

https://github.com/rancher/rancher/issues/9879
(3).port resource fail to release when remove