### PR TITLE
Fail allocation if cant do scheduler IP scheduling

### DIFF
--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/AllocatorDao.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/AllocatorDao.java
@@ -67,5 +67,5 @@ public interface AllocatorDao {
 
     boolean isScheulderIpsEnabled(long accountId);
 
-    boolean schedulerServiceEnabled(Long accountId);
+    boolean isSchedulerServiceEnabled(Long accountId);
  }

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/AllocatorDao.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/AllocatorDao.java
@@ -64,4 +64,8 @@ public interface AllocatorDao {
     Iterator<AllocationCandidate> iteratorHosts(List<String> orderedHostUuids, List<Long> volumes, QueryOptions options);
 
     void updateInstancePorts(List<Map<String, Object>> dataList);
+
+    boolean isScheulderIpsEnabled(long accountId);
+
+    boolean schedulerServiceEnabled(Long accountId);
  }

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/impl/AllocatorDaoImpl.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/dao/impl/AllocatorDaoImpl.java
@@ -767,7 +767,7 @@ public class AllocatorDaoImpl extends AbstractJooqDao implements AllocatorDao {
     }
 
     @Override
-    public boolean schedulerServiceEnabled(Long accountId) {
+    public boolean isSchedulerServiceEnabled(Long accountId) {
         return create()
                 .select(SERVICE.ID)
                 .from(SERVICE)

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/impl/AllocatorServiceImpl.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/impl/AllocatorServiceImpl.java
@@ -704,14 +704,14 @@ public class AllocatorServiceImpl implements AllocatorService, Named {
     @SuppressWarnings("unchecked")
     private void callExternalSchedulerToReserve(AllocationAttempt attempt, AllocationCandidate candidate) {
         List<Long> agentIds = getAgentResource(attempt.getAccountId(), attempt.getInstances());
-        if (agentIds.isEmpty() && !attempt.getInstances().get(0).getSystem() && allocatorDao.schedulerServiceEnabled(attempt.getAccountId())
+        if (agentIds.isEmpty() && !attempt.getInstances().get(0).getSystem() && allocatorDao.isSchedulerServiceEnabled(attempt.getAccountId())
                 && allocatorDao.isScheulderIpsEnabled(attempt.getAccountId())) {
             List<ResourceRequest> resourceRequests = gatherResourceRequests(attempt.getInstances(), attempt.getVolumes(), null);
             for (ResourceRequest r : resourceRequests) {
                 if (r instanceof PortBindingResourceRequest) {
                     PortBindingResourceRequest pr = (PortBindingResourceRequest)r;
                     for (PortSpec ps : pr.getPortRequests()) {
-                        if (StringUtils.isEmpty(ps.getIpAddress()) || !"0.0.0.0".equals(ps.getIpAddress())) {
+                        if (!"0.0.0.0".equals(ps.getIpAddress())) {
                             throw new FailedToAllocate("Cannot perform IP scheduling because external scheduler is unavailable");
                         }
                     }

--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/impl/AllocatorServiceImpl.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/impl/AllocatorServiceImpl.java
@@ -704,6 +704,21 @@ public class AllocatorServiceImpl implements AllocatorService, Named {
     @SuppressWarnings("unchecked")
     private void callExternalSchedulerToReserve(AllocationAttempt attempt, AllocationCandidate candidate) {
         List<Long> agentIds = getAgentResource(attempt.getAccountId(), attempt.getInstances());
+        if (agentIds.isEmpty() && !attempt.getInstances().get(0).getSystem() && allocatorDao.schedulerServiceEnabled(attempt.getAccountId())
+                && allocatorDao.isScheulderIpsEnabled(attempt.getAccountId())) {
+            List<ResourceRequest> resourceRequests = gatherResourceRequests(attempt.getInstances(), attempt.getVolumes(), null);
+            for (ResourceRequest r : resourceRequests) {
+                if (r instanceof PortBindingResourceRequest) {
+                    PortBindingResourceRequest pr = (PortBindingResourceRequest)r;
+                    for (PortSpec ps : pr.getPortRequests()) {
+                        if (StringUtils.isEmpty(ps.getIpAddress()) || !"0.0.0.0".equals(ps.getIpAddress())) {
+                            throw new FailedToAllocate("Cannot perform IP scheduling because external scheduler is unavailable");
+                        }
+                    }
+                }
+            }
+        }
+
         for (Long agentId : agentIds) {
             EventVO<Map<String, Object>> schedulerEvent = buildEvent(SCHEDULER_RESERVE_EVENT, InstanceConstants.PROCESS_ALLOCATE, attempt.getInstances(),
                     attempt.getVolumes(), agentId);
@@ -1078,6 +1093,9 @@ public class AllocatorServiceImpl implements AllocatorService, Named {
     }
 
     protected String getSchedulerVersion(Long agentId) {
+        if (agentId == null) {
+            return "NotApplicable";
+        }
         Instance instance = agentInstanceDao.getInstanceByAgent(agentId);
         String imageUuid = (String) DataAccessor.fields(instance).withKey(InstanceConstants.FIELD_IMAGE_UUID).get();
         DockerImage img = DockerImage.parse(imageUuid);


### PR DESCRIPTION
Fail allocation if the external scheduler is unavailable and a
user has configured the scheduler IP feature and an allocation
request is created that has a port request that would need the feature
to operate correctly.

Addresses https://github.com/rancher/rancher/issues/10187