### PR TITLE
Upgrade of LB should add the agent and environmentAdmin role always

### DIFF
--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/util/ServiceDiscoveryUtil.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/util/ServiceDiscoveryUtil.java
@@ -399,11 +399,8 @@ public class ServiceDiscoveryUtil {
         if (labelsObj != null) {
             labels = (Map<String, String>) labelsObj;
         }
-        if (!labels.containsKey(SystemLabels.LABEL_AGENT_ROLE)) {
-            labels.put(SystemLabels.LABEL_AGENT_ROLE, AgentConstants.ENVIRONMENT_ADMIN_ROLE + ",agent");
-            labels.put(SystemLabels.LABEL_AGENT_CREATE, "true");
-        }
-
+        labels.put(SystemLabels.LABEL_AGENT_ROLE, AgentConstants.ENVIRONMENT_ADMIN_ROLE + ",agent");
+        labels.put(SystemLabels.LABEL_AGENT_CREATE, "true");
         launchConfig.put(InstanceConstants.FIELD_LABELS, labels);
 
         // set health check


### PR DESCRIPTION
On LB upgrades, we were adding the label ""io.rancher.container.agent.role" only if it is not already present.

Now since the value of this label is changing since 1.6.11, we should change the label always on upgrades. No need of the if conditional really.

https://github.com/rancher/rancher/issues/10061

@cjellick pls. review

