### PR TITLE
Add drain provider label to LoadBalancers based on image version

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/util/SystemLabels.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/util/SystemLabels.java
@@ -28,6 +28,7 @@ public class SystemLabels {
     public static final String LABEL_AGENT_SERVICE_IPSEC = "io.rancher.container.agent_service.ipsec";
     public static final String LABEL_AGENT_SERVICE_COMPOSE_PROVIDER = "io.rancher.container.agent_service.docker_compose";
     public static final String LABEL_AGENT_SERVICE_SCHEDULING_PROVIDER = "io.rancher.container.agent_service.scheduling";
+    public static final String LABEL_AGENT_SERVICE_DRAIN_PROVIDER = "io.rancher.container.agent_service.drain_provider";
 
     public static final String LABEL_VM = "io.rancher.vm";
     public static final String LABEL_VM_USERDATA = "io.rancher.vm.userdata";

--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/util/ServiceDiscoveryUtil.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/util/ServiceDiscoveryUtil.java
@@ -1,6 +1,7 @@
 package io.cattle.platform.servicediscovery.api.util;
 
 import io.cattle.platform.allocator.service.AllocationHelper;
+import io.cattle.platform.archaius.util.ArchaiusUtil;
 import io.cattle.platform.core.addon.InServiceUpgradeStrategy;
 import io.cattle.platform.core.addon.InstanceHealthCheck;
 import io.cattle.platform.core.constants.AgentConstants;
@@ -11,6 +12,7 @@ import io.cattle.platform.core.model.Service;
 import io.cattle.platform.core.model.Stack;
 import io.cattle.platform.core.util.PortSpec;
 import io.cattle.platform.core.util.SystemLabels;
+import io.cattle.platform.docker.client.DockerImage;
 import io.cattle.platform.object.meta.ObjectMetaDataManager;
 import io.cattle.platform.object.util.DataAccessor;
 import io.cattle.platform.object.util.DataUtils;
@@ -28,10 +30,13 @@ import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.netflix.config.DynamicStringProperty;
+
 public class ServiceDiscoveryUtil {
 
     public static final List<String> SERVICE_INSTANCE_NAME_DIVIDORS = Arrays.asList("-", "_");
     private static final int LB_HEALTH_CHECK_PORT = 42;
+    private static final DynamicStringProperty LB_DRAIN_IMAGE_VERSION = ArchaiusUtil.getString("loadbalancher.drain.image.version");
 
     public static String getInstanceName(Instance instance) {
         if (instance != null && instance.getRemoved() == null) {
@@ -401,6 +406,12 @@ public class ServiceDiscoveryUtil {
         }
         labels.put(SystemLabels.LABEL_AGENT_ROLE, AgentConstants.ENVIRONMENT_ADMIN_ROLE + ",agent");
         labels.put(SystemLabels.LABEL_AGENT_CREATE, "true");
+
+        //check if the LB service is a drainProvider from lb image
+        if(doesLBHaveDrainSupport(launchConfig)){
+            labels.put(SystemLabels.LABEL_AGENT_SERVICE_DRAIN_PROVIDER, "true");
+        }
+
         launchConfig.put(InstanceConstants.FIELD_LABELS, labels);
 
         // set health check
@@ -417,6 +428,70 @@ public class ServiceDiscoveryUtil {
             launchConfig.put(InstanceConstants.FIELD_HEALTH_CHECK, healthCheck);
         }
     }
+
+    private static boolean doesLBHaveDrainSupport(Map<Object, Object> launchConfig) {
+        if(launchConfig.get(InstanceConstants.FIELD_IMAGE_UUID) != null) {
+            String imageUuid = (String)launchConfig.get(InstanceConstants.FIELD_IMAGE_UUID);
+            DockerImage img = DockerImage.parse(imageUuid);
+            String[] imageParts = img.getFullName().split(":");
+            if (imageParts.length <= 1) {
+                return false;
+            }
+            if (!imageParts[0].equals("rancher/lb-service-haproxy")) {
+                return false;
+            }
+            return isDrainProvider(imageParts[imageParts.length - 1]);
+        }
+        return false;
+    }
+
+    private static boolean isDrainProvider(String actualVersion) {
+        String requiredVersion = LB_DRAIN_IMAGE_VERSION.get();
+        if (StringUtils.isEmpty(requiredVersion)) {
+            return false;
+        }
+        String[] requiredParts = requiredVersion.split("\\.");
+        if (requiredParts.length < 3) {
+            // Required image is not following semantic versioning.
+            return false;
+        }
+        int requiredMajor, requiredMinor, requiredPatch = 0;
+        try {
+            String majorTemp = requiredParts[0].startsWith("v") ? requiredParts[0].substring(1, requiredParts[0].length()) : requiredParts[0];
+            requiredMajor = Integer.valueOf(majorTemp);
+            requiredMinor = Integer.valueOf(requiredParts[1]);
+            requiredPatch = Integer.valueOf(requiredParts[2]);
+        } catch (NumberFormatException e) {
+            // Require image is not following semantic versioning.
+            return false;
+        }
+
+        String[] actualParts = actualVersion.split("\\.");
+        if (actualParts.length < 3) {
+            // Image is not following semantic versioning.
+            return false;
+        }
+
+        int actualMajor, actualMinor, actualPatch = 0;
+        try {
+            String majorTemp = actualParts[0].startsWith("v") ? actualParts[0].substring(1, actualParts[0].length()) : actualParts[0];
+            actualMajor = Integer.valueOf(majorTemp).intValue();
+            actualMinor = Integer.valueOf(actualParts[1]).intValue();
+            String[] patchParts = actualParts[2].split("\\-");
+            actualPatch = Integer.valueOf(patchParts[0]);
+        } catch (NumberFormatException e) {
+            // Image is not following semantic versioning.
+            return false;
+        }
+
+        if (actualMajor > requiredMajor) {
+            return true;
+        } else if (actualMajor == requiredMajor && actualMinor >= requiredMinor && actualPatch >= requiredPatch) {
+            return true;
+        }
+        return false;
+    }
+
 
     @SuppressWarnings("unchecked")
     public static void validateScaleSwitch(Object newLaunchConfig, Object currentLaunchConfig) {

--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/system-services/defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/system-services/defaults.properties
@@ -194,3 +194,5 @@ cluster.default.port=9345
 cluster.checkin.seconds=5
 cluster.checkin.misses=3
 cluster.default.http.port=8080
+
+loadbalancher.drain.image.version=v0.7.12


### PR DESCRIPTION
This is added to make sure we send events during drain only to agents where the LB is listening for events. So LB's with older images are not sent the events.

https://github.com/rancher/rancher/issues/10013

@cjellick pls review.