### PR TITLE
Validate TenantId while configuring Azure auth

### DIFF
--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/azure/AzureRESTClient.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/azure/AzureRESTClient.java
@@ -158,7 +158,15 @@ public class AzureRESTClient extends AzureConfigurable{
             Map<String, Object> jsonData = jsonMapper.readValue(response.getEntity().getContent());
             accessToken = ObjectUtils.toString(jsonData.get("access_token"));
             refreshToken = ObjectUtils.toString(jsonData.get("refresh_token"));
-            
+
+            //Also validate tenantID by issuing a search request for the user, if it errors we error out else login is successful
+            String filter = "$filter=userPrincipalName%20eq%20'" + URLEncoder.encode(username, "UTF-8") + "'";
+            HttpResponse newResponse = getFromAzure(accessToken, getURL(AzureClientEndpoints.USERS, "") + "&"+ filter);
+            statusCode = newResponse.getStatusLine().getStatusCode();
+            if(statusCode >= 300) {
+                noAzure(newResponse);
+            }
+
             ApiContext.getContext().getApiRequest().setAttribute(AzureConstants.AZURE_ACCESS_TOKEN, accessToken);
             ApiContext.getContext().getApiRequest().setAttribute(AzureConstants.AZURE_REFRESH_TOKEN, refreshToken);
 


### PR DESCRIPTION
While configuring Azure auth, we take in parameters like 'tenantId', 'clientId, 'domain', along with azure credentials to test.

For testing the creds, 'tenantId' parameter is not required, so we miss out on finding if that parameter is wrong and when creds are authenticated we turn on the auth. Later while pulling the identities of that user, this tenantId is needed and this API then starts failing and blocking the user's login to Rancher.

Solution: Make an extra search request (for the username) to Azure during configuring auth which will need us to use the tenantID in the request - that will validate if the parameter is correct and error if not , avoiding this situation

@cjellick @deniseschannon need review
https://github.com/rancher/rancher/issues/14541