### PR TITLE
Add Env admin generic object Resource

### DIFF
--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/genericobject/EnvAdminGenericObjectFilter.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/genericobject/EnvAdminGenericObjectFilter.java
@@ -1,0 +1,123 @@
+package io.cattle.platform.iaas.api.filter.genericobject;
+
+import io.cattle.platform.core.constants.GenericObjectConstants;
+import io.cattle.platform.core.model.tables.records.GenericObjectRecord;
+import io.cattle.platform.iaas.api.filter.common.AbstractDefaultResourceManagerFilter;
+import io.cattle.platform.object.meta.ObjectMetaDataManager;
+import io.cattle.platform.util.type.CollectionUtils;
+import io.github.ibuildthecloud.gdapi.condition.Condition;
+import io.github.ibuildthecloud.gdapi.condition.ConditionType;
+import io.github.ibuildthecloud.gdapi.model.ListOptions;
+import io.github.ibuildthecloud.gdapi.request.ApiRequest;
+import io.github.ibuildthecloud.gdapi.request.resource.ResourceManager;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class EnvAdminGenericObjectFilter extends AbstractDefaultResourceManagerFilter {
+
+    @Override
+    public String[] getTypes() {
+        return new String[] {"genericObject"};
+    }
+
+    private Map<Object, Object> setfilterEnvAdminCondition(Map<Object, Object> criteria) {
+        if (criteria == null) {
+            criteria = new LinkedHashMap<Object, Object>();
+        }
+        Condition notEnvAdminGenericObjectCondition = new Condition(ConditionType.NE, GenericObjectConstants.ENV_ADMIN_TYPE);
+
+        Object key = ObjectMetaDataManager.KIND_FIELD;
+        Object value = Arrays.asList(notEnvAdminGenericObjectCondition);
+        Object existing = criteria.get(key);
+
+        if (existing instanceof List) {
+            List<Object> newCondition = new ArrayList<Object>();
+            newCondition.add(value);
+            newCondition.addAll((List<?>)existing);
+            criteria.put(key, newCondition);
+        } else if (existing == null) {
+            criteria.put(key, value);
+        } else {
+            criteria.put(key, Arrays.asList(value, existing));
+        }
+        return criteria;
+    }
+
+    private boolean isEnvAdminGenericObject(String type, String id, ApiRequest request, ResourceManager next) {
+        Object obj = next.getById(type, id, new ListOptions(request));
+        if(obj != null && obj instanceof GenericObjectRecord){
+            if(GenericObjectConstants.ENV_ADMIN_TYPE.equals(((GenericObjectRecord)obj).getKind())){
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Object getById(String type, String id, ListOptions options, ResourceManager next) {
+        Object obj = next.getById(type, id, options);
+        if(obj != null && obj instanceof GenericObjectRecord){
+            if(GenericObjectConstants.ENV_ADMIN_TYPE.equals(((GenericObjectRecord)obj).getKind())){
+                return null;
+            }
+        }
+        return obj;
+    }
+
+    @Override
+    public Object getLink(String type, String id, String link, ApiRequest request, ResourceManager next) {
+        if(isEnvAdminGenericObject(type, id, request, next)){
+            return null;
+        }
+        return next.getLink(type, id, link, request);
+    }
+
+    @Override
+    public Object list(String type, ApiRequest request, ResourceManager next) {
+        Map<Object, Object> criteria = setfilterEnvAdminCondition(new LinkedHashMap<Object, Object>(request.getConditions()));
+        return next.list(type, criteria, new ListOptions(request));
+    }
+
+    @Override
+    public List<?> list(String type, Map<Object, Object> criteria, ListOptions options, ResourceManager next) {
+        return next.list(type, setfilterEnvAdminCondition(criteria), options);
+    }
+
+    @Override
+    public Object create(String type, ApiRequest request, ResourceManager next) {
+        Map<Object, Object> properties = CollectionUtils.toMap(request.getRequestObject());
+        if(GenericObjectConstants.ENV_ADMIN_TYPE.equals(properties.get(ObjectMetaDataManager.KIND_FIELD))){
+            return null;
+        }
+        return next.create(type, request);
+    }
+
+    @Override
+    public Object update(String type, String id, ApiRequest request, ResourceManager next) {
+        if(isEnvAdminGenericObject(type, id, request, next)){
+            return null;
+        }
+        return next.update(type, id, request);
+    }
+
+    @Override
+    public Object delete(String type, String id, ApiRequest request, ResourceManager next) {
+        if(isEnvAdminGenericObject(type, id, request, next)){
+            return null;
+        }
+        return next.delete(type, id, request);
+    }
+
+    @Override
+    public Object resourceAction(String type, ApiRequest request, ResourceManager next) {
+        if(isEnvAdminGenericObject(type, request.getId(), request, next)){
+            return null;
+        }
+        return next.resourceAction(type, request);
+    }
+
+}

--- a/code/iaas/model/src/main/java/io/cattle/platform/core/constants/GenericObjectConstants.java
+++ b/code/iaas/model/src/main/java/io/cattle/platform/core/constants/GenericObjectConstants.java
@@ -8,4 +8,6 @@ public class GenericObjectConstants {
 
     public static final String PROCESS_CREATE = "genericobject.create";
 
+    public static final String ENV_ADMIN_TYPE = "envAdminGenericObject";
+
 }

--- a/code/packaging/app-config/src/main/java/io/cattle/platform/app/CoreModelConfig.java
+++ b/code/packaging/app-config/src/main/java/io/cattle/platform/app/CoreModelConfig.java
@@ -129,6 +129,7 @@ public class CoreModelConfig {
                 "launchConfig,parent=container",
                 "secondaryLaunchConfig,parent=launchConfig",
                 "pullTask,parent=genericObject",
+                "envAdminGenericObject,parent=genericObject",
                 "externalVolumeEvent,parent=externalEvent",
                 "externalStoragePoolEvent,parent=externalEvent",
                 "externalServiceEvent,parent=externalEvent",

--- a/code/packaging/app-config/src/main/java/io/cattle/platform/app/IaasApiConfig.java
+++ b/code/packaging/app-config/src/main/java/io/cattle/platform/app/IaasApiConfig.java
@@ -68,6 +68,7 @@ import io.cattle.platform.iaas.api.filter.compat.CompatibilityOutputFilter;
 import io.cattle.platform.iaas.api.filter.containerevent.ContainerEventFilter;
 import io.cattle.platform.iaas.api.filter.dynamic.schema.DynamicSchemaFilter;
 import io.cattle.platform.iaas.api.filter.externalevent.ExternalEventFilter;
+import io.cattle.platform.iaas.api.filter.genericobject.EnvAdminGenericObjectFilter;
 import io.cattle.platform.iaas.api.filter.hosts.HostsFilter;
 import io.cattle.platform.iaas.api.filter.instance.InstanceImageValidationFilter;
 import io.cattle.platform.iaas.api.filter.instance.InstanceOutputFilter;
@@ -429,6 +430,11 @@ public class IaasApiConfig {
     @Bean
     DynamicSchemaFilter DynamicSchemaFilter() {
         return new DynamicSchemaFilter();
+    }
+
+    @Bean
+    EnvAdminGenericObjectFilter EnvAdminGenericObjectFilter() {
+        return new EnvAdminGenericObjectFilter();
     }
 
     @Bean

--- a/resources/content/schema/projectadmin/projectadmin-auth.json
+++ b/resources/content/schema/projectadmin/projectadmin-auth.json
@@ -5,6 +5,8 @@
         "service.resourceActions.certificate": "c",
         "registryCredential.secretValue": "cur",
         "certificate.key": "cur",
+        "envAdminGenericObject" : "crud",
+        "envAdminGenericObject.kind" : "r",
         "end" : ""
     }
 }


### PR DESCRIPTION
Regarding: https://github.com/rancher/rancher/issues/10303
Added an envAdminGenericObject resource type which is only accessible by env admin role. It is stored in generic_object table with kind=envAdminGenericObject. EnvAdminGenericObject use generic object as the parent. 

To avoid operating envAdminGenericObject via generic object API, a generic object resource manager filter is added(This is because resource data is available from parent type, e.g. given "container,parent=instance", you can get container data in instance API). To avoid database changes and reuse current DB table, `kind=envAdminGenericObject` is used to differentiate envAdminGO & GO.

@cjellick @yasker 