### PR TITLE
Standalone container upgrade: fixed name setting

### DIFF
--- a/modules/caas/backend/src/main/java/io/cattle/platform/inator/launchconfig/impl/ServiceLaunchConfig.java
+++ b/modules/caas/backend/src/main/java/io/cattle/platform/inator/launchconfig/impl/ServiceLaunchConfig.java
@@ -270,7 +270,7 @@ public class ServiceLaunchConfig implements LaunchConfig {
 
     public String getInstanceName(StackWrapper stack, RevisionWrapper service, int index) {
         if (index <= 0) {
-            return name;
+            return service.getName();
         }
         return ServiceUtil.generateServiceInstanceName(stack.getName(), service.getName(), name, index);
     }

--- a/modules/caas/backend/src/main/java/io/cattle/platform/inator/util/InstanceFactory.java
+++ b/modules/caas/backend/src/main/java/io/cattle/platform/inator/util/InstanceFactory.java
@@ -10,9 +10,7 @@ import io.cattle.platform.inator.wrapper.StackWrapper;
 import io.cattle.platform.object.meta.ObjectMetaDataManager;
 import io.cattle.platform.util.type.CollectionUtils;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 

--- a/modules/model/src/main/java/io/cattle/platform/core/util/ServiceUtil.java
+++ b/modules/model/src/main/java/io/cattle/platform/core/util/ServiceUtil.java
@@ -76,29 +76,6 @@ public class ServiceUtil {
         return launchConfigNames;
     }
 
-    public static Map<String, Object> getLaunchConfigWithServiceDataAsMap(Service service, String launchConfigName) {
-        Map<String, Object> data = new HashMap<>();
-        // 1) get service data
-        data.putAll(DataAccessor.getFields(service));
-
-        // 2) remove launchConfig/secondaryConfig data
-        Object launchConfig = data
-                .get(ServiceConstants.FIELD_LAUNCH_CONFIG);
-        if (launchConfig != null) {
-            data.remove(ServiceConstants.FIELD_LAUNCH_CONFIG);
-        }
-
-        Object secondaryLaunchConfigs = data
-                .get(ServiceConstants.FIELD_SECONDARY_LAUNCH_CONFIGS);
-        if (secondaryLaunchConfigs != null) {
-            data.remove(ServiceConstants.FIELD_SECONDARY_LAUNCH_CONFIGS);
-        }
-        // 3) populate launch config data
-        data.putAll(getLaunchConfigDataAsMap(service, launchConfigName));
-
-        return data;
-    }
-
     @SuppressWarnings("unchecked")
     public static Map<String, Object> getLaunchConfigDataAsMap(Service service, String launchConfigName) {
         if (launchConfigName == null) {


### PR DESCRIPTION
Bug fix for "When upgrade/edit container, the name of the container is lost and comes back as io.rancher.service.primary.launch.config"

and some code cleanup