### PR TITLE
Trim label key and value during comparison

### DIFF
--- a/code/iaas/labels/src/main/java/io/cattle/iaas/labels/service/impl/LabelsServiceImpl.java
+++ b/code/iaas/labels/src/main/java/io/cattle/iaas/labels/service/impl/LabelsServiceImpl.java
@@ -40,7 +40,7 @@ public class LabelsServiceImpl implements LabelsService {
         // DB query ignores leading/trailing whitesapce, so we need to check that keys and values are truly equal
         Label label = null;
         for (Label l : labels) {
-            if (StringUtils.equals(key, l.getKey()) && StringUtils.equals(value, l.getValue())) {
+            if (StringUtils.equals(StringUtils.trim(key), l.getKey()) && StringUtils.equals(StringUtils.trim(value), l.getValue())) {
                 label = l;
                 break;
             }


### PR DESCRIPTION
This addresses a bug where if a label.value with a trailing space already
exists (because it was added by a previous host), adding a new host
with the same label.key and label.value with a trailing space, the
label with the trailing space would be used.