### PR TITLE
Include service to exposeMap for instance

### DIFF
--- a/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/dao/ServiceExposeMapDao.java
+++ b/code/iaas/service-discovery/api/src/main/java/io/cattle/platform/servicediscovery/api/dao/ServiceExposeMapDao.java
@@ -26,7 +26,7 @@ public interface ServiceExposeMapDao {
 
     List<? extends Instance> listServiceManagedInstances(Service service, String launchConfigName);
 
-    ServiceExposeMap findInstanceExposeMap(Instance instance);
+    ServiceExposeMap findInstanceExposeMap(Instance instance, Service service);
 
     ServiceExposeMap createServiceInstanceMap(Service service, Instance instance, boolean managed);
 

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/dao/impl/ServiceExposeMapDaoImpl.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/dao/impl/ServiceExposeMapDaoImpl.java
@@ -201,18 +201,20 @@ public class ServiceExposeMapDaoImpl extends AbstractJooqDao implements ServiceE
     }
 
     @Override
-    public ServiceExposeMap findInstanceExposeMap(Instance instance) {
+    public ServiceExposeMap findInstanceExposeMap(Instance instance, Service service) {
         if (instance == null) {
             return null;
         }
-        List<? extends ServiceExposeMap> instanceServiceMap = mapDao.findNonRemoved(ServiceExposeMap.class,
+        List<? extends ServiceExposeMap> maps = mapDao.findNonRemoved(ServiceExposeMap.class,
                 Instance.class,
                 instance.getId());
-        if (instanceServiceMap.isEmpty()) {
-            // not a service instance
-            return null;
+
+        for (ServiceExposeMap entry : maps) {
+            if (entry.getServiceId().equals(service.getId())) {
+                return entry;
+            }
         }
-        return instanceServiceMap.get(0);
+        return null;
     }
 
     @Override

--- a/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/DefaultDeploymentUnitInstance.java
+++ b/code/iaas/service-discovery/server/src/main/java/io/cattle/platform/servicediscovery/deployment/impl/unit/DefaultDeploymentUnitInstance.java
@@ -64,7 +64,7 @@ public class DefaultDeploymentUnitInstance extends DeploymentUnitInstance implem
         this.instanceName = instanceName;
         this.instance = instance;
         if (this.instance != null) {
-            exposeMap = context.exposeMapDao.findInstanceExposeMap(this.instance);
+            exposeMap = context.exposeMapDao.findInstanceExposeMap(this.instance, service);
             Long svcIndexId = instance.getServiceIndexId();
             if (svcIndexId != null) {
                 serviceIndex = context.objectManager


### PR DESCRIPTION
Noticed this bug while debugging some issue around selectors. Basically when instance is both managed by service1 and attached to service2 using selector, there are chances that incorrect serviceExposeMap would be picked for it by DeploymentUnitInstance