### PR TITLE
Add mount_delete.purge.after.seconds setting

### DIFF
--- a/code/packaging/app-config/src/main/resources/META-INF/cattle/core-model/defaults.properties
+++ b/code/packaging/app-config/src/main/resources/META-INF/cattle/core-model/defaults.properties
@@ -30,3 +30,5 @@ process_instance.purge.after.seconds=3600
 audit_log.purge.after.seconds=2592000
 # 1 Day
 service_log.purge.after.seconds=86400
+# 1 Hour
+mount_delete.purge.after.seconds=3600


### PR DESCRIPTION
Add mount_delete.purge.after.seconds to control how long a stale secret
volume should live in database. Default is 3600 seconds