### PR TITLE
Make auditLog.responseCode an int

### DIFF
--- a/modules/resources/src/main/resources/schema/base/auditLog.json
+++ b/modules/resources/src/main/resources/schema/base/auditLog.json
@@ -1,7 +1,7 @@
 {
   "resourceFields": {
     "responseCode": {
-      "type": "string"
+      "type": "int"
     },
     "requestObject": {
       "type": "string"


### PR DESCRIPTION
We store it and return it as an int, so schema should be made to matc