### PR TITLE
add lock even when volume is active and detached

### DIFF
--- a/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/impl/AllocatorServiceImpl.java
+++ b/code/iaas/allocator/src/main/java/io/cattle/platform/allocator/service/impl/AllocatorServiceImpl.java
@@ -368,7 +368,7 @@ public class AllocatorServiceImpl implements AllocatorService, Named {
             if (driver != null) {
                 String accessMode = DataAccessor.fieldString(driver, StorageDriverConstants.FIELD_VOLUME_ACCESS_MODE);
                 if (VolumeConstants.ACCESS_MODE_SINGLE_HOST_RW.equals(accessMode) || VolumeConstants.ACCESS_MODE_SINGLE_INSTANCE_RW.equals(accessMode)) {
-                    if (!CommonStatesConstants.ACTIVE.equals(volume.getAllocationState())) {
+                    if (!CommonStatesConstants.ACTIVE.equals(volume.getAllocationState()) || VolumeConstants.STATE_DETACHED.equals(volume.getState())) {
                         locks.add(new AllocateConstraintLock(AllocateConstraintLock.Type.VOLUME, volume.getId().toString()));
                     }
                 }


### PR DESCRIPTION
we should also add lock in scheduling instances when volume is active
but detached. This will prevent a race condition when we try to
schedule instances using an existing volume or when it failed to pass
healthcheck and reschedule containers using existing volume.