### PR TITLE
Fix Hazelcast message amplification 

### DIFF
--- a/code/implementation/hazelcast/eventing/src/main/java/io/cattle/platform/hazelcast/eventing/HazelcastEventService.java
+++ b/code/implementation/hazelcast/eventing/src/main/java/io/cattle/platform/hazelcast/eventing/HazelcastEventService.java
@@ -5,12 +5,15 @@ import io.cattle.platform.eventing.model.Event;
 import io.cattle.platform.util.type.Named;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.cloudstack.managed.context.NoExceptionRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,26 +22,43 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ITopic;
 import com.hazelcast.core.Message;
 import com.hazelcast.core.MessageListener;
+import com.hazelcast.spi.AbstractDistributedObject;
+import com.hazelcast.spi.EventService;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.topic.impl.TopicService;
 
 public class HazelcastEventService extends AbstractThreadPoolingEventService implements Named {
 
     private static final Logger log = LoggerFactory.getLogger(HazelcastEventService.class);
+    private static final long DELETE_INTERVAL = 15L;
+    private static final int DELETE_COUNT = 3;
 
+    ScheduledExecutorService scheduledExecutorService;
     HazelcastInstance hazelcast;
-    Map<String, String> registrations = new ConcurrentHashMap<String, String>();
+    Map<String, String> registrations = new ConcurrentHashMap<>();
+    Map<String, Integer> toDelete = new ConcurrentHashMap<>();
+
+    @Override
+    public void init() {
+        super.init();
+        scheduledExecutorService.scheduleWithFixedDelay(new NoExceptionRunnable() {
+            @Override
+            protected void doRun() throws Exception {
+                processDeletes();
+            }
+        }, DELETE_INTERVAL, DELETE_INTERVAL, TimeUnit.SECONDS);
+    }
 
     @Override
     protected boolean doPublish(String name, Event event, String eventString) throws IOException {
-        TopicName topicName = new TopicName(name);
-        ITopic<String> topic = hazelcast.getTopic(topicName.getName());
-        topic.publish(topicName.encode(eventString));
+        ITopic<String> topic = hazelcast.getTopic(name);
+        topic.publish(eventString);
 
         return true;
     }
 
     @Override
     protected synchronized void doSubscribe(final String eventName, SettableFuture<?> future) {
-        TopicName topicName = new TopicName(eventName);
         boolean success = false;
         Throwable t = null;
         try {
@@ -46,11 +66,11 @@ public class HazelcastEventService extends AbstractThreadPoolingEventService imp
                 throw new IllegalStateException("Already subscribed to [" + eventName + "]");
             }
 
-            ITopic<String> topic = hazelcast.getTopic(topicName.getName());
+            ITopic<String> topic = hazelcast.getTopic(eventName);
             MessageListener<String> listener = new MessageListener<String>() {
                 @Override
                 public void onMessage(Message<String> message) {
-                    String eventString = topicName.decode(message.getMessageObject());
+                    String eventString = message.getMessageObject();
                     if (eventString != null) {
                         onEvent(null, eventName, eventString);
                     }
@@ -78,17 +98,52 @@ public class HazelcastEventService extends AbstractThreadPoolingEventService imp
         }
     }
 
+    protected synchronized void processDeletes() {
+        Map<String, Integer> newToDelete = new HashMap<>();
+
+        for (Map.Entry<String, Integer> entry : toDelete.entrySet()) {
+            String topicName = entry.getKey();
+            int count = entry.getValue();
+            if (registrations.containsKey(topicName)) {
+                continue;
+            }
+
+            ITopic<String> topic = hazelcast.getTopic(topicName);
+            if (!(topic instanceof AbstractDistributedObject)) {
+                continue;
+            }
+
+            NodeEngine engine = ((AbstractDistributedObject<?>)topic).getNodeEngine();
+            EventService eventService = engine.getEventService();
+            if (eventService.getRegistrations(TopicService.SERVICE_NAME, topicName).size() != 0) {
+                continue;
+            }
+
+            count++;
+            if (count > DELETE_COUNT) {
+                log.info("Removing hazelcast topic [{}]", topicName);
+                try {
+                    topic.destroy();
+                } catch (Throwable t) {
+                   // Ignore
+                }
+            } else {
+                newToDelete.put(topicName, count);
+            }
+        }
+
+        toDelete = newToDelete;
+    }
+
     @Override
     protected synchronized void doUnsubscribe(String eventName) {
         String id = registrations.remove(eventName);
         log.info("Unsubscribing from [{}] id [{}]", eventName, id);
 
         if (id != null) {
-            ITopic<String> topic = hazelcast.getTopic(new TopicName(eventName).getName());
+            ITopic<String> topic = hazelcast.getTopic(eventName);
             topic.removeMessageListener(id);
-            if (eventName.startsWith("reply.")) {
-                topic.destroy();
-            }
+            toDelete.put(eventName, 0);
         }
     }
 
@@ -110,36 +165,12 @@ public class HazelcastEventService extends AbstractThreadPoolingEventService imp
         return "EventService";
     }
 
-    private static class TopicName {
-        String name;
-        String qualifier;
+    public ScheduledExecutorService getScheduledExecutorService() {
+        return scheduledExecutorService;
+    }
 
-        public TopicName(String topic) {
-            String[] parts = StringUtils.split(topic, ";", 2);
-            this.name = parts[0];
-            if (parts.length > 1) {
-                this.qualifier = parts[1] + ":";
-                this.name += ";";
-            }
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public String encode(String eventString) {
-            return qualifier == null ? eventString : qualifier + eventString;
-        }
-
-        public String decode(String eventString) {
-            if (qualifier == null) {
-                return eventString;
-            }
-            if (eventString.startsWith(this.qualifier)) {
-                return eventString.substring(this.qualifier.length());
-            }
-            return null;
-        }
+    public void setScheduledExecutorService(ScheduledExecutorService scheduledExecutorService) {
+        this.scheduledExecutorService = scheduledExecutorService;
     }
 
 }

--- a/code/packaging/app-config/src/main/java/io/cattle/platform/app/HzEventingConfig.java
+++ b/code/packaging/app-config/src/main/java/io/cattle/platform/app/HzEventingConfig.java
@@ -3,6 +3,7 @@ package io.cattle.platform.app;
 import io.cattle.platform.hazelcast.eventing.HazelcastEventService;
 
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -14,9 +15,10 @@ import org.springframework.context.annotation.Profile;
 public class HzEventingConfig {
 
     @Bean
-    HazelcastEventService EventService(@Qualifier("CoreExecutorService") ExecutorService es) {
+    HazelcastEventService EventService(@Qualifier("CoreExecutorService") ExecutorService es, ScheduledExecutorService ses) {
         HazelcastEventService service = new HazelcastEventService();
         service.setExecutorService(es);
+        service.setScheduledExecutorService(ses);
         return service;
     }
 


### PR DESCRIPTION
Cattle will create topics such as "ping;agent=4" on demand per agent.  The
approach taken previously was to create one topic named "ping;" and then
multiplex all "ping;*" messages over the same topic.  This kept down the
number of topics we create, but also avoided the need to have some type
of GC logic of deleting topics.

If two topics, "ping;agent=1" and "ping;agent=2" were needed then one
topic "ping;" was created with two subscriptions.  The subscribers would
then check the message key if it matched "agent=1" or "agent=2".

Unfortunately this approach has some fairly bad side effects in
Hazelcast which has lead to a fairly large amplification of traffic.
What has been often seen is if you X bytes flowing over port 8080, you'd
have 10X flowing over port 9345.

The reason for this is that when one publishes to a topic there is one
message sent per subscriber, not one per node that has a subscriber.
The later was assumed to be the behavior.  For example, if node A
published a message to a topic that has 10 subscribers on node B, node B
will get 10 messages across the wire.  Not one message for node B that
is then seen by the 10 subscribers.

Topics are used quite a bit in Cattle but one distinct example is
pinging nodes.  One topic per node (which is described as an agent in
the system) is created.  If one had 100 nodes, in the previous code, 1
topic is created with 100 subscriptions.  Every 15 seconds an agent is
pinged.  100 nodes would translate to 100 published messages every 15
seconds.  Given an HA setup with worst case distribution you would
expect 100 messages across the wire every 15 seconds. Unfortunately,
due to how Hazelcast works it is actually N^2 every 15 seconds, so 10000
messages.

To fix this issue we no longer multiplex messages across topics and
create one topic per full name, thus reducing the subscription count.
This does mean we dynamically create and delete topics now.  GC logic
has been added such that a topic with 0 subscription for 15 seconds will
be deleted.  If that topic is needed later it will be created again.