### PR TITLE
DNS: Add search domain instance-{containerUUID}.rancher.internal to every container

### DIFF
--- a/modules/caas/backend/src/main/java/io/cattle/platform/inator/util/InstanceFactory.java
+++ b/modules/caas/backend/src/main/java/io/cattle/platform/inator/util/InstanceFactory.java
@@ -29,7 +29,6 @@ public class InstanceFactory {
 
         Map<String, Object> fields = new HashMap<>(launchConfig);
         addAdditionalFields(fields, stack, service, unit, launchConfigName);
-        addDns(fields, stack, service);
         addHostnameOverride(instanceName, fields);
 
         fields.put(ObjectMetaDataManager.NAME_FIELD, instanceName);
@@ -57,14 +56,6 @@ public class InstanceFactory {
         fields.put(InstanceConstants.FIELD_LABELS, labels);
     }
 
-    protected static void addDns(Map<String, Object> fields, StackWrapper stack, RevisionWrapper service) {
-        Map<String, String> labels = CollectionUtils.toMap(fields.get(InstanceConstants.FIELD_LABELS));
-        if ("false".equalsIgnoreCase(labels.get(SystemLabels.LABEL_USE_RANCHER_DNS))) {
-            return;
-        }
-        List<Object> dns = new ArrayList<>(CollectionUtils.toList(fields.get(InstanceConstants.FIELD_DNS_SEARCH)));
-        fields.put(InstanceConstants.FIELD_DNS_SEARCH, dns);
-    }
 
     private static String getOverrideHostName(Object domainName, String instanceName) {
         if (instanceName == null || instanceName.length() <= 64) {

--- a/modules/caas/backend/src/main/java/io/cattle/platform/inator/util/InstanceFactory.java
+++ b/modules/caas/backend/src/main/java/io/cattle/platform/inator/util/InstanceFactory.java
@@ -3,21 +3,20 @@ package io.cattle.platform.inator.util;
 import io.cattle.platform.allocator.constraint.ContainerLabelAffinityConstraint;
 import io.cattle.platform.core.constants.InstanceConstants;
 import io.cattle.platform.core.constants.ServiceConstants;
-import io.cattle.platform.core.util.ServiceUtil;
 import io.cattle.platform.core.util.SystemLabels;
 import io.cattle.platform.inator.wrapper.DeploymentUnitWrapper;
 import io.cattle.platform.inator.wrapper.RevisionWrapper;
 import io.cattle.platform.inator.wrapper.StackWrapper;
 import io.cattle.platform.object.meta.ObjectMetaDataManager;
 import io.cattle.platform.util.type.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class InstanceFactory {
 
@@ -64,18 +63,7 @@ public class InstanceFactory {
             return;
         }
         List<Object> dns = new ArrayList<>(CollectionUtils.toList(fields.get(InstanceConstants.FIELD_DNS_SEARCH)));
-        for (String entry : getSearchDomains(stack, service)) {
-            if (!dns.contains(entry)) {
-                dns.add(entry);
-            }
-        }
         fields.put(InstanceConstants.FIELD_DNS_SEARCH, dns);
-    }
-
-    protected static List<String> getSearchDomains(StackWrapper stack, RevisionWrapper service) {
-        String stackNamespace = ServiceUtil.getStackNamespace(stack.getName());
-        String serviceNamespace = ServiceUtil.getServiceNamespace(stack.getName(), service.getName());
-        return Arrays.asList(stackNamespace, serviceNamespace);
     }
 
     private static String getOverrideHostName(Object domainName, String instanceName) {

--- a/modules/caas/backend/src/main/java/io/cattle/platform/lifecycle/impl/NetworkLifecycleManagerImpl.java
+++ b/modules/caas/backend/src/main/java/io/cattle/platform/lifecycle/impl/NetworkLifecycleManagerImpl.java
@@ -105,17 +105,8 @@ public class NetworkLifecycleManagerImpl implements NetworkLifecycleManager {
             setField(instance, InstanceConstants.FIELD_DNS, dnsList);
         }
 
-        for (String dnsSearch : fieldStringList(network, NetworkConstants.FIELD_DNS_SEARCH)) {
-            List<String> dnsSearchList = appendToFieldStringList(instance, InstanceConstants.FIELD_DNS_SEARCH, dnsSearch);
-            String stackDns = null;
-            if (stack != null) {
-                stackDns = ServiceUtil.getStackNamespace(stack.getName());
-            }
-            if (!dnsSearchList.contains(stackDns)) {
-                dnsSearchList.add(stackDns);
-            }
-            setField(instance, InstanceConstants.FIELD_DNS_SEARCH, dnsSearchList);
-        }
+        List<String> dnsSearchList = appendToFieldStringList(instance, InstanceConstants.FIELD_DNS_SEARCH, ServiceUtil.getContainerNamespace(instance));
+        setField(instance, InstanceConstants.FIELD_DNS_SEARCH, dnsSearchList);
     }
 
     private void setupCNILabels(Instance instance, Network network) {

--- a/modules/caas/backend/src/main/java/io/cattle/platform/lifecycle/impl/NetworkLifecycleManagerImpl.java
+++ b/modules/caas/backend/src/main/java/io/cattle/platform/lifecycle/impl/NetworkLifecycleManagerImpl.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static io.cattle.platform.object.util.DataAccessor.*;
 
@@ -107,6 +108,8 @@ public class NetworkLifecycleManagerImpl implements NetworkLifecycleManager {
 
         List<String> dnsSearchList = appendToFieldStringList(instance, InstanceConstants.FIELD_DNS_SEARCH, ServiceUtil.getContainerNamespace(instance));
         setField(instance, InstanceConstants.FIELD_DNS_SEARCH, dnsSearchList);
+        String searchLabel = dnsSearchList.stream().collect(Collectors.joining(","));
+        setLabel(instance, SystemLabels.LABEL_DNS_SEARCH, searchLabel);
     }
 
     private void setupCNILabels(Instance instance, Network network) {

--- a/modules/caas/common/src/main/java/io/cattle/platform/certificate/impl/CertificateServiceImpl.java
+++ b/modules/caas/common/src/main/java/io/cattle/platform/certificate/impl/CertificateServiceImpl.java
@@ -4,6 +4,7 @@ import io.cattle.platform.certificate.CertificateService;
 import io.cattle.platform.core.constants.NetworkConstants;
 import io.cattle.platform.core.constants.ServiceConstants;
 import io.cattle.platform.core.dao.DataDao;
+import io.cattle.platform.core.model.Account;
 import io.cattle.platform.core.model.Service;
 import io.cattle.platform.core.model.Stack;
 import io.cattle.platform.object.ObjectManager;
@@ -63,9 +64,11 @@ public class CertificateServiceImpl implements CertificateService {
             .withDefault(Collections.emptyList()).asList(String.class);
         List<String> sans = new ArrayList<>(configuredSans);
 
+        Account account = objectManager.loadResource(Account.class, service.getAccountId());
+
         sans.add(serviceName.toLowerCase());
-        sans.add(String.format("%s.%s", serviceName, stack.getName()).toLowerCase());
-        sans.add(String.format("%s.%s.%s", serviceName, stack.getName(), NetworkConstants.INTERNAL_DNS_SEARCH_DOMAIN)
+        sans.add(String.format("%s.%s.%", serviceName, stack.getName(), account.getName()).toLowerCase());
+        sans.add(String.format("%s.%s.%s.%", serviceName, stack.getName(), account.getName(), NetworkConstants.INTERNAL_DNS_SEARCH_DOMAIN)
                 .toLowerCase());
 
         CertSet certSet = keyProvider.generateCertificate(serviceName, sans.toArray(new String[sans.size()]));

--- a/modules/model/src/main/java/io/cattle/platform/core/constants/NetworkConstants.java
+++ b/modules/model/src/main/java/io/cattle/platform/core/constants/NetworkConstants.java
@@ -6,7 +6,7 @@ import java.util.Set;
 
 public class NetworkConstants {
 
-    public static final String INTERNAL_DNS_SEARCH_DOMAIN = "rancher.internal";
+    public static final String INTERNAL_DNS_SEARCH_DOMAIN = "discover.internal";
 
     public static final String FIELD_DEFAULT_POLICY_ACTION = "defaultPolicyAction";
     public static final String FIELD_DNS = "dns";

--- a/modules/model/src/main/java/io/cattle/platform/core/util/ServiceUtil.java
+++ b/modules/model/src/main/java/io/cattle/platform/core/util/ServiceUtil.java
@@ -187,13 +187,8 @@ public class ServiceUtil {
         return NetworkConstants.INTERNAL_DNS_SEARCH_DOMAIN;
     }
 
-    public static String getServiceNamespace(String stackName, String serviceName) {
-        return new StringBuilder().append(serviceName).append(".").append(getStackNamespace(stackName))
-                .toString().toLowerCase();
-    }
-
-    public static String getStackNamespace(String stackName) {
-        return new StringBuilder().append(stackName).append(".")
+    public static String getContainerNamespace(Instance instance) {
+        return new StringBuilder().append(instance.getUuid().substring(0, 12)).append(".")
                 .append(getGlobalNamespace()).toString().toLowerCase();
     }
 

--- a/modules/model/src/main/java/io/cattle/platform/core/util/ServiceUtil.java
+++ b/modules/model/src/main/java/io/cattle/platform/core/util/ServiceUtil.java
@@ -183,13 +183,9 @@ public class ServiceUtil {
         }
     }
 
-    private static String getGlobalNamespace() {
-        return NetworkConstants.INTERNAL_DNS_SEARCH_DOMAIN;
-    }
-
     public static String getContainerNamespace(Instance instance) {
         return new StringBuilder().append(instance.getUuid().substring(0, 12)).append(".")
-                .append(getGlobalNamespace()).toString().toLowerCase();
+                .append(NetworkConstants.INTERNAL_DNS_SEARCH_DOMAIN).toString().toLowerCase();
     }
 
     public static List<String> getServiceActiveStates() {

--- a/modules/model/src/main/java/io/cattle/platform/core/util/SystemLabels.java
+++ b/modules/model/src/main/java/io/cattle/platform/core/util/SystemLabels.java
@@ -29,6 +29,7 @@ public class SystemLabels {
     public static final String LABEL_STACK_SERVICE_NAME = "io.rancher.stack_service.name";
     public static final String LABEL_USE_RANCHER_DNS = "io.rancher.container.dns";
     public static final String LABEL_VOLUME_CLEANUP_STRATEGY = "io.rancher.container.volume_cleanup_strategy";
+    public static final String LABEL_DNS_SEARCH = "io.rancher.container.dnssearch";
 
     // K8s labels
     public static final String LABEL_K8S_POD_UID = "io.kubernetes.pod.uid";


### PR DESCRIPTION
Corresponding PRs:

rancher/metadata#4
rancher/plugin-manager#88
rancher/rancher-dns#68

DNS changes:

1. Every container started via rancher gets only one rancher search domain:

instance-{containerUUID}.rancher.internal

2. On the rancher DNS side:
2.1 Answers will have client sections for every {containerUUID} + container ip (to support backwards compatibility) 
2.2 Search domains for clients are

* serviceName.stackName.environmentName.rancher.internal
* stackName.environmentName.rancher.internal
* environmentName.rancher.internal
* rancher.internal
* user domains

2.3 services are resolved as serviceName.stackName.environmentName.rancher.internal
2.4 containers are resolved as containerName.environmentName.rancher.internal
2.5 links are resolved as "alias" (no stack/global search domain appended as it used to be before)