### PR TITLE
No network mode for secondary launch config

### DIFF
--- a/modules/main/src/main/java/io/cattle/platform/app/components/Model.java
+++ b/modules/main/src/main/java/io/cattle/platform/app/components/Model.java
@@ -398,7 +398,8 @@ public class Model {
                 "setProjectMembersInput",
                 "stackUpgrade",
                 "storageDriverService,parent=service",
-                "virtualMachine,parent=container");
+                "virtualMachine,parent=container",
+                "secondaryLaunchConfig,parent=launchConfig");
     }
 
 }

--- a/modules/resources/src/main/resources/schema/auth/user-auth.json
+++ b/modules/resources/src/main/resources/schema/auth/user-auth.json
@@ -803,6 +803,8 @@
 
         "secondaryLaunchConfig" : "cr",
         "secondaryLaunchConfig.name" : "cr",
+        "secondaryLaunchConfig.networkMode" : "r",
+        "secondaryLaunchConfig.requestedIpAddress" : "",
 
         "serviceLink" : "cr",
         "serviceLink.serviceId" : "cr",

--- a/modules/resources/src/main/resources/schema/base/service.json
+++ b/modules/resources/src/main/resources/schema/base/service.json
@@ -42,7 +42,7 @@
       "nullable": true
     },
     "secondaryLaunchConfigs": {
-      "type": "array[launchConfig]",
+      "type": "array[secondaryLaunchConfig]",
       "create": true,
       "required": false,
       "nullable": true,


### PR DESCRIPTION
@ibuildthecloud this PR just disables setting networkMode and requestedIpAddress for sidekicks. There are a couple of issues that are yet to be addressed:

1) I still see ip address being allocated to the sidekick instance, and it is different from the primary container. Seeing that the ip address comes as a part of deploymentsyncrequest, I assume it is being allocated on the backend?

2) What would be the right place to set networkFromContainerId on the container?