### PR TITLE
Add null check to ldap attribute retrieval

### DIFF
--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/LDAPIdentityProvider.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/ldap/LDAPIdentityProvider.java
@@ -21,6 +21,7 @@ import javax.annotation.PostConstruct;
 import javax.naming.Context;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
@@ -237,7 +238,12 @@ public abstract class LDAPIdentityProvider implements IdentityProvider{
     protected boolean isType(Attributes search, String type) {
         NamingEnumeration<?> objectClass;
         try {
-            objectClass = search.get(getConstantsConfig().objectClass()).getAll();
+            Attribute attr = search.get(getConstantsConfig().objectClass());
+            if (attr == null) {
+                getLogger().info("Object class attribute [{}] not found. Object does not match type [{}]", getConstantsConfig().objectClass(), type);
+                return false;
+            }
+            objectClass = attr.getAll();
             while (objectClass.hasMoreElements()) {
                 Object object = objectClass.next();
                 if ((object.toString()).equalsIgnoreCase(type)){


### PR DESCRIPTION
Getting an attribute can return null, so we need to check that it isn't null before using it.

Addresses: https://github.com/rancher/rancher/issues/10056