### PR TITLE
Update to lb-service-haproxy:v0.9.11

### DIFF
--- a/resources/content/cattle-global.properties
+++ b/resources/content/cattle-global.properties
@@ -5,7 +5,7 @@
 api.ui.index=//releases.rancher.com/ui/stable
 api.ui.js.url=https://releases.rancher.com/api-ui/1.0.4/ui.min.js
 api.ui.css.url=https://releases.rancher.com/api-ui/1.0.4/ui.min.css
-lb.instance.image=rancher/lb-service-haproxy:v0.9.6
+lb.instance.image=rancher/lb-service-haproxy:v0.9.11
 bootstrap.required.image=rancher/agent:v1.2.11
 bootstrap.required.windows.image=rancher/agent-windows:v0.2.0
 agent.package.python.agent.url=https://github.com/rancher/agent/releases/download/v0.13.11/go-agent.tar.gz


### PR DESCRIPTION
This pr updates the lb-image cattle uses to lb-service-haproxy v0.9.11

https://github.com/rancher/rancher/issues/17932