### PR TITLE
Noop when rancher/external-service image is set

### DIFF
--- a/modules/model/src/main/java/io/cattle/platform/core/constants/ServiceConstants.java
+++ b/modules/model/src/main/java/io/cattle/platform/core/constants/ServiceConstants.java
@@ -90,6 +90,7 @@ public class ServiceConstants {
 
     public static final String IMAGE_NONE = "rancher/none";
     public final static String IMAGE_DNS = "rancher/dns-service";
+    public final static String IMAGE_EXTERNAL = "rancher/external-service";
 
     public static final List<String> SERVICE_INSTANCE_NAME_DIVIDORS = Arrays.asList("-", "_");
     public static final List<String> skipStatesForDeactivate = Arrays.asList(CommonStatesConstants.REMOVED,

--- a/modules/model/src/main/java/io/cattle/platform/core/util/ServiceUtil.java
+++ b/modules/model/src/main/java/io/cattle/platform/core/util/ServiceUtil.java
@@ -271,7 +271,9 @@ public class ServiceUtil {
         } else {
             Map<String, Object> data = CollectionUtils.toMap(config);
             Object image = data.get(InstanceConstants.FIELD_IMAGE);
-            if (image == null || StringUtils.equals(image.toString(), ServiceConstants.IMAGE_DNS)|| StringUtils.equals(image.toString(), ServiceConstants.IMAGE_NONE) ) {
+            if (image == null || StringUtils.equals(image.toString(), ServiceConstants.IMAGE_DNS)
+                    || StringUtils.equals(image.toString(), ServiceConstants.IMAGE_EXTERNAL)
+                    || StringUtils.equals(image.toString(), ServiceConstants.IMAGE_NONE)) {
                 noOp = true;
             }
         }


### PR DESCRIPTION
Apparently rancher-compose still sets this image for external service