### PR TITLE
Add setting to control restricted user exec

### DIFF
--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/iaas-api/defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/iaas-api/defaults.properties
@@ -84,3 +84,4 @@ project.create.default=true
 project.set.member.roles=owner
 
 modify.infrastructure.roles=superadmin,admin,service,owner,member,project,environment,projectadmin,agent,v1-superadmin,v1-admin,v1-service,v1-owner,v1-member,v1-project,v1-environment,v1-projectadmin,v1-agent
+allow.restricted.user.exec=false


### PR DESCRIPTION
We currently prevent restricted users from execing into privileged containers
or ones that have capAdd set to any non-empty value. This change adds a setting
that can be used to disable that functionality.