### PR TITLE
don't compare the old and new spec

### DIFF
--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceUpdatePostListener.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/process/LoadBalancerServiceUpdatePostListener.java
@@ -92,10 +92,6 @@ public class LoadBalancerServiceUpdatePostListener extends AbstractObjectProcess
             newPortDefs = (List<String>) launchConfigData.get(InstanceConstants.FIELD_PORTS);
         }
 
-        if (newPortDefs.containsAll(oldPortDefs) && oldPortDefs.containsAll(newPortDefs)) {
-            return;
-        }
-
         List<? extends Instance> serviceContainers = expMapDao.listServiceManagedInstancesAll(service);
         for (Instance instance : serviceContainers) {
             List<Port> toCreate = new ArrayList<>();


### PR DESCRIPTION
if we update the port for lb for the first time, if there is a port conflict it will get stuck at updating. Then if we update the same port spec
for the second time, it will compare the current port specs with the old spec(the first update), which is no different and it willl return success immediately.
So, don't compare the stuff and let all of them go through the external scheduler phase to decide whether those ports are being used or not.