### PR TITLE
Ignore DrainTimeoutMs value on Sidekicks, secondary launch_config will…

### DIFF
--- a/resources/content/schema/user/user-auth.json
+++ b/resources/content/schema/user/user-auth.json
@@ -880,6 +880,7 @@
 
         "secondaryLaunchConfig" : "cr",
         "secondaryLaunchConfig.name" : "cr",
+        "secondaryLaunchConfig.drainTimeoutMs" : "",
 
         "serviceLink" : "cr",
         "serviceLink.serviceId" : "cr",

--- a/tests/integration/cattletest/core/test_svc_discovery.py
+++ b/tests/integration/cattletest/core/test_svc_discovery.py
@@ -3915,4 +3915,3 @@ def test_drain_timeout_launch_config(client, context, super_client):
     service = client.wait_success(service)
     assert len(service.secondaryLaunchConfigs) == 1
     assert service.launchConfig.drainTimeoutMs is not None
-    assert service.secondaryLaunchConfigs[0].drainTimeoutMs is not None


### PR DESCRIPTION
secondary launch_config will always default drainTimeoutMs to zero. Thus Sidekick containers will not be drained.

https://github.com/rancher/rancher/issues/10087

@alena1108 pls. review