### PR TITLE
Fail to process healthcheck when network is down

### DIFF
--- a/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/ServiceEventCreate.java
+++ b/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/ServiceEventCreate.java
@@ -1,9 +1,14 @@
 package io.cattle.iaas.healthcheck.process;
 
+import static io.cattle.platform.core.model.tables.ServiceTable.*;
+
 import io.cattle.iaas.healthcheck.service.HealthcheckService;
+import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.constants.HealthcheckConstants;
+import io.cattle.platform.core.constants.ServiceConstants;
 import io.cattle.platform.core.dao.ServiceDao;
 import io.cattle.platform.core.model.HealthcheckInstanceHostMap;
+import io.cattle.platform.core.model.Service;
 import io.cattle.platform.core.model.ServiceEvent;
 import io.cattle.platform.engine.handler.HandlerResult;
 import io.cattle.platform.engine.handler.ProcessHandler;
@@ -12,12 +17,20 @@ import io.cattle.platform.engine.process.ProcessState;
 import io.cattle.platform.process.common.handler.AbstractObjectProcessHandler;
 import io.cattle.platform.util.type.Priority;
 
+import io.github.ibuildthecloud.gdapi.exception.ClientVisibleException;
+import io.github.ibuildthecloud.gdapi.util.ResponseCodes;
+
+import java.util.Arrays;
+import java.util.List;
+
 import javax.inject.Inject;
 import javax.inject.Named;
+
 
 @Named
 public class ServiceEventCreate extends AbstractObjectProcessHandler implements ProcessHandler, Priority {
 
+    private static final List<String> UP_STATES = Arrays.asList(CommonStatesConstants.ACTIVE, CommonStatesConstants.UPDATING_ACTIVE);
     @Inject
     HealthcheckService healthcheckService;
 
@@ -36,6 +49,8 @@ public class ServiceEventCreate extends AbstractObjectProcessHandler implements 
             return null;
         }
 
+
+
         // don't process init event as its being set by cattle on instance restart
         // that is done to avoid the scenario when init state is reported on healthcheck process restart inside the
         // agent happening around the time when instance becomes unheatlhy
@@ -45,6 +60,16 @@ public class ServiceEventCreate extends AbstractObjectProcessHandler implements 
             return null;
         }
 
+        if (isNetworkUp(event.getAccountId())) {
+            processHealthcheck(event);
+        } else {
+            throw new ClientVisibleException(ResponseCodes.CONFLICT);
+        }
+
+        return null;
+    }
+
+    private void processHealthcheck(ServiceEvent event) {
         String[] splitted = event.getHealthcheckUuid().split("_");
         // find host map uuid
         HealthcheckInstanceHostMap hostMap = null;
@@ -61,13 +86,30 @@ public class ServiceEventCreate extends AbstractObjectProcessHandler implements 
             healthcheckService.updateHealthcheck(uuid, event.getExternalTimestamp(),
                     getHealthState(event.getReportedHealth()));
         }
+    }
 
-        return null;
+    private boolean isNetworkUp(long accountId) {
+        Service networkDriverService = objectManager.findAny(Service.class, SERVICE.ACCOUNT_ID, accountId, SERVICE.REMOVED, null, SERVICE.KIND,
+                ServiceConstants.KIND_NETWORK_DRIVER_SERVICE);
+        if (networkDriverService == null) {
+            return true;
+        }
+        if (!UP_STATES.contains(networkDriverService.getState())) {
+            return false;
+        }
+        List<Service> services = objectManager.find(Service.class, SERVICE.ACCOUNT_ID, accountId, SERVICE.REMOVED, null, SERVICE.STACK_ID,
+                networkDriverService.getStackId());
+        for (Service service : services) {
+            if (!UP_STATES.contains(service.getState())) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     protected String getHealthState(String reportedHealth) {
         String healthState = "";
-
 
         if (reportedHealth.equals("UP")) {
             healthState = HealthcheckConstants.HEALTH_STATE_HEALTHY;


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/10217

@cjellick tested by:

* manually changed the state to inactive in the DB for ipsec/networkdriver services
* created new instance with healthcheck enabled. Make sure it is stuck in Init state
* changed the state back to active for the service. Validated that the healthstate update event is resent = instance becomes healthy