### PR TITLE
SAML CLI should be able to list user environments he/she creates or is added to as a member. Groups not supported

### DIFF
--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/external/ExternalServiceAuthProvider.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/integration/external/ExternalServiceAuthProvider.java
@@ -322,6 +322,12 @@ public class ExternalServiceAuthProvider {
             ApiRequest request = ApiContext.getContext().getApiRequest();
             request.setAttribute(ServiceAuthConstants.ACCESS_TOKEN, accessToken);
             return tokenUtil.getIdentities();
+        } else if(ServiceAuthConstants.NO_IDENTITY_LOOKUP_SUPPORTED.get()) {
+            Set<Identity> identities = new HashSet<>();
+            if (StringUtils.equals(account.getExternalIdType(), ServiceAuthConstants.USER_TYPE.get())) {
+                identities.add(new Identity(account.getExternalIdType(), account.getExternalId(), null, null, null, null, true));
+            }
+            return identities;
         }
         String jwt = null;
         if (SecurityConstants.SECURITY.get() && !StringUtils.isBlank(accessToken)) {


### PR DESCRIPTION
For SAML users, identities of the user cannot be lookup on SAML provider as lookup is not supported by the protocol.

The list GET /identities call just returned the internal rancher_id identity and the saml shibboleth_user external_id was missing from the results. So the environments the shibboleth_user has access to were not getting listed.

Fix is to also add the shibboleth_user to the list of identities. 
Limitation: Groups that the user belongs to will be missing from the list of identities that the CLI sees, since we cant look that info. Hence any environments that the user's groups have access to wont be listed by the CLI.

https://github.com/rancher/rancher/issues/16530