### PR TITLE
Handle null account_id in AgentRemove

### DIFF
--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/agent/AgentRemove.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/agent/AgentRemove.java
@@ -59,11 +59,17 @@ public class AgentRemove extends AbstractObjectProcessHandler {
             }
         }
 
-        deactivateThenScheduleRemove(objectManager.loadResource(Account.class, agent.getAccountId()), state.getData());
+        Account account = objectManager.loadResource(Account.class, agent.getAccountId());
+        if (account != null && account.getRemoved() == null) {
+            deactivateThenScheduleRemove(account, state.getData());
+        }
 
         List<Long> authedRoleAccountIds = DataAccessor.fieldLongList(agent, AgentConstants.FIELD_AUTHORIZED_ROLE_ACCOUNTS);
         for (Long accountId : authedRoleAccountIds) {
-            deactivateThenScheduleRemove(objectManager.loadResource(Account.class, accountId), state.getData());
+            account = objectManager.loadResource(Account.class, accountId);
+            if (account != null && account.getRemoved() == null) {
+                deactivateThenScheduleRemove(account, state.getData());
+            }
         }
 
         return null;


### PR DESCRIPTION
When an agent is first created and boostrap into the system
(RegisterCreate), it is created without an account_id set.
The account_id is set in a downstream process (AgentCreate).
This creates a scenario where if something goes wrong in AgentCreate
and the agent is ultimately removed, it will be removed while having a
null account_id. This results in an NPE in AgentRemove.

This addresses that scenario by checking for a null account before
attempting to remove it.