### PR TITLE
Add more logging around websocket subscriptions

### DIFF
--- a/code/framework/api-pub-sub-jetty/src/main/java/io/cattle/platform/api/pubsub/subscribe/jetty/JettyWebSocketSubcriptionHandler.java
+++ b/code/framework/api-pub-sub-jetty/src/main/java/io/cattle/platform/api/pubsub/subscribe/jetty/JettyWebSocketSubcriptionHandler.java
@@ -1,7 +1,12 @@
 package io.cattle.platform.api.pubsub.subscribe.jetty;
 
+import io.cattle.platform.api.auth.Policy;
 import io.cattle.platform.api.pubsub.subscribe.MessageWriter;
 import io.cattle.platform.api.pubsub.subscribe.NonBlockingSubscriptionHandler;
+import io.cattle.platform.api.pubsub.util.SubscriptionUtils;
+import io.cattle.platform.api.pubsub.util.SubscriptionUtils.SubscriptionStyle;
+import io.cattle.platform.api.utils.ApiUtils;
+import io.cattle.platform.iaas.event.IaasEvents;
 import io.github.ibuildthecloud.gdapi.request.ApiRequest;
 
 import java.io.IOException;
@@ -9,6 +14,7 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jetty.websocket.server.WebSocketServerFactory;
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
@@ -20,7 +26,17 @@ public class JettyWebSocketSubcriptionHandler extends NonBlockingSubscriptionHan
     protected MessageWriter getMessageWriter(ApiRequest apiRequest) throws IOException {
         HttpServletRequest req = apiRequest.getServletContext().getRequest();
         HttpServletResponse resp = apiRequest.getServletContext().getResponse();
-        final WebSocketMessageWriter messageWriter = new WebSocketMessageWriter();
+        Policy policy = ApiUtils.getPolicy();
+        String identifier = null;
+        SubscriptionStyle style = SubscriptionUtils.getSubscriptionStyle(policy);
+        if (SubscriptionStyle.QUALIFIED.equals(style)) {
+            String key = SubscriptionUtils.getSubscriptionQualifier(policy);
+            String value = SubscriptionUtils.getSubscriptionQualifierValue(policy);
+            if (IaasEvents.AGENT_QUALIFIER.equals(key) && StringUtils.isNotEmpty(value)) {
+                identifier = String.format("%s [%s]", key, value);
+            }
+        }
+        final WebSocketMessageWriter messageWriter = new WebSocketMessageWriter(identifier);
         WebSocketServerFactory factory = new WebSocketServerFactory();
         factory.getPolicy().setAsyncWriteTimeout(1000);
         factory.setCreator(new WebSocketCreator() {

--- a/code/framework/api-pub-sub-jetty/src/main/java/io/cattle/platform/api/pubsub/subscribe/jetty/WebSocketMessageWriter.java
+++ b/code/framework/api-pub-sub-jetty/src/main/java/io/cattle/platform/api/pubsub/subscribe/jetty/WebSocketMessageWriter.java
@@ -25,6 +25,15 @@ public class WebSocketMessageWriter extends WebSocketAdapter implements MessageW
     private boolean connectionClosed = false;
     private AtomicInteger queuedMessageCount = new AtomicInteger();
 
+    private String identifier;
+
+    public WebSocketMessageWriter(String identifier) {
+        this.identifier = identifier;
+        if (identifier != null) {
+            log.info("Creating websocket message writer for {}", identifier);
+        }
+    }
+
     @Override
     public void onWebSocketConnect(Session session) {
         this.session = session;
@@ -33,7 +42,18 @@ public class WebSocketMessageWriter extends WebSocketAdapter implements MessageW
     @Override
     public void onWebSocketClose(int closeCode, String message) {
         connectionClosed = true;
-        log.debug("Websocket connection closed. Code: [{}], message: [{}].", closeCode, message);
+        if (identifier != null) {
+            log.info("Websocket connection closed for {}. Code: [{}], message: [{}].", identifier, closeCode, message);
+        } else {
+            log.debug("Websocket connection closed. Code: [{}], message: [{}].", closeCode, message);
+        }
+    }
+
+    @Override
+    public void onWebSocketError(Throwable cause) {
+        if (identifier != null) {
+            log.warn("Unexpected websocket error for {}", identifier);
+        }
     }
 
     @Override


### PR DESCRIPTION
This introduces two logging changes:
1. Add the host id to the error that we log when  an agent misses the maximum number of pings and we log that we are scheduling a reconnect
2. When a webscocket connection is made for subscribing to events, If that subscription is **for an agent** (as opposed to a user in the UI), log more details about connects, disconnects, and errors. Sepcifically:
    - log when the connection is made and the agent for which it was made
    - log when the connection is closde and the agent for which it was made
    - if an abnormal exception is encountered, log it and the corresponding agent. I say "abnormal" exception because the websocket library we groups exceptions into two types. Some are "normal" and handle by the library. These include the connection being closed. Others are abnormal and the library provides a hook for doing something when they are encountered.
