### PR TITLE
For project member if member is deleted externally, set name as externalId if name is missing

### DIFF
--- a/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/identity/IdentityManager.java
+++ b/code/iaas/auth-logic/src/main/java/io/cattle/platform/iaas/api/auth/identity/IdentityManager.java
@@ -188,8 +188,12 @@ public class IdentityManager extends AbstractNoOpResourceManager {
         Identity gotIdentity;
         gotIdentity = projectMemberToIdentity(member.getExternalIdType() + ':' + member.getExternalId());
         if (gotIdentity == null){
-            gotIdentity = new Identity(member.getExternalIdType(), member.getExternalId(), member.getName(),
-                    null, null, '(' + member.getExternalIdType().split("_")[1].toUpperCase() +  "  not found) " + member.getName(), false);
+            String name = member.getName();
+            if (name == null) {
+                name = member.getExternalId();
+            }
+            gotIdentity = new Identity(member.getExternalIdType(), member.getExternalId(), name,
+                    null, null, '(' + member.getExternalIdType().split("_")[1].toUpperCase() +  "  not found) " + name, false);
         }
         return untransform(new Identity(gotIdentity, member.getRole(), String.valueOf(member.getProjectId())), false);
     }


### PR DESCRIPTION
When the github team is removed on github, the projects where the team is added as a member, that environment can no longer be edited on the UI.

The reason is actually UI hitting a NPE since for github team, it tries to use the member.name property which may be null.

We are adding a fix on the backend to ensure that if the name of the member is null, we set the name to be externalID in such case where the backend entity is removed.