### PR TITLE
handle null/empty secrets

### DIFF
--- a/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/manager/SecretManager.java
+++ b/code/iaas/api-logic/src/main/java/io/cattle/platform/iaas/api/manager/SecretManager.java
@@ -7,6 +7,7 @@ import io.cattle.platform.framework.secret.SecretsService;
 import io.cattle.platform.object.util.DataAccessor;
 import io.github.ibuildthecloud.gdapi.exception.ClientVisibleException;
 import io.github.ibuildthecloud.gdapi.util.ResponseCodes;
+import io.github.ibuildthecloud.gdapi.validation.ValidationErrorCodes;
 
 import java.io.IOException;
 import java.util.Map;
@@ -45,6 +46,8 @@ public class SecretManager extends AbstractJooqResourceManager {
                 log.error("Failed to secret", e);
                 throw new ClientVisibleException(ResponseCodes.SERVICE_UNAVAILABLE);
             }
+        } else {
+            throw new ClientVisibleException(ResponseCodes.UNPROCESSABLE_ENTITY, ValidationErrorCodes.NOT_NULLABLE, "Secret value cannot be null/empty", "");
         }
         T result = super.createAndScheduleObject(clz, properties);
         if (result instanceof Secret) {

--- a/code/iaas/logic/src/main/java/io/cattle/platform/process/secret/SecretRemove.java
+++ b/code/iaas/logic/src/main/java/io/cattle/platform/process/secret/SecretRemove.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,13 +26,15 @@ public class SecretRemove extends AbstractDefaultProcessHandler {
 
     @Override
     public HandlerResult handle(ProcessState state, ProcessInstance process) {
-        Secret secret = (Secret)state.getResource();
-        try {
-            secretsService.delete(secret.getAccountId(), secret.getValue());
-        } catch (IOException e) {
-            log.error("Failed to delete secret from storage [{}]",
-                    secret.getId(), e);
-            throw new IllegalStateException(e);
+        Secret secret = (Secret) state.getResource();
+        String secretValue = secret.getValue();
+        if (StringUtils.isNotBlank(secretValue)) {
+            try {
+                secretsService.delete(secret.getAccountId(), secret.getValue());
+            } catch (IOException e) {
+                log.error("Failed to delete secret from storage [{}]", secret.getId(), e);
+                throw new IllegalStateException(e);
+            }
         }
         return null;
     }


### PR DESCRIPTION
Fixes: https://github.com/rancher/rancher/issues/17907

1) Don't allow the creation of secrets with null/empty values. (UI already has a check, API doesn't)
2) Allow deletion of already created secrets with null/empty values.