### PR TITLE
Bumped up jetty version and stop sending server version in http headers

### DIFF
--- a/code/framework/launcher/src/main/java/io/cattle/platform/launcher/jetty/Main.java
+++ b/code/framework/launcher/src/main/java/io/cattle/platform/launcher/jetty/Main.java
@@ -100,6 +100,7 @@ public class Main {
             HttpConfiguration httpConfig = new HttpConfiguration();
             httpConfig.setRequestHeaderSize(16 * 1024);
             httpConfig.setOutputBufferSize(512);
+            httpConfig.setSendServerVersion(false);
             ServerConnector http = new ServerConnector(s, new HttpConnectionFactory(httpConfig));
             http.setPort(Integer.parseInt(getHttpPort()));
             s.setConnectors(new Connector[] {http});

--- a/code/meta-parent/pom.xml
+++ b/code/meta-parent/pom.xml
@@ -41,7 +41,7 @@
         </developer>
     </developers>
     <properties>
-        <jetty.version>9.2.11.v20150529</jetty.version>
+        <jetty.version>9.2.26.v20180806</jetty.version>
         <jooq.version>3.3.0</jooq.version>
         <jackson.version>2.5.3</jackson.version>
         <spring.version>4.3.2.RELEASE</spring.version>


### PR DESCRIPTION
This PR bumps up the jetty version to 9.2.26.v20180806 and also stops sending Jetty server version in the HTTP headers.

https://github.com/rancher/rancher/issues/14554