### PR TITLE
Cleanup service from alias links on removal

### DIFF
--- a/modules/caas/backend/src/main/java/io/cattle/platform/lifecycle/impl/AliasServiceLinkLock.java
+++ b/modules/caas/backend/src/main/java/io/cattle/platform/lifecycle/impl/AliasServiceLinkLock.java
@@ -1,0 +1,10 @@
+package io.cattle.platform.lifecycle.impl;
+
+import io.cattle.platform.lock.definition.AbstractBlockingLockDefintion;
+
+public class AliasServiceLinkLock extends AbstractBlockingLockDefintion {
+
+    public AliasServiceLinkLock (long serviceId) {
+        super("ALIAS.SERVICE.LINK.UPDATE." + serviceId);
+    }
+}

--- a/modules/main/src/main/java/io/cattle/platform/app/components/Backend.java
+++ b/modules/main/src/main/java/io/cattle/platform/app/components/Backend.java
@@ -236,7 +236,7 @@ public class Backend {
         agentLifecycleManager = new AgentLifecycleManagerImpl(agentInstanceFactory, f.resourceMonitor);
         secretsLifecycleManager = new SecretsLifecycleManagerImpl(c.tokenService, d.storageDriverDao);
         loadBalancerService = new LoadBalancerServiceImpl(f.jsonMapper, f.lockManager, f.objectManager);
-        serviceLifecycleManager = new ServiceLifecycleManagerImpl(f.objectManager, f.resourcePoolManager, networkService, d.serviceDao, c.revisionManager, loadBalancerService, f.processManager);
+        serviceLifecycleManager = new ServiceLifecycleManagerImpl(f.objectManager, f.resourcePoolManager, networkService, d.serviceDao, c.revisionManager, loadBalancerService, f.processManager,f.lockManager);
         upgradeManager = new UpgradeManager(c.catalogService, d.stackDao, d.resourceDao, f.lockManager, f.processManager);
 
         Reconcile reconcile = new Reconcile(f, d, c, this);


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/10042

@ibuildthecloud still have doubts if we should fix the bug and cleanup the service from links on target service removal. Given that reference to it is in serviceName/stackName, not the serviceId + on when create dns config, the target service is ignored if can't be found.