### PR TITLE
Health check fixes

### DIFF
--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/serviceevent/ServiceEventFilter.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/filter/serviceevent/ServiceEventFilter.java
@@ -5,7 +5,6 @@ import io.cattle.platform.api.auth.Policy;
 import io.cattle.platform.api.utils.ApiUtils;
 import io.cattle.platform.core.constants.AgentConstants;
 import io.cattle.platform.core.constants.CommonStatesConstants;
-import io.cattle.platform.core.constants.HealthcheckConstants;
 import io.cattle.platform.core.constants.ServiceConstants;
 import io.cattle.platform.core.dao.AgentDao;
 import io.cattle.platform.core.dao.ServiceDao;
@@ -33,6 +32,13 @@ import javax.inject.Inject;
 public class ServiceEventFilter extends AbstractDefaultResourceManagerFilter {
 
     private static List<String> invalidStates = Arrays.asList(CommonStatesConstants.REMOVED, CommonStatesConstants.REMOVING);
+    private static List<String> upgradingStates = Arrays.asList(
+            ServiceConstants.STATE_UPGRADING,
+            ServiceConstants.STATE_UPGRADED,
+            ServiceConstants.STATE_ROLLINGBACK,
+            ServiceConstants.STATE_CANCELING_UPGRADE,
+            ServiceConstants.STATE_CANCELED_UPGRADE,
+            ServiceConstants.STATE_FINISHING_UPGRADE);
     public static final String VERIFY_AGENT = "CantVerifyHealthcheck";
 
     @Inject
@@ -99,7 +105,7 @@ public class ServiceEventFilter extends AbstractDefaultResourceManagerFilter {
             throw new ClientVisibleException(ResponseCodes.FORBIDDEN, VERIFY_AGENT);
         }
         if(!isNetworkStack(resourceAccId, healthcheckInstance.getInstanceId())) {
-            if (!isNetworkUp(resourceAccId)) {
+            if (event.getReportedHealth().startsWith("DOWN") && isNetworkUpgrading(resourceAccId)) {
                 throw new ClientVisibleException(ResponseCodes.CONFLICT);
             }
         }
@@ -111,7 +117,7 @@ public class ServiceEventFilter extends AbstractDefaultResourceManagerFilter {
         return super.create(type, request, next);
     }
 
-    private boolean isNetworkUp(long accountId) {
+    private boolean isNetworkUpgrading(long accountId) {
             Service networkDriverService = null;
         List<Service> networkDriverServices = objectManager.find(Service.class, SERVICE.ACCOUNT_ID, accountId, SERVICE.REMOVED, null, SERVICE.KIND,
                 ServiceConstants.KIND_NETWORK_DRIVER_SERVICE);
@@ -122,16 +128,16 @@ public class ServiceEventFilter extends AbstractDefaultResourceManagerFilter {
                 networkDriverService = service;
         }
         if (networkDriverService == null) {
-            return true;
+            return false;
         }
         List<Service> services = objectManager.find(Service.class, SERVICE.ACCOUNT_ID, accountId, SERVICE.REMOVED, null, SERVICE.STACK_ID,
                 networkDriverService.getStackId());
         for (Service service : services) {
-            if (!(service.getState().equals(CommonStatesConstants.ACTIVE) && service.getHealthState().equals(HealthcheckConstants.HEALTH_STATE_HEALTHY))) {
-                return false;
+            if (upgradingStates.contains(service.getState())) {
+                return true;
             }
         }
-        return true;
+        return false;
     }
 
     private boolean isNetworkStack(long accountId, long instanceId) {

--- a/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/ServiceEventCreate.java
+++ b/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/process/ServiceEventCreate.java
@@ -1,7 +1,5 @@
 package io.cattle.iaas.healthcheck.process;
 
-import static io.cattle.platform.core.model.tables.ServiceTable.*;
-
 import io.cattle.iaas.healthcheck.service.HealthcheckService;
 import io.cattle.platform.core.constants.HealthcheckConstants;
 import io.cattle.platform.core.dao.ServiceDao;

--- a/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/service/impl/HealthcheckCleanupMonitorImpl.java
+++ b/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/service/impl/HealthcheckCleanupMonitorImpl.java
@@ -3,6 +3,7 @@ package io.cattle.iaas.healthcheck.service.impl;
 import static io.cattle.platform.core.model.tables.HealthcheckInstanceTable.HEALTHCHECK_INSTANCE;
 import static io.cattle.platform.core.model.tables.InstanceTable.INSTANCE;
 import io.cattle.platform.core.addon.InstanceHealthCheck;
+import io.cattle.platform.core.addon.InstanceHealthCheck.Strategy;
 import io.cattle.platform.core.constants.CommonStatesConstants;
 import io.cattle.platform.core.constants.HealthcheckConstants;
 import io.cattle.platform.core.constants.InstanceConstants;
@@ -76,6 +77,9 @@ public class HealthcheckCleanupMonitorImpl extends AbstractJooqDao implements Ta
         boolean remove = false;
         InstanceHealthCheck healthCheck = DataAccessor.field(instance,
                 InstanceConstants.FIELD_HEALTH_CHECK, jsonMapper, InstanceHealthCheck.class);
+        if(healthCheck.getStrategy() == Strategy.none) {
+                return remove;
+        }
         Integer timeout;
         if (instance.getHealthState().equalsIgnoreCase(HealthcheckConstants.HEALTH_STATE_INITIALIZING)) {
             timeout = healthCheck.getInitializingTimeout();

--- a/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/service/impl/HealthcheckServiceImpl.java
+++ b/code/iaas/healthcheck/src/main/java/io/cattle/iaas/healthcheck/service/impl/HealthcheckServiceImpl.java
@@ -297,21 +297,23 @@ public class HealthcheckServiceImpl implements HealthcheckService {
         availableActiveHostIds.removeAll(allocatedActiveHostIds);
         requiredNumber = requiredNumber - allocatedActiveHostIds.size();
         Collections.shuffle(availableActiveHostIds);
-
+   
         // place inferiorHostId to the end of the list
         if (inferiorHostId != null) {
-            if (availableActiveHostIds.contains(inferiorHostId)) {
-                availableActiveHostIds.remove(inferiorHostId);
-                if (availableActiveHostIds.isEmpty() && allocatedActiveHostIds.isEmpty()) {
+                if (availableActiveHostIds.contains(inferiorHostId)) {
+                    availableActiveHostIds.remove(inferiorHostId);
+                }
+                if(!allocatedActiveHostIds.contains(inferiorHostId)) {
                     availableActiveHostIds.add(inferiorHostId);
                 }
-            }
         }
 
         // Figure out the final number of hosts
         int returnedNumber = requiredNumber > availableActiveHostIds.size() ? availableActiveHostIds.size() : requiredNumber;
-
-        return availableActiveHostIds.subList(0, returnedNumber);
+        
+        // always include inferiorHostId
+        int start_index = availableActiveHostIds.size() - returnedNumber; 
+        return availableActiveHostIds.subList(start_index, availableActiveHostIds.size());
     }
 
     private Long getInstanceHostId(HealthcheckInstanceType type, long instanceId) {


### PR DESCRIPTION
- drop healthcheck only when service event starts with down and network stack is upgrading
- ignore instances having healthcheck noop for cleanup
- always include the host where instance is deployed in the healthcheckers 

https://github.com/rancher/rancher/issues/13398 
