### PR TITLE
Fix db cleanup 

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/cleanup/TableCleanup.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/cleanup/TableCleanup.java
@@ -82,6 +82,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.HashSet;
 
 import org.jooq.Field;
 import org.jooq.ForeignKey;
@@ -262,43 +263,46 @@ public class TableCleanup extends AbstractJooqDao implements Task {
 
             table.clearRowCounts();
             Result<Record1<Long>> toDelete;
-            List<Long> idsToFix = new ArrayList<>();
-            while ((toDelete = ids.fetch()).size() > 0) {
-                List<Long> idsToDelete = new ArrayList<>();
+            HashSet<Long> idsToFix = new HashSet<Long>();
+            HashSet<Long> idsToFilter = new HashSet<Long>();
+            ResultQuery<Record1<Long>> filterIds;
+            Result<Record1<Long>> toFilter;
 
-                for (Record1<Long> record : toDelete) {
-                    if (!idsToFix.contains(record.value1())) {
-                        idsToDelete.add(record.value1());
-                    }
-                }
-
-                if (idsToDelete.size() == 0) {
-                    break;
-                }
-
+            if ((toDelete = ids.fetch()).size() > 0) {
                 List<ForeignKey<?, ?>> keys = getReferencesFrom(table, tables);
                 for (ForeignKey<?, ?> key : keys) {
-                    Table<?> referencingTable = key.getTable();
                     if (key.getFields().size() > 1) {
                         log.error("Composite foreign key filtering unsupported");
                     }
+                }
+                for (ForeignKey<?, ?> key : keys) {
+                    Table<?> referencingTable = key.getTable();
                     Field<Long> foreignKeyField = (Field<Long>) key.getFields().get(0);
 
-                    ResultQuery<Record1<Long>> filterIds = create()
-                        .selectDistinct(foreignKeyField)
-                        .from(referencingTable)
-                        .where(foreignKeyField.in(idsToDelete));
+                    filterIds = create().selectDistinct(foreignKeyField).from(referencingTable);
 
-                    Result<Record1<Long>> toFilter = filterIds.fetch();
-                    if (toFilter.size() > 0) {
+                    if ((toFilter = filterIds.fetch()).size() > 0) {
                         for (Record1<Long> record : toFilter) {
-                            if (idsToDelete.remove(record.value1())) {
-                                idsToFix.add(record.value1());
-                            }
+                            idsToFilter.add(record.value1());
                         }
                     }
                 }
+            }
 
+            while (toDelete.size() > 0) {
+                HashSet<Long> idsToDelete = new HashSet<Long>();
+                for (Record1<Long> record : toDelete) {
+                    if (idsToFilter.contains(record.value1())) {
+                        idsToFix.add(record.value1());
+                        idsToFilter.remove(record.value1());
+                    }
+                    if ((!idsToFix.contains(record.value1()))) {
+                        idsToDelete.add(record.value1());
+                    }
+                }
+                if (idsToDelete.size() == 0) {
+                    break;
+                }
                 try {
                     table.addRowsDeleted(create()
                             .delete(table.table)
@@ -312,6 +316,7 @@ public class TableCleanup extends AbstractJooqDao implements Task {
                 if (idsToFix.size() > 0) {
                     ids = create().select(id).from(table.table).where(remove.lt(cutoffTime)).orderBy(id)
                         .limit(QUERY_LIMIT_ROWS.getValue()).offset(idsToFix.size());
+                    toDelete = ids.fetch();
                 }
             }
             if (idsToFix.size() > 0) {

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/cleanup/TableCleanup.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/cleanup/TableCleanup.java
@@ -309,6 +309,10 @@ public class TableCleanup extends AbstractJooqDao implements Task {
                     log.info(e.getMessage());
                     break;
                 }
+                if (idsToFix.size() > 0) {
+                    ids = create().select(id).from(table.table).where(remove.lt(cutoffTime)).orderBy(id)
+                        .limit(QUERY_LIMIT_ROWS.getValue()).offset(idsToFix.size());
+                }
             }
             if (idsToFix.size() > 0) {
                 table.addRowsSkipped(idsToFix.size());


### PR DESCRIPTION
[rancher/rancher#7050](https://github.com/rancher/rancher/issues/7050)
[rancher/rancher#7606](https://github.com/rancher/rancher/issues/7606)

I tried reproducing both of the issues mentioned above but couldn't. I observed that 
1) Sometimes, instances without any references also didn't get deleted. 
2) Cleanup took way longer than expected, even with records to be purged ~100k. 

This is because ids were always fetched without any offset, hence the skipped records keep getting fetched again and again. Hence, the number of records getting deleted with every fetch was way below query_limit_rows limit. 
At some point, it so happens that the entire fetched batch has only skipped records and idsToDelete becomes 0 and loop breaks. 

This PR - 
1) fixes the logic of fetching ids with proper offset, so all instances supposed to be deleted get removed. 
2) optimize the way we find ids to be skipped, instead of getting foreign key references for every loop, store them beforehand. They wouldn't change because the cutoff time for the entire cleanup function remains the same. 

Tested with a table that had ~500k+ records to be purged. I adjusted QUERY_LIMIT_ROWS = 10k for easier debugging. 
A sample log showing it deleted expected number and within an expected time range. 
```
2017-09-22 21:07:19,891 INFO  [:] [] [] [] [ecutorService-4] [i.c.p.core.cleanup.TableCleanup     ] idsToDelete 8735
2017-09-22 21:07:48,380 INFO  [:] [] [] [] [ecutorService-4] [i.c.p.core.cleanup.TableCleanup     ] idsToDelete 8986 
2017-09-22 21:08:20,201 INFO  [:] [] [] [] [ecutorService-4] [i.c.p.core.cleanup.TableCleanup     ] idsToDelete 9122 
2017-09-22 21:08:53,219 INFO  [:] [] [] [] [ecutorService-4] [i.c.p.core.cleanup.TableCleanup     ] idsToDelete 8941  
2017-09-22 21:09:24,271 INFO  [:] [] [] [] [ecutorService-4] [i.c.p.core.cleanup.TableCleanup     ] idsToDelete 9173 
2017-09-22 21:09:58,735 INFO  [:] [] [] [] [ecutorService-4] [i.c.p.core.cleanup.TableCleanup     ] idsToDelete 8873 
```

Note - 
while testing, after one round of cleanup, you might still see instances with state = "purged" and removed < cutoff-time. This is because, those containers had sidekicks. Since sidekicks have a dependency, in the first round - they are not removed but will be successfully deleted in the next cleanup. 
You might see entries similar to - 
```
+--------+-------------------------------------------+--------+---------------------+
| id     | name                                      | state  | removed             |
+--------+-------------------------------------------+--------+---------------------+
| 413574 | ipsec-ipsec-1                             | purged | 2017-02-04 19:45:59 |
| 453905 | ipsec-ipsec-1                             | purged | 2017-02-16 20:06:44 |
| 453909 | network-services-metadata-1               | purged | 2017-02-07 18:35:51 |
| 467119 | elasticsearch-2-elasticsearch-datanodes-4 | purged | 2017-02-08 11:30:19 |
| 467715 | kubernetes-kubectld-1                     | purged | 2017-02-08 12:04:35 |
+--------+-------------------------------------------+--------+---------------------+
``` 