### PR TITLE
Drop io.rancher.container.network for managed network mode

### DIFF
--- a/code/iaas/logic-common/src/main/java/io/cattle/platform/network/impl/NetworkServiceImpl.java
+++ b/code/iaas/logic-common/src/main/java/io/cattle/platform/network/impl/NetworkServiceImpl.java
@@ -103,20 +103,21 @@ public class NetworkServiceImpl implements NetworkService {
     public String getNetworkMode(Map<String, Object> instanceData) {
         Map<String, Object> labels = CollectionUtils.toMap(instanceData.get(InstanceConstants.FIELD_LABELS));
         String mode = ObjectUtils.toString(labels.get(SystemLabels.LABEL_CNI_NETWORK));
-
-        if (mode == null && "true".equals(labels.get(SystemLabels.LABEL_RANCHER_NETWORK))) {
-            mode = NetworkConstants.NETWORK_MODE_MANAGED;
-        }
-
-        if (mode == null) {
-            if (instanceData.containsKey(DockerInstanceConstants.FIELD_NETWORK_MODE)) {
-                mode = ObjectUtils.toString(instanceData.get(DockerInstanceConstants.FIELD_NETWORK_MODE));
-            } else {
+        
+        if(mode == null) {
+            String dataMode = ObjectUtils.toString(instanceData.get(DockerInstanceConstants.FIELD_NETWORK_MODE));
+            if (inAllowedModesForManaged(dataMode) && "true".equals(labels.get(SystemLabels.LABEL_RANCHER_NETWORK))) {
                 mode = NetworkConstants.NETWORK_MODE_MANAGED;
+            } else {
+                mode = dataMode;
             }
         }
 
         return mode;
     }
-
+    
+    private boolean inAllowedModesForManaged(String dataMode) {
+        return dataMode==null || dataMode.equals(NetworkConstants.NETWORK_MODE_NONE) 
+        || dataMode.equals(NetworkConstants.NETWORK_MODE_DEFAULT) || dataMode.equals(NetworkConstants.NETWORK_MODE_BRIDGE);
+    }
 }

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/containerevent/ContainerEventCreate.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/containerevent/ContainerEventCreate.java
@@ -21,7 +21,6 @@ import io.cattle.platform.core.dao.NetworkDao;
 import io.cattle.platform.core.model.ContainerEvent;
 import io.cattle.platform.core.model.Host;
 import io.cattle.platform.core.model.Instance;
-import io.cattle.platform.core.util.SystemLabels;
 import io.cattle.platform.engine.handler.HandlerResult;
 import io.cattle.platform.engine.process.ProcessInstance;
 import io.cattle.platform.engine.process.ProcessState;
@@ -228,11 +227,7 @@ public class ContainerEventCreate extends AbstractDefaultProcessHandler {
     }
 
     private void setLabels(Map<String, Object> inspect, Map<String, Object> data, Instance instance) {
-        Map<String, Object> labels = DataAccessor.fieldMap(instance, InstanceConstants.FIELD_LABELS);
-        if ("true".equals(labels.get(SystemLabels.LABEL_RANCHER_NETWORK))) {
-            labels.put(SystemLabels.LABEL_CNI_NETWORK, NetworkConstants.NETWORK_MODE_MANAGED);
-        }
-        labels.putAll(getLabels(inspect, data));
+        Map<String, Object> labels = getLabels(inspect, data);
         DataAccessor.setField(instance, InstanceConstants.FIELD_LABELS, labels);
     }
 

--- a/tests/integration-v1/cattletest/core/test_container.py
+++ b/tests/integration-v1/cattletest/core/test_container.py
@@ -169,7 +169,7 @@ def test_container_special_labels(client, context):
 
     assert container.state == 'stopped'
     assert container.name == 'from-label'
-    assert container.networkMode == 'managed'
+    assert container.networkMode == 'none'
 
 
 def test_container_create_then_start(super_client, client, context):

--- a/tests/integration-v1/cattletest/core/test_container_event.py
+++ b/tests/integration-v1/cattletest/core/test_container_event.py
@@ -275,6 +275,7 @@ def test_requested_ip_address_with_managed(super_client, client, host,
     container = super_client.reload(container)
     assert container['data']['fields']['requestedIpAddress'] == '10.42.0.240'
     assert container.nics()[0].network().kind == 'network'
+    assert container.networkMode == 'managed'
     assert container.primaryIpAddress == '10.42.0.240'
 
 

--- a/tests/integration/cattletest/core/test_container.py
+++ b/tests/integration/cattletest/core/test_container.py
@@ -170,7 +170,7 @@ def test_container_special_labels(client, context):
 
     assert container.state == 'stopped'
     assert container.name == 'from-label'
-    assert container.networkMode == 'managed'
+    assert container.networkMode == 'none'
 
 
 def test_container_create_then_start(super_client, client, context):

--- a/tests/integration/cattletest/core/test_container_event.py
+++ b/tests/integration/cattletest/core/test_container_event.py
@@ -275,6 +275,7 @@ def test_requested_ip_address_with_managed(super_client, client, host,
     container = super_client.reload(container)
     assert container['data']['fields']['requestedIpAddress'] == '10.42.0.240'
     assert container.nics()[0].network().kind == 'network'
+    assert container.networkMode == 'managed'
     assert container.primaryIpAddress == '10.42.0.240'
 
 


### PR DESCRIPTION
This PR - 
1) drops io.rancher.container.network label for non-native containers and native containers with --net=host or --net=container. 
2) Assigns managed network mode to native containers only if the label is set and --net is default or none. 
