### PR TITLE
Make Azure admin credential fields optional

### DIFF
--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/azure/AzureConfig.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/azure/AzureConfig.java
@@ -11,6 +11,7 @@ public class AzureConfig {
     private String clientId;
     private String accessMode;  
     private String domain;  
+    //Admin credential fields are not really used for any functionality by Azure provider, keeping it as 'optional'
     private String adminAccountUsername;
     private String adminAccountPassword;
 
@@ -54,14 +55,15 @@ public class AzureConfig {
         return domain;
     }   
     
-    @Field(nullable = true, required = true, minLength = 1)
+    //this field is not really used for any functionality by Azure provider, keeping it as 'optional'
+    @Field(nullable = true, required = false, minLength = 1)
     public String getAdminAccountUsername() {
         return adminAccountUsername;
     }
-
-    @Field(nullable = true, required = true, minLength = 1)
+    //this field is not really used for any functionality by Azure provider, keeping it as 'optional'
+    @Field(nullable = true, required = false, minLength = 1)
     public String getAdminAccountPassword() {
         return adminAccountPassword;
-    }    
+    }
 
 }


### PR DESCRIPTION
Making Azure Admin username/password optional, since these fields are really not required for any functionality.

https://github.com/rancher/rancher/issues/11614