### PR TITLE
Allocate/release ports logic

### DIFF
--- a/modules/caas/backend/src/main/java/io/cattle/platform/allocator/constraint/PortsConstraint.java
+++ b/modules/caas/backend/src/main/java/io/cattle/platform/allocator/constraint/PortsConstraint.java
@@ -1,11 +1,9 @@
 package io.cattle.platform.allocator.constraint;
 
 import io.cattle.platform.allocator.service.AllocationCandidate;
-import io.cattle.platform.core.addon.PortInstance;
 import io.cattle.platform.core.util.PortSpec;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 public class PortsConstraint extends HardConstraint implements Constraint {
@@ -26,25 +24,15 @@ public class PortsConstraint extends HardConstraint implements Constraint {
         }
 
         // TODO: Performance improvement. Move more of the filtering into the DB query itself
-        Set<PortInstance> portsUsedByHost = candidate.getUsedPorts();
-        for (PortInstance portUsed : portsUsedByHost) {
+        Set<String> portsUsedByHost = candidate.getUsedPorts();
+        for (String portUsed : portsUsedByHost) {
             for (PortSpec requestedPort : ports) {
-                if (requestedPort.getPublicPort() != null &&
-                        requestedPort.getPublicPort().equals(portUsed.getPublicPort()) &&
-                        publicIpTheSame(requestedPort, portUsed) &&
-                        requestedPort.getProtocol().equals(portUsed.getProtocol())) {
+                if (requestedPort.toSpecConstraint().equals(portUsed)) {
                     return false;
                 }
             }
         }
         return true;
-    }
-
-    private boolean publicIpTheSame(PortSpec requestedPort, PortInstance portUsed) {
-        if (portUsed.isBindAll()) {
-            return true;
-        }
-        return Objects.equals(requestedPort.getIpAddress(), portUsed.getBindIpAddress());
     }
 
     @Override

--- a/modules/caas/backend/src/main/java/io/cattle/platform/allocator/lock/AllocateResourceLock.java
+++ b/modules/caas/backend/src/main/java/io/cattle/platform/allocator/lock/AllocateResourceLock.java
@@ -4,7 +4,7 @@ import io.cattle.platform.lock.definition.AbstractLockDefinition;
 
 public class AllocateResourceLock extends AbstractLockDefinition {
 
-    public AllocateResourceLock(Long resourceId) {
-        super("ALLOCATE.RESOURCE.INSTANCE." + resourceId);
+    public AllocateResourceLock(Long resourceId, String resourceType) {
+        super("ALLOCATE.RESOURCE." + resourceType + "." + resourceId);
     }
 }

--- a/modules/caas/backend/src/main/java/io/cattle/platform/allocator/service/AllocationCandidate.java
+++ b/modules/caas/backend/src/main/java/io/cattle/platform/allocator/service/AllocationCandidate.java
@@ -1,6 +1,5 @@
 package io.cattle.platform.allocator.service;
 
-import io.cattle.platform.core.addon.PortInstance;
 import io.cattle.platform.util.resource.UUID;
 
 import java.util.HashSet;
@@ -12,7 +11,7 @@ public class AllocationCandidate {
     Long clusterId;
     Long host;
     String hostUuid;
-    Set<PortInstance> usedPorts;
+    Set<String> usedPorts;
 
     public AllocationCandidate(long clusterId, long hostId, String hostUuid) {
         this.clusterId = clusterId;
@@ -27,7 +26,7 @@ public class AllocationCandidate {
         this.usedPorts = candidate.usedPorts == null ? new HashSet<>() : new HashSet<>(candidate.usedPorts);
     }
 
-    public AllocationCandidate(Long hostId, String hostUuid, Set<PortInstance> usedPorts, Long clusterId) {
+    public AllocationCandidate(Long hostId, String hostUuid, Set<String> usedPorts, Long clusterId) {
         super();
         this.clusterId = clusterId;
         this.host = hostId;
@@ -51,7 +50,7 @@ public class AllocationCandidate {
         return hostUuid;
     }
 
-    public Set<PortInstance> getUsedPorts() {
+    public Set<String> getUsedPorts() {
         return usedPorts;
     }
 

--- a/modules/main/src/main/java/io/cattle/platform/app/components/Backend.java
+++ b/modules/main/src/main/java/io/cattle/platform/app/components/Backend.java
@@ -228,6 +228,7 @@ public class Backend {
         allocationHelper = reconcile.allocationHelper;
 
         allocatorService = new AllocatorServiceImpl(d.agentDao, c.agentLocator, d.allocatorDao, f.lockManager, f.objectManager,f. processManager, allocationHelper, d.volumeDao, metadataManager, f.eventService,
+                d.clusterDao,
                 new ClusterConstraintsProvider(),
                 new BaseConstraintsProvider(d.allocatorDao),
                 new AffinityConstraintsProvider(allocationHelper),

--- a/modules/model/src/main/java/io/cattle/platform/core/addon/metadata/HostInfo.java
+++ b/modules/model/src/main/java/io/cattle/platform/core/addon/metadata/HostInfo.java
@@ -4,6 +4,7 @@ import io.cattle.platform.core.addon.PortInstance;
 import io.cattle.platform.core.constants.HostConstants;
 import io.cattle.platform.core.model.Host;
 import io.cattle.platform.object.util.DataAccessor;
+
 import io.github.ibuildthecloud.gdapi.annotation.Field;
 
 import java.util.HashSet;
@@ -26,6 +27,7 @@ public class HostInfo implements MetadataObject {
     Long milliCpu;
     Long memory;
     String nodeName;
+    Set<String> portSpecs;
 
     public HostInfo(Host host) {
         this.id = host.getId();
@@ -43,6 +45,7 @@ public class HostInfo implements MetadataObject {
         this.ports = new HashSet<>(
                 DataAccessor.fieldObjectList(host, HostConstants.FIELD_PUBLIC_ENDPOINTS, PortInstance.class));
         this.nodeName = DataAccessor.fieldString(host, HostConstants.FIELD_NODE_NAME);
+        this.portSpecs = new HashSet<>(DataAccessor.fieldStringList(host, HostConstants.FIELD_PORT_SPECS));
     }
 
     public long getId() {
@@ -125,6 +128,10 @@ public class HostInfo implements MetadataObject {
         return nodeName;
     }
 
+    public Set<String> getPortSpecs() {
+        return portSpecs;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -147,6 +154,8 @@ public class HostInfo implements MetadataObject {
         if (hostname != null ? !hostname.equals(hostInfo.hostname) : hostInfo.hostname != null) return false;
         if (milliCpu != null ? !milliCpu.equals(hostInfo.milliCpu) : hostInfo.milliCpu != null) return false;
         if (memory != null ? !memory.equals(hostInfo.memory) : hostInfo.memory != null) return false;
+        if (portSpecs != null ? !portSpecs.equals(hostInfo.portSpecs) : hostInfo.portSpecs != null)
+            return false;
         return nodeName != null ? nodeName.equals(hostInfo.nodeName) : hostInfo.nodeName == null;
     }
 
@@ -167,6 +176,7 @@ public class HostInfo implements MetadataObject {
         result = 31 * result + (milliCpu != null ? milliCpu.hashCode() : 0);
         result = 31 * result + (memory != null ? memory.hashCode() : 0);
         result = 31 * result + (nodeName != null ? nodeName.hashCode() : 0);
+        result = 31 * result + (portSpecs != null ? portSpecs.hashCode() : 0);
         return result;
     }
 }

--- a/modules/model/src/main/java/io/cattle/platform/core/constants/HostConstants.java
+++ b/modules/model/src/main/java/io/cattle/platform/core/constants/HostConstants.java
@@ -23,6 +23,7 @@ public class HostConstants {
     public static final String FIELD_MILLI_CPU = "milliCpu";
     public static final String FIELD_NODE_NAME = "nodeName";
     public static final String FIELD_PUBLIC_ENDPOINTS = "publicEndpoints";
+    public static final String FIELD_PORT_SPECS = "portSpecs";
 
     public static final String PROCESS_ACTIVATE = "host.activate";
     public static final String PROCESS_PROVISION = "host.provision";

--- a/modules/model/src/main/java/io/cattle/platform/core/util/PortSpec.java
+++ b/modules/model/src/main/java/io/cattle/platform/core/util/PortSpec.java
@@ -133,6 +133,15 @@ public class PortSpec {
         return bindIP + publicPort + privatePortProto;
     }
 
+    public String toSpecConstraint() {
+        String publicPort = this.publicPort != null ? this.publicPort.toString() + ":" : "";
+        String bindIP = "";
+        if (StringUtils.isNotBlank(this.ipAddress)) {
+            bindIP = this.ipAddress + ":";
+        }
+        return bindIP + publicPort + this.protocol;
+    }
+
     @Override
     public String toString() {
         return toSpec();

--- a/modules/resources/src/main/resources/schema/base/host.json
+++ b/modules/resources/src/main/resources/schema/base/host.json
@@ -35,6 +35,11 @@
       "required": false,
       "nullable": true
     },
+    "portSpecs": {
+      "type": "array[string]",
+      "required": false,
+      "nullable": true
+    },
     "localStorageMb": {
       "attributes": {
         "scheduleUpdate": true


### PR DESCRIPTION
* lock on cluster
* allocate on start/release on stop

@ibuildthecloud something tells me you might be unhappy with storing portSpecs to the host DB...Couldn't figure out the proper init point for metadata cache where I could catch all instances on the host to transform them to the host's ports constraints.