### PR TITLE
Cleanup fix - fetch new records on every iteration

### DIFF
--- a/code/iaas/model/src/main/java/io/cattle/platform/core/cleanup/TableCleanup.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/cleanup/TableCleanup.java
@@ -315,9 +315,9 @@ public class TableCleanup extends AbstractJooqDao implements Task {
                 }
                 if (idsToFix.size() > 0) {
                     ids = create().select(id).from(table.table).where(remove.lt(cutoffTime)).orderBy(id)
-                        .limit(QUERY_LIMIT_ROWS.getValue()).offset(idsToFix.size());
-                    toDelete = ids.fetch();
+                    .limit(QUERY_LIMIT_ROWS.getValue()).offset(idsToFix.size());
                 }
+                toDelete = ids.fetch();
             }
             if (idsToFix.size() > 0) {
                 table.addRowsSkipped(idsToFix.size());


### PR DESCRIPTION
[rancher/rancher#7050](https://github.com/rancher/rancher/issues/7050)
If idsToFix =0, new records still need to be fetched according to old query definition of ids. 