### PR TITLE
Fix "Form too large" exception

### DIFF
--- a/code/framework/launcher/src/main/java/io/cattle/platform/launcher/jetty/Main.java
+++ b/code/framework/launcher/src/main/java/io/cattle/platform/launcher/jetty/Main.java
@@ -103,6 +103,7 @@ public class Main {
             ServerConnector http = new ServerConnector(s, new HttpConnectionFactory(httpConfig));
             http.setPort(Integer.parseInt(getHttpPort()));
             s.setConnectors(new Connector[] {http});
+            s.setAttribute("org.eclipse.jetty.server.Request.maxFormContentSize", -1);
 
             MBeanContainer mbContainer = new MBeanContainer(ManagementFactory.getPlatformMBeanServer());
             s.addEventListener(mbContainer);


### PR DESCRIPTION
When a SAML user belonging to multiple (~1k) groups tries to login,
a POST to v1/token containing all the group identities is done, so cattle
can create cattle identities for these groups and generates a token for the
user. This POST was causing "Form too large" exception and not letting such
users login

https://github.com/rancher/rancher/issues/8754
https://github.com/rancher/rancher/issues/14756